### PR TITLE
feat: adds support for composing styles to styled api

### DIFF
--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -19,6 +19,7 @@
     "src"
   ],
   "dependencies": {
+    "@compiled/css": "0.4.7",
     "@babel/core": "^7.10.2",
     "@babel/generator": "^7.10.2",
     "@babel/helper-plugin-utils": "^7.10.2",

--- a/packages/babel-plugin/src/css-prop/index.tsx
+++ b/packages/babel-plugin/src/css-prop/index.tsx
@@ -1,41 +1,8 @@
 import * as t from '@babel/types';
 import { NodePath } from '@babel/core';
 import { buildCompiledComponent } from '../utils/ast-builders';
-import { buildCss, CSSOutput } from '../utils/css-builders';
+import { buildCss } from '../utils/css-builders';
 import { Metadata } from '../types';
-
-const extractCssFromExpression = (node: t.Expression, meta: Metadata): CSSOutput => {
-  if (t.isIdentifier(node)) {
-    const binding = meta.parentPath.scope.getBinding(node.name);
-
-    if (
-      binding &&
-      t.isVariableDeclarator(binding.path.node) &&
-      t.isExpression(binding.path.node.init)
-    ) {
-      return buildCss(binding.path.node.init, meta);
-    }
-  }
-
-  if (t.isArrayExpression(node)) {
-    let css = '';
-    let variables: CSSOutput['variables'] = [];
-
-    node.elements.forEach((element) => {
-      if (!element) {
-        return;
-      }
-
-      const result = extractCssFromExpression(element as t.Expression, meta);
-      css += result.css;
-      variables = variables.concat(result.variables);
-    });
-
-    return { css, variables };
-  }
-
-  return buildCss(node, meta);
-};
 
 const getJsxAttributeExpression = (node: t.JSXAttribute) => {
   if (t.isStringLiteral(node.value)) {
@@ -72,9 +39,10 @@ export const visitCssPropPath = (path: NodePath<t.JSXOpeningElement>, meta: Meta
     return;
   }
 
+  const cssOutput = buildCss(getJsxAttributeExpression(cssProp), meta);
+
   // Remove css prop
   path.node.attributes.splice(cssPropIndex, 1);
-  const cssOutput = extractCssFromExpression(getJsxAttributeExpression(cssProp), meta);
 
   path.parentPath.replaceWith(
     buildCompiledComponent({

--- a/packages/babel-plugin/src/styled/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/index.test.tsx
@@ -49,6 +49,22 @@ describe('styled component transformer', () => {
     `);
   });
 
+  it('should compose CSS from multiple sources', () => {
+    const actual = transform(`
+      import { styled } from '@compiled/core';
+
+      const styles = { fontSize: 12 };
+
+      const ListItem = styled.div([
+        styles,
+        \`color: blue;\`,
+        { fontWeight: 500 }
+      ]);
+    `);
+
+    expect(actual).toInclude('.cc-hash-test{font-size:12px;color:blue;font-weight:500}');
+  });
+
   it('should not pass down invalid html attributes to the node', () => {
     const actual = transform(`
       import { styled } from '@compiled/core';

--- a/packages/babel-plugin/src/styled/index.tsx
+++ b/packages/babel-plugin/src/styled/index.tsx
@@ -32,7 +32,7 @@ const extractStyledDataFromNode = (
     t.isMemberExpression(node.callee) &&
     t.isIdentifier(node.callee.object) &&
     node.callee.object.name === 'styled' &&
-    t.isObjectExpression(node.arguments[0]) &&
+    t.isExpression(node.arguments[0]) &&
     t.isIdentifier(node.callee.property)
   ) {
     const tagName = node.callee.property.name;


### PR DESCRIPTION
Closes #246 

So this was mostly already implemented in CSS prop - I did a bit of refactoring to move the logic to `css-builder`.