### PR TITLE
Add ax runtime

### DIFF
--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -33,14 +33,14 @@ describe('babel plugin', () => {
 
     expect(output?.code).toMatchInlineSnapshot(`
       "import * as React from 'react';
-      import { CC, CS } from '@compiled/core';
+      import { ax, CC, CS } from '@compiled/core';
       const MyDiv = React.forwardRef(({
         as: C = \\"div\\",
         style,
         ...props
       }, ref) => <CC>
             <CS hash=\\"1x3e11p\\">{[\\".cc-1x3e11p{font-size:12px}\\"]}</CS>
-            <C {...props} style={style} ref={ref} className={\\"cc-1x3e11p\\" + (props.className ? \\" \\" + props.className : \\"\\")} />
+            <C {...props} style={style} ref={ref} className={ax([\\"cc-1x3e11p\\", props.className])} />
           </CC>);"
     `);
   });
@@ -59,7 +59,7 @@ describe('babel plugin', () => {
 
     expect(output?.code).toMatchInlineSnapshot(`
       "import * as React from 'react';
-      import { CC, CS } from '@compiled/core';
+      import { ax, CC, CS } from '@compiled/core';
 
       const MyDiv = () => {
         return <CC>

--- a/packages/babel-plugin/src/__tests__/module-imports.test.tsx
+++ b/packages/babel-plugin/src/__tests__/module-imports.test.tsx
@@ -71,9 +71,9 @@ describe('import specifiers', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import*as React from'react';import{ThemeProvider,CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{ThemeProvider,ax,CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS hash=\\"hash-test\\">{[\\".cc-hash-test{font-size:20px}\\"]}</CS>
-            <C{...props}style={style}ref={ref}className={\\"cc-hash-test\\"+(props.className?\\" \\"+props.className:\\"\\")}/>
+            <C{...props}style={style}ref={ref}className={ax([\\"cc-hash-test\\",props.className])}/>
           </CC>);"
     `);
   });

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
@@ -119,7 +119,7 @@ describe('css prop behaviour', () => {
       <div className="foobar" css={{}}>hello world</div>
     `);
 
-    expect(actual).toInclude('className={"cc-hash-test"+(" "+"foobar")}');
+    expect(actual).toInclude('className={ax(["cc-hash-test","foobar"])}');
   });
 
   it('should pass through spread props', () => {
@@ -165,7 +165,7 @@ describe('css prop behaviour', () => {
       <div className={className} css={{}}>hello world</div>
     `);
 
-    expect(actual).toInclude('className={"cc-hash-test"+(className?" "+className:"")}');
+    expect(actual).toInclude('className={ax(["cc-hash-test",className])}');
   });
 
   it('should pick up array composition', () => {
@@ -219,7 +219,7 @@ describe('css prop behaviour', () => {
       <div css={{}} className={getFoo()}>hello world</div>
     `);
 
-    expect(actual).toInclude('className={"cc-hash-test"+(getFoo()?" "+getFoo():"")}');
+    expect(actual).toInclude('className={ax(["cc-hash-test",getFoo()])}');
   });
 
   it('should allow inlined expressions as property values', () => {

--- a/packages/babel-plugin/src/index.tsx
+++ b/packages/babel-plugin/src/index.tsx
@@ -45,7 +45,7 @@ export default declare<State>((api) => {
             return true;
           })
           // Add on the util imports we're going to use later in the transform.
-          .concat([importSpecifier('CC'), importSpecifier('CS')]);
+          .concat([importSpecifier('ax'), importSpecifier('CC'), importSpecifier('CS')]);
       },
       TaggedTemplateExpression(path, state) {
         if (!state.compiledImports?.styled) {

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
@@ -25,9 +25,9 @@ describe('styled component behaviour', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import*as React from'react';import{ThemeProvider,CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{ThemeProvider,ax,CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS hash=\\"hash-test\\">{[\\".cc-hash-test{font-size:20px}\\"]}</CS>
-            <C{...props}style={style}ref={ref}className={\\"cc-hash-test\\"+(props.className?\\" \\"+props.className:\\"\\")}/>
+            <C{...props}style={style}ref={ref}className={ax([\\"cc-hash-test\\",props.className])}/>
           </CC>);"
     `);
   });
@@ -42,9 +42,9 @@ describe('styled component behaviour', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import*as React from'react';import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{ax,CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS hash=\\"hash-test\\">{[\\".cc-hash-test{font-size:20px}\\"]}</CS>
-            <C{...props}style={style}ref={ref}className={\\"cc-hash-test\\"+(props.className?\\" \\"+props.className:\\"\\")}/>
+            <C{...props}style={style}ref={ref}className={ax([\\"cc-hash-test\\",props.className])}/>
           </CC>);"
     `);
   });
@@ -97,9 +97,9 @@ describe('styled component behaviour', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import*as React from'react';import{CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{ax,CC,CS}from'@compiled/core';const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS hash=\\"hash-test\\">{[\\".cc-hash-test{font-size:20px}\\"]}</CS>
-            <C{...props}style={style}ref={ref}className={\\"cc-hash-test\\"+(props.className?\\" \\"+props.className:\\"\\")}/>
+            <C{...props}style={style}ref={ref}className={ax([\\"cc-hash-test\\",props.className])}/>
           </CC>);"
     `);
   });
