### PR TITLE
feat: add React imports if missing in the module

### DIFF
--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -32,7 +32,8 @@ describe('babel plugin', () => {
     );
 
     expect(output?.code).toMatchInlineSnapshot(`
-      "import { CC, CS } from '@compiled/core';
+      "import * as React from 'react';
+      import { CC, CS } from '@compiled/core';
       const MyDiv = React.forwardRef(({
         as: C = \\"div\\",
         style,

--- a/packages/babel-plugin/src/index.tsx
+++ b/packages/babel-plugin/src/index.tsx
@@ -1,4 +1,5 @@
 import * as t from '@babel/types';
+import template from '@babel/template';
 import { declare } from '@babel/helper-plugin-utils';
 import { importSpecifier } from './utils/ast-builders';
 import { visitCssPropPath } from './css-prop';
@@ -11,15 +12,57 @@ export default declare<State>((api) => {
   return {
     inherits: require('babel-plugin-syntax-jsx'),
     visitor: {
-      ImportDeclaration(path, state) {
-        if (path.node.source.value === '@compiled/core') {
+      Program(path, state) {
+        const importDeclarations = path.node.body.filter((node) => t.isImportDeclaration(node));
+        if (
+          importDeclarations.some(
+            (declaration: any) => declaration.source.value === '@compiled/core'
+          )
+        ) {
           state.compiledImportFound = true;
+
+          const isCompiledStyledImportFound = importDeclarations.some(
+            (declaration: any) =>
+              declaration.source.value === '@compiled/core' &&
+              declaration.specifiers.find(
+                (specifier: t.ImportSpecifier) => specifier.local.name === 'styled'
+              )
+          );
+
+          const isReactImportFound = importDeclarations.some(
+            (declaration: any) => declaration.source.value === 'react'
+          );
+
+          // If we have a Compiled 'styled' import and we don't have a React
+          // import, we add a namespaced import to the top of the file.
+          if (isCompiledStyledImportFound && !isReactImportFound) {
+            path.unshiftContainer('body', template.ast(`import * as React from 'react'`));
+            return;
+          }
+        }
+      },
+      ImportDeclaration(path, state) {
+        if (!state.compiledImportFound) {
+          return;
+        }
+        if (path.node.source.value === '@compiled/core') {
           path.node.specifiers = path.node.specifiers
             .filter(
               (specifier) =>
                 specifier.local.name !== 'styled' && specifier.local.name !== 'ClassNames'
             )
             .concat([importSpecifier('CC'), importSpecifier('CS')]);
+        }
+        // If we find only named React imports but no default, we modify the
+        // import declaration to include a default specifier.
+        if (
+          path.node.source.value === 'react' &&
+          !path.node.specifiers.find(
+            (specifier) =>
+              t.isImportDefaultSpecifier(specifier) || t.isImportNamespaceSpecifier(specifier)
+          )
+        ) {
+          path.unshiftContainer('specifiers', t.importDefaultSpecifier(t.identifier('React')));
         }
       },
       VariableDeclaration(path, state) {

--- a/packages/babel-plugin/src/index.tsx
+++ b/packages/babel-plugin/src/index.tsx
@@ -13,24 +13,24 @@ export default declare<State>((api) => {
     inherits: require('babel-plugin-syntax-jsx'),
     visitor: {
       Program(path, state) {
-        const importDeclarations = path.node.body.filter((node) => t.isImportDeclaration(node));
+        const importDeclarations = path.node.body.filter((node): node is t.ImportDeclaration =>
+          t.isImportDeclaration(node)
+        );
         if (
           importDeclarations.some(
-            (declaration: any) => declaration.source.value === '@compiled/core'
+            (declaration: t.ImportDeclaration) => declaration.source.value === '@compiled/core'
           )
         ) {
           state.compiledImportFound = true;
 
           const isCompiledStyledImportFound = importDeclarations.some(
-            (declaration: any) =>
+            (declaration) =>
               declaration.source.value === '@compiled/core' &&
-              declaration.specifiers.find(
-                (specifier: t.ImportSpecifier) => specifier.local.name === 'styled'
-              )
+              declaration.specifiers.find((specifier) => specifier.local.name === 'styled')
           );
 
           const isReactImportFound = importDeclarations.some(
-            (declaration: any) => declaration.source.value === 'react'
+            (declaration) => declaration.source.value === 'react'
           );
 
           // If we have a Compiled 'styled' import and we don't have a React

--- a/packages/babel-plugin/src/styled/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/index.test.tsx
@@ -25,7 +25,7 @@ describe('styled component transformer', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS hash=\\"hash-test\\">{[\\".cc-hash-test{font-size:20px}\\"]}</CS>
             <C{...props}style={style}ref={ref}className={\\"cc-hash-test\\"+(props.className?\\" \\"+props.className:\\"\\")}/>
           </CC>);"
@@ -42,7 +42,7 @@ describe('styled component transformer', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS hash=\\"hash-test\\">{[\\".cc-hash-test{font-size:20px}\\"]}</CS>
             <C{...props}style={style}ref={ref}className={\\"cc-hash-test\\"+(props.className?\\" \\"+props.className:\\"\\")}/>
           </CC>);"
@@ -81,7 +81,7 @@ describe('styled component transformer', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS hash=\\"hash-test\\">{[\\".cc-hash-test{font-size:20px}\\"]}</CS>
             <C{...props}style={style}ref={ref}className={\\"cc-hash-test\\"+(props.className?\\" \\"+props.className:\\"\\")}/>
           </CC>);"
@@ -100,18 +100,17 @@ describe('styled component transformer', () => {
     expect(actual).toInclude('"--var-test-propscolor": (props.color || "") + "px"');
   });
 
-  xit('should add react default import if missing', () => {
+  it('should add react default import if missing', () => {
     const actual = transform(`
       import { styled } from '@compiled/core';
       const ListItem = styled.div\`
         font-size: 20px;
       \`;
     `);
-
-    expect(actual).toInclude('import React from "react";');
+    expect(actual).toInclude(`${transform("import * as React from 'react'")}`);
   });
 
