### PR TITLE
fix: imports react at the end of the transformation if its missing

### DIFF
--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -32,7 +32,8 @@ describe('babel plugin', () => {
     );
 
     expect(output?.code).toMatchInlineSnapshot(`
-      "import { CC, CS } from '@compiled/core';
+      "import * as React from 'react';
+      import { CC, CS } from '@compiled/core';
       const MyDiv = React.forwardRef(({
         as: C = \\"div\\",
         style,
@@ -57,7 +58,8 @@ describe('babel plugin', () => {
     );
 
     expect(output?.code).toMatchInlineSnapshot(`
-      "import { CC, CS } from '@compiled/core';
+      "import * as React from 'react';
+      import { CC, CS } from '@compiled/core';
 
       const MyDiv = () => {
         return <CC>

--- a/packages/babel-plugin/src/index.tsx
+++ b/packages/babel-plugin/src/index.tsx
@@ -1,4 +1,5 @@
 import { declare } from '@babel/helper-plugin-utils';
+import template from '@babel/template';
 import { importSpecifier } from './utils/ast-builders';
 import { visitCssPropPath } from './css-prop';
 import { visitStyledPath } from './styled';
@@ -10,6 +11,14 @@ export default declare<State>((api) => {
   return {
     inherits: require('babel-plugin-syntax-jsx'),
     visitor: {
+      Program: {
+        exit(path) {
+          if (!path.scope.getBinding('React')) {
+            // React is missing - add it in at the last moment!
+            path.unshiftContainer('body', template.ast(`import * as React from 'react'`));
+          }
+        },
+      },
       ImportDeclaration(path, state) {
         if (path.node.source.value === '@compiled/core') {
           state.compiledImportFound = true;

--- a/packages/babel-plugin/src/index.tsx
+++ b/packages/babel-plugin/src/index.tsx
@@ -12,8 +12,8 @@ export default declare<State>((api) => {
     inherits: require('babel-plugin-syntax-jsx'),
     visitor: {
       Program: {
-        exit(path) {
-          if (!path.scope.getBinding('React')) {
+        exit(path, state) {
+          if (state.compiledImportFound && !path.scope.getBinding('React')) {
             // React is missing - add it in at the last moment!
             path.unshiftContainer('body', template.ast(`import * as React from 'react'`));
           }

--- a/packages/babel-plugin/src/styled/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/index.test.tsx
@@ -25,7 +25,7 @@ describe('styled component transformer', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS hash=\\"hash-test\\">{[\\".cc-hash-test{font-size:20px}\\"]}</CS>
             <C{...props}style={style}ref={ref}className={\\"cc-hash-test\\"+(props.className?\\" \\"+props.className:\\"\\")}/>
           </CC>);"
@@ -42,7 +42,7 @@ describe('styled component transformer', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS hash=\\"hash-test\\">{[\\".cc-hash-test{font-size:20px}\\"]}</CS>
             <C{...props}style={style}ref={ref}className={\\"cc-hash-test\\"+(props.className?\\" \\"+props.className:\\"\\")}/>
           </CC>);"
@@ -81,7 +81,7 @@ describe('styled component transformer', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS hash=\\"hash-test\\">{[\\".cc-hash-test{font-size:20px}\\"]}</CS>
             <C{...props}style={style}ref={ref}className={\\"cc-hash-test\\"+(props.className?\\" \\"+props.className:\\"\\")}/>
           </CC>);"
@@ -120,7 +120,7 @@ describe('styled component transformer', () => {
     expect(actual).toInclude('"--var-hash-test":(props.color||"")+"px"');
   });
 
-  xit('should add react default import if missing', () => {
+  it('should add react default import if missing', () => {
     const actual = transform(`
       import { styled } from '@compiled/core';
       const ListItem = styled.div\`
@@ -128,10 +128,10 @@ describe('styled component transformer', () => {
       \`;
     `);
 
-    expect(actual).toInclude('import React from "react";');
+    expect(actual).toInclude(`import*as React from'react'`);
   });
 
-  xit('should add react default import if it only has named imports', () => {
+  it('should add react default import if it only has named imports', () => {
     const actual = transform(`
       import { useState } from 'react';
       import { styled } from '@compiled/core';
@@ -140,7 +140,7 @@ describe('styled component transformer', () => {
       \`;
     `);
 
-    expect(actual).toInclude(`import React, { useState } from 'react';`);
+    expect(actual).toInclude(`import*as React from'react';import{useState}from'react';`);
   });
 
   it('should spread down props to element', () => {
@@ -167,7 +167,7 @@ describe('styled component transformer', () => {
     expect(actual).toInclude('ListItem.displayName = "ListItem";');
   });
 
-  xit('should do nothing if react default import is already defined', () => {
+  it('should do nothing if react default import is already defined', () => {
     const actual = transform(`
       import React from 'react';
       import { styled } from '@compiled/core';
@@ -176,7 +176,7 @@ describe('styled component transformer', () => {
       \`;
     `);
 
-    expect(actual).toInclude("import React from 'react';");
+    expect(actual).toInclude("import React from'react';");
   });
 
   xit('should compose a component using template literal', () => {


### PR DESCRIPTION
Closes #241 

Built on what you did @lol-russo but simplified it a lot. The basic premise is "does `React` exist somewhere in the scope - yes? Do nothing. No? Add it.