@@ -198,9 +198,7 @@ describe('styled component behaviour', () => {
       \`;
     `);
 
-    expect(actual).toInclude(
-      `className={\"cc-hash-test\"+(props.className?\" \"+props.className:\"\")}`
-    );
+    expect(actual).toInclude(`className={ax([\"cc-hash-test\",props.className])}`);
   });
 
   it('should inline constant identifier string literal', () => {

--- a/packages/babel-plugin/src/utils/ast-builders.tsx
+++ b/packages/babel-plugin/src/utils/ast-builders.tsx
@@ -326,11 +326,11 @@ export const buildCompiledComponent = (opts: CompiledOpts) => {
       ? classNameProp.value.expression
       : classNameProp.value;
 
-    const newClassNameValue = t.isStringLiteral(classNameExpression)
-      ? joinExpressions(t.stringLiteral(className), classNameExpression)
-      : conditionallyJoinExpressions(t.stringLiteral(className), classNameExpression);
-
-    classNameProp.value = t.jsxExpressionContainer(newClassNameValue);
+    classNameProp.value = t.jsxExpressionContainer(
+      t.callExpression(t.identifier('ax'), [
+        t.arrayExpression([t.stringLiteral(className), classNameExpression as t.Expression]),
+      ])
+    );
   } else {
     // No class name - just push our own one.
     opts.node.openingElement.attributes.push(

--- a/packages/babel-plugin/src/utils/ast-builders.tsx
+++ b/packages/babel-plugin/src/utils/ast-builders.tsx
@@ -197,9 +197,12 @@ const styledTemplate = (opts: {
   }, ref) => (
     <CC>
       <CS ${nonceAttribute} hash="${opts.hash}">{%%cssNode%%}</CS>
-      <C {...props} style={%%styleProp%%} ref={ref} className={"${
-        opts.className
-      }" + (props.className ? " " + props.className : "")} />
+      <C
+        {...props}
+        style={%%styleProp%%}
+        ref={ref}
+        className={ax(["${opts.className}", props.className])}
+      />
     </CC>
   ));
 `,

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -1,4 +1,4 @@
-export { CS, CC } from '@compiled/runtime';
+export { CS, CC, ax } from '@compiled/runtime';
 export { styled } from './styled';
 export { ClassNames } from './class-names';
 import { CssFunction } from './types';

--- a/packages/runtime/src/__tests__/ax.test.tsx
+++ b/packages/runtime/src/__tests__/ax.test.tsx
@@ -1,0 +1,40 @@
+import { ax } from '../ax';
+
+describe('ax', () => {
+  it('should join single classes together', () => {
+    const result = ax(['foo', 'bar']);
+
+    expect(result).toEqual('foo bar');
+  });
+
+  it('should join multi classes together', () => {
+    const result = ax(['foo baz', 'bar']);
+
+    expect(result).toEqual('foo baz bar');
+  });
+
+  it('should remove undefined', () => {
+    const result = ax(['foo', 'bar', undefined]);
+
+    expect(result).toEqual('foo bar');
+  });
+
+  it('should ensure the last atomic declaration of a single group wins', () => {
+    const result = ax(['_aaaabbbb', '_aaaacccc']);
+
+    expect(result).toEqual('_aaaacccc');
+  });
+
+  it('should not remove any atomic declarations if there are no duplicate groups', () => {
+    const result = ax(['_aaaabbbb', '_bbbbcccc']);
+
+    expect(result).toEqual('_aaaabbbb _bbbbcccc');
+  });
+
+  it('should not apply conditional class', () => {
+    const isEnabled: boolean = (() => false)();
+    const result = ax([isEnabled && 'foo', 'bar']);
+
+    expect(result).toEqual('bar');
+  });
+});

--- a/packages/runtime/src/ax.tsx
+++ b/packages/runtime/src/ax.tsx
@@ -1,9 +1,9 @@
 /**
  * Joins classes together and ensures atomic declarations of a single group exist.
- * This function is made to be fast and small - so it takes some liberties with its API.
- *
- * Atomic declarations take the form of `_{group}{value}`,
+ * Atomic declarations take the form of `_{group}{value}` (always prefixed with an underscore),
  * where both `group` and `value` are hashes **four characters long**.
+ * Class names can be of any length,
+ * this function can take both atomic declarations and class names.
  *
  * Input:
  *

--- a/packages/runtime/src/ax.tsx
+++ b/packages/runtime/src/ax.tsx
@@ -1,0 +1,36 @@
+/**
+ * Joins classes together and ensures atomic declarations of a single group exist.
+ * This function is made to be fast and small - so it takes some liberties with its API.
+ *
+ * Atomic declarations take the form of `_{group}{value}`,
+ * where both `group` and `value` are hashes **four characters long**.
+ *
+ * Input:
+ *
+ * ```
+ * ax(['_aaaabbbb', '_aaaacccc'])
+ * ```
+ *
+ * Output:
+ *
+ * ```
+ * '_aaaacccc'
+ * ```
+ *
+ * @param classes
+ */
+export const ax = (classes: (string | undefined | false)[]): string => {
+  const found: Record<string, string> = {};
+
+  for (let i = 0; i < classes.length; i++) {
+    const cls = classes[i];
+    if (!cls) {
+      continue;
+    }
+
+    const group = cls.slice(0, cls.charCodeAt(0) === 95 ? 5 : undefined);
+    found[group] = cls;
+  }
+
+  return Object.values(found).join(' ');
+};

--- a/packages/runtime/src/index.tsx
+++ b/packages/runtime/src/index.tsx
@@ -1,2 +1,3 @@
 export { default as CS } from './style';
 export { default as CC } from './provider';
+export { ax } from './ax';


### PR DESCRIPTION
Adds the ax runtime. This still works without the atomic CSS implementation - examples still work as expected.