-  xit('should add react default import if it only has named imports', () => {
+  it('should add react default import if it only has named imports', () => {
     const actual = transform(`
       import { useState } from 'react';
       import { styled } from '@compiled/core';
@@ -119,8 +118,7 @@ describe('styled component transformer', () => {
         font-size: 20px;
       \`;
     `);
-
-    expect(actual).toInclude(`import React, { useState } from 'react';`);
+    expect(actual).toInclude(`${transform("import React, { useState } from 'react';")}`);
   });
 
   xit('should spread down props to element', () => {
@@ -147,7 +145,7 @@ describe('styled component transformer', () => {
     expect(actual).toInclude('ListItem.displayName = "ListItem";');
   });
 
-  xit('should do nothing if react default import is already defined', () => {
+  it('should do nothing if react default import is already defined', () => {
     const actual = transform(`
       import React from 'react';
       import { styled } from '@compiled/core';
@@ -156,7 +154,7 @@ describe('styled component transformer', () => {
       \`;
     `);
 
-    expect(actual).toInclude("import React from 'react';");
+    expect(actual).toInclude(transform("import React from 'react';"));
   });
 
   xit('should compose a component using template literal', () => {

--- a/packages/babel-plugin/src/styled/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/index.test.tsx
@@ -100,7 +100,7 @@ describe('styled component transformer', () => {
     expect(actual).toInclude('"--var-test-propscolor": (props.color || "") + "px"');
   });
 
-  it('should add react default import if missing', () => {
+  it('should add react namespaced import if missing', () => {
     const actual = transform(`
       import { styled } from '@compiled/core';
       const ListItem = styled.div\`
@@ -155,6 +155,18 @@ describe('styled component transformer', () => {
     `);
 
     expect(actual).toInclude(transform("import React from 'react';"));
+  });
+
+  it('should do nothing if react namespaced import is already defined', () => {
+    const actual = transform(`
+      import * as React from 'react'
+      import { styled } from '@compiled/core';
+      const ListItem = styled.div\`
+        font-size: 20px;
+      \`;
+    `);
+
+    expect(actual).toInclude(transform("import * as React from 'react'"));
   });
 
   xit('should compose a component using template literal', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,7 +55,7 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.10.1", "@babel/helper-annotate-as-pure@^7.10.4", "@babel/helper-annotate-as-pure@^7.8.3":
+"@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.10.4", "@babel/helper-annotate-as-pure@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz#5bf0d495a3f757ac3bda48b5bf3b3ba309c72ba3"
   integrity sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==
@@ -70,7 +70,7 @@
     "@babel/helper-explode-assignable-expression" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helper-builder-react-jsx-experimental@^7.10.1", "@babel/helper-builder-react-jsx-experimental@^7.10.4":
+"@babel/helper-builder-react-jsx-experimental@^7.10.4":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.5.tgz#f35e956a19955ff08c1258e44a515a6d6248646b"
   integrity sha512-Buewnx6M4ttG+NLkKyt7baQn7ScC/Td+e99G914fRU8fGIUivDDgVIQeDHFa5e4CRSJQt58WpNHhsAZgtzVhsg==
@@ -79,7 +79,7 @@
     "@babel/helper-module-imports" "^7.10.4"
     "@babel/types" "^7.10.5"
 
-"@babel/helper-builder-react-jsx@^7.10.1", "@babel/helper-builder-react-jsx@^7.10.4":
+"@babel/helper-builder-react-jsx@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz#8095cddbff858e6fa9c326daee54a2f2732c1d5d"
   integrity sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==
@@ -166,7 +166,7 @@
   dependencies:
     "@babel/types" "^7.11.0"
 
-"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.1", "@babel/helper-module-imports@^7.10.4":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
   integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
@@ -193,7 +193,7 @@
   dependencies:
     "@babel/types" "^7.10.4"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.1", "@babel/helper-plugin-utils@^7.10.2", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.2", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
   integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
@@ -439,7 +439,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.10.1", "@babel/plugin-syntax-jsx@^7.10.2", "@babel/plugin-syntax-jsx@^7.10.4":
+"@babel/plugin-syntax-jsx@^7.10.2", "@babel/plugin-syntax-jsx@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz#39abaae3cbf710c4373d8429484e6ba21340166c"
   integrity sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
@@ -697,14 +697,14 @@
     "@babel/helper-annotate-as-pure" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-react-display-name@^7.10.1", "@babel/plugin-transform-react-display-name@^7.10.4":
+"@babel/plugin-transform-react-display-name@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz#b5795f4e3e3140419c3611b7a2a3832b9aef328d"
   integrity sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-react-jsx-development@^7.10.1", "@babel/plugin-transform-react-jsx-development@^7.10.4":
+"@babel/plugin-transform-react-jsx-development@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.10.4.tgz#6ec90f244394604623880e15ebc3c34c356258ba"
   integrity sha512-RM3ZAd1sU1iQ7rI2dhrZRZGv0aqzNQMbkIUCS1txYpi9wHQ2ZHNjo5TwX+UD6pvFW4AbWqLVYvKy5qJSAyRGjQ==
@@ -713,7 +713,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-jsx" "^7.10.4"
 
-"@babel/plugin-transform-react-jsx-self@^7.10.1", "@babel/plugin-transform-react-jsx-self@^7.10.4":
+"@babel/plugin-transform-react-jsx-self@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.10.4.tgz#cd301a5fed8988c182ed0b9d55e9bd6db0bd9369"
   integrity sha512-yOvxY2pDiVJi0axdTWHSMi5T0DILN+H+SaeJeACHKjQLezEzhLx9nEF9xgpBLPtkZsks9cnb5P9iBEi21En3gg==
@@ -721,7 +721,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-jsx" "^7.10.4"
 
-"@babel/plugin-transform-react-jsx-source@^7.10.1", "@babel/plugin-transform-react-jsx-source@^7.10.4":
+"@babel/plugin-transform-react-jsx-source@^7.10.4":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.10.5.tgz#34f1779117520a779c054f2cdd9680435b9222b4"
   integrity sha512-wTeqHVkN1lfPLubRiZH3o73f4rfon42HpgxUSs86Nc+8QIcm/B9s8NNVXu/gwGcOyd7yDib9ikxoDLxJP0UiDA==
@@ -729,7 +729,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-jsx" "^7.10.4"
 
-"@babel/plugin-transform-react-jsx@^7.10.1", "@babel/plugin-transform-react-jsx@^7.10.4":
+"@babel/plugin-transform-react-jsx@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz#673c9f913948764a4421683b2bef2936968fddf2"
   integrity sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==
@@ -739,7 +739,7 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-jsx" "^7.10.4"
 
-"@babel/plugin-transform-react-pure-annotations@^7.10.1", "@babel/plugin-transform-react-pure-annotations@^7.10.4":
+"@babel/plugin-transform-react-pure-annotations@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.10.4.tgz#3eefbb73db94afbc075f097523e445354a1c6501"
   integrity sha512-+njZkqcOuS8RaPakrnR9KvxjoG1ASJWpoIv/doyWngId88JoFlPlISenGXjrVacZUIALGUr6eodRs1vmPnF23A==
@@ -975,7 +975,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.0.0", "@babel/types@^7.10.1", "@babel/types@^7.10.2", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+"@babel/types@^7.0.0", "@babel/types@^7.10.2", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.0.tgz#2ae6bf1ba9ae8c3c43824e5861269871b206e90d"
   integrity sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
@@ -3349,7 +3349,7 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   dependencies:
@@ -4456,7 +4456,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
+enhanced-resolve@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz#2937e2b8066cd0fe7ce0990a98f0d71a35189f66"
   dependencies:
@@ -6958,7 +6958,7 @@ loader-utils@1.2.3:
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -7209,7 +7209,7 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-micromatch@^4.0.0, micromatch@^4.0.2:
+micromatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
   dependencies:
@@ -10219,17 +10219,6 @@ tryer@^1.0.1:
 ts-dedent@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-1.1.0.tgz#67983940793183dc7c7f820acb66ba02cdc33c6e"
-
-ts-loader@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-7.0.2.tgz#465bc904aea4c331e9550e7c7d75dd17a0b7c24c"
-  integrity sha512-DwpZFB67RoILQHx42dMjSgv2STpacsQu5X+GD/H9ocd8IhU0m8p3b/ZrIln2KmcucC6xep2PdEMEblpWT71euA==
-  dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.0.2"
-    micromatch "^4.0.0"
-    semver "^6.0.0"
 
 ts-node@8.9.1:
   version "8.9.1"


### PR DESCRIPTION
- should add react *  namespaced import if missing
- should add react default import if it only has named imports
- should do nothing if react default import or namespaced import is already defined