### PR TITLE
Atomic post css plugin

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -19,6 +19,7 @@
     "src"
   ],
   "dependencies": {
+    "@compiled/utils": "0.4.7",
     "autoprefixer": "^9.7.6",
     "convert-source-map": "^1.7.0",
     "cssnano-preset-default": "^4.0.7",

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -61,7 +61,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"._1tclglyw:hover, ._16wpglyw:focus{-ms-user-select:none;user-select:none}"`
+      `"@media (min-width: 30rem){._3r8kglyw{-ms-user-select:none;user-select:none}}"`
     );
   });
 
@@ -77,7 +77,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"._1tclglyw:hover, ._16wpglyw:focus{-ms-user-select:none;user-select:none}"`
+      `"@media (min-width: 30rem){._1a7jglyw div{-ms-user-select:none;user-select:none}}"`
     );
   });
 
@@ -93,7 +93,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"._1tclglyw:hover, ._16wpglyw:focus{-ms-user-select:none;user-select:none}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._1cg4glyw{-ms-user-select:none;user-select:none}}}"`
     );
   });
 

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -164,17 +164,20 @@ describe('atomicify rules', () => {
     }).toThrow('atomicify-rules: <css input>:3:11: Nested rules are not allowed.');
   });
 
-  xit('should atomicify at rule styles', () => {
+  it('should atomicify at rule styles', () => {
     const actual = transform`
       @media (min-width: 30rem) {
         display: block;
+        font-size: 20px;
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`".not yet"`);
+    expect(actual).toMatchInlineSnapshot(
+      `"@media (min-width: 30rem){._1ie31ule{display:block}._4ubngktf{font-size:20px}}"`
+    );
   });
 
-  xit('should atomicify nested at rule styles', () => {
+  it('should atomicify nested at rule styles', () => {
     const actual = transform`
       @media (min-width: 30rem) {
         @media (min-width: 20rem) {
@@ -183,10 +186,12 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`".not yet"`);
+    expect(actual).toMatchInlineSnapshot(
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._16pr1ule{display:block}}}"`
+    );
   });
 
-  xit('should atomicify at rule nested styles', () => {
+  it('should atomicify at rule nested styles', () => {
     const actual = transform`
       @media (min-width: 30rem) {
         div {
@@ -195,10 +200,12 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`".not yet"`);
+    expect(actual).toMatchInlineSnapshot(
+      `"@media (min-width: 30rem){._166e1ule div{display:block}}"`
+    );
   });
 
-  xit('should atomicify double nested at rule nested styles', () => {
+  it('should atomicify double nested at rule nested styles', () => {
     const actual = transform`
       @media (min-width: 30rem) {
         @media (min-width: 20rem) {
@@ -209,6 +216,8 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`".not yet"`);
+    expect(actual).toMatchInlineSnapshot(
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._15ac1ule div{display:block}}}"`
+    );
   });
 });

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -1,0 +1,44 @@
+import postcss, { Plugin } from 'postcss';
+import whitespace from 'postcss-normalize-whitespace';
+import autoprefixer from 'autoprefixer';
+import { atomicifyRules } from '../atomicify-rules';
+
+const transform = (cssOrPlugins: TemplateStringsArray | Plugin<any>[]) => {
+  const result = postcss([atomicifyRules(), whitespace]).process(cssOrPlugins[0], {
+    from: undefined,
+  });
+
+  return result.css;
+};
+
+describe('atomicify rules', () => {
+  it('should atomicify a single declaration', () => {
+    const actual = transform`
+      color: blue;
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._17ab13q2{color:blue}"`);
+  });
+
+  it('should should atomicify multiple declarations', () => {
+    const actual = transform`
+      color: blue;
+      font-size: 12px;
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._17ab13q2{color:blue}._dsob1fwx{font-size:12px}"`);
+  });
+
+  it('should autoprefix atomic rules', () => {
+    process.env.BROWSERSLIST = 'Edge 16';
+
+    const result = postcss([atomicifyRules(), whitespace, autoprefixer]).process(
+      'user-select: none;',
+      {
+        from: undefined,
+      }
+    );
+
+    expect(result.css).toMatchInlineSnapshot(`"._1c5tglyw{-ms-user-select:none;user-select:none}"`);
+  });
+});

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -12,6 +12,10 @@ const transform = (css: TemplateStringsArray) => {
 };
 
 describe('atomicify rules', () => {
+  beforeEach(() => {
+    process.env.BROWSERSLIST = 'last 1 version';
+  });
+
   it('should atomicify a single declaration', () => {
     const actual = transform`
       color: blue;
@@ -311,6 +315,23 @@ describe('atomicify rules', () => {
 
     expect(actual).toMatchInlineSnapshot(
       `"@media (min-width: 30rem){@media (min-width: 20rem){._15ac1ule div{display:block}}}"`
+    );
+  });
+
+  it('should ignore unhanded at rules', () => {
+    const actual = transform`
+      @charset 'utf-8';
+      @import 'custom.css';
+      @namespace 'XML-namespace-URL';
+
+      @keyframes hello-world { from: { opacity: 0 } to { opacity: 1 } }
+      @font-face {
+        font-family: "Open Sans";
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(
+      `"@charset 'utf-8';@import 'custom.css';@namespace 'XML-namespace-URL';@-webkit-keyframes hello-world{from:{opacity:0}to{opacity:1}}@keyframes hello-world{from:{opacity:0}to{opacity:1}}@font-face{font-family:\\"Open Sans\\"}"`
     );
   });
 });

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -41,4 +41,27 @@ describe('atomicify rules', () => {
 
     expect(result.css).toMatchInlineSnapshot(`"._1c5tglyw{-ms-user-select:none;user-select:none}"`);
   });
+
+  it('should callback with created class names', () => {
+    const classes: string[] = [];
+    const callback = (className: string) => {
+      classes.push(className);
+    };
+
+    const result = postcss([atomicifyRules({ callback }), whitespace, autoprefixer]).process(
+      'display:block;text-align:center;',
+      {
+        from: undefined,
+      }
+    );
+
+    result.css;
+
+    expect(classes).toMatchInlineSnapshot(`
+      Array [
+        "_o72g1ule",
+        "_1glk1h6o",
+      ]
+    `);
+  });
 });

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -163,4 +163,52 @@ describe('atomicify rules', () => {
       `;
     }).toThrow('atomicify-rules: <css input>:3:11: Nested rules are not allowed.');
   });
+
+  xit('should atomicify at rule styles', () => {
+    const actual = transform`
+      @media (min-width: 30rem) {
+        display: block;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`".not yet"`);
+  });
+
+  xit('should atomicify nested at rule styles', () => {
+    const actual = transform`
+      @media (min-width: 30rem) {
+        @media (min-width: 20rem) {
+          display: block;
+        }
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`".not yet"`);
+  });
+
+  xit('should atomicify at rule nested styles', () => {
+    const actual = transform`
+      @media (min-width: 30rem) {
+        div {
+          display: block;
+        }
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`".not yet"`);
+  });
+
+  xit('should atomicify double nested at rule nested styles', () => {
+    const actual = transform`
+      @media (min-width: 30rem) {
+        @media (min-width: 20rem) {
+          div {
+            display: block;
+          }
+        }
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`".not yet"`);
+  });
 });

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -85,34 +85,41 @@ describe('atomicify rules', () => {
     expect(actual).toMatchInlineSnapshot(`"._k2hc13q2 div{color:blue}"`);
   });
 
-  it('should atomicify a nested pseudo rule', () => {
-    const actual = transform`
-      :hover {
+  it('should generate the same class hash for semantically same but different rules', () => {
+    const firstActual = transform`
+      &:first-child {
+        color: blue;
+      }
+    `;
+    const secondActual = transform`
+      :first-child {
         color: blue;
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1uhh13q2:hover{color:blue}"`);
+    const expected = '._roi113q2:first-child{color:blue}';
+    expect(firstActual).toEqual(expected);
+    expect(secondActual).toEqual(expected);
   });
 
-  xit('should reference the atomic class with the self selector', () => {
+  it('should behind reversed nesting', () => {
     const actual = transform`
-      &:hover {
-        color: blue;
+      :first-child & {
+        color: hotpink;
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1uhh13q2:hover{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._1qab1q9v:first-child ._1qab1q9v{color:hotpink}"`);
   });
 
-  xit('should reference the atomic class with the self selector', () => {
+  it('should reference the atomic class with the nesting selector', () => {
     const actual = transform`
-      :hover & {
+      & :first-child {
         color: blue;
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1uhh13q2 :hover{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._p9sj13q2 :first-child{color:blue}"`);
   });
 
   it('should atomicify a double tag rule', () => {

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -17,7 +17,7 @@ describe('atomicify rules', () => {
       color: blue;
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._17ab13q2{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._1doq13q2{color:blue}"`);
   });
 
   it('should should atomicify multiple declarations', () => {
@@ -26,7 +26,7 @@ describe('atomicify rules', () => {
       font-size: 12px;
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._17ab13q2{color:blue}._dsob1fwx{font-size:12px}"`);
+    expect(actual).toMatchInlineSnapshot(`"._1doq13q2{color:blue}._36l61fwx{font-size:12px}"`);
   });
 
   it('should autoprefix atomic rules', () => {
@@ -39,7 +39,7 @@ describe('atomicify rules', () => {
       }
     );
 
-    expect(result.css).toMatchInlineSnapshot(`"._1c5tglyw{-ms-user-select:none;user-select:none}"`);
+    expect(result.css).toMatchInlineSnapshot(`"._q4hxglyw{-ms-user-select:none;user-select:none}"`);
   });
 
   it('should callback with created class names', () => {
@@ -59,8 +59,8 @@ describe('atomicify rules', () => {
 
     expect(classes).toMatchInlineSnapshot(`
       Array [
-        "_o72g1ule",
-        "_1glk1h6o",
+        "_dj7i1ule",
+        "_o3nk1h6o",
       ]
     `);
   });
@@ -72,7 +72,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1aij13q2 div{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._k2hc13q2 div{color:blue}"`);
   });
 
   it('should atomicify a nested tag rule', () => {
@@ -82,7 +82,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1aij13q2 div{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._k2hc13q2 div{color:blue}"`);
   });
 
   it('should atomicify a nested pseudo rule', () => {
@@ -95,6 +95,46 @@ describe('atomicify rules', () => {
     expect(actual).toMatchInlineSnapshot(`"._1uhh13q2:hover{color:blue}"`);
   });
 
+  xit('should reference the atomic class with the self selector', () => {
+    const actual = transform`
+      &:hover {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._1uhh13q2:hover{color:blue}"`);
+  });
+
+  xit('should reference the atomic class with the self selector', () => {
+    const actual = transform`
+      :hover & {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._1uhh13q2 :hover{color:blue}"`);
+  });
+
+  it('should atomicify a double tag rule', () => {
+    const actual = transform`
+      div span {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._m59i13q2 div span{color:blue}"`);
+  });
+
+  it('should atomicify a double tag with pseudos rule', () => {
+    const actual = transform`
+      div:hover span:active {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._107g13q2 div:hover span:active{color:blue}"`);
+  });
+
   it('should atomicify a nested tag pseudo rule', () => {
     const actual = transform`
       div:hover {
@@ -102,7 +142,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._15mr13q2 div:hover{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._5tvz13q2 div:hover{color:blue}"`);
   });
 
   it('should blow up if a doubly nested rule was found', () => {

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -103,19 +103,35 @@ describe('atomicify rules', () => {
       classes.push(className);
     };
 
-    const result = postcss([atomicifyRules({ callback }), whitespace, autoprefixer]).process(
-      'display:block;text-align:center;',
+    const result = postcss([atomicifyRules({ callback }), whitespace]).process(
+      `
+        display:block;
+        text-align:center;
+        @media (min-width: 30rem) {
+          @media (min-width: 20rem) {
+            user-select: none;
+          }
+        }
+        div, span, :hover {
+          user-select: none;
+        }
+      `,
       {
         from: undefined,
       }
     );
 
+    // Need to call this to fire the transformation.
     result.css;
 
     expect(classes).toMatchInlineSnapshot(`
       Array [
         "_dj7i1ule",
         "_o3nk1h6o",
+        "_1cg4glyw",
+        "_1qcvglyw",
+        "_1uoyglyw",
+        "_1tclglyw",
       ]
     `);
   });

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -104,4 +104,16 @@ describe('atomicify rules', () => {
 
     expect(actual).toMatchInlineSnapshot(`"._15mr13q2 div:hover{color:blue}"`);
   });
+
+  it('should blow up if a doubly nested rule was found', () => {
+    expect(() => {
+      transform`
+        div {
+          div {
+            font-size: 12px;
+          }
+        }
+      `;
+    }).toThrow('atomicify-rules: <css input>:3:11: Nested rules are not allowed.');
+  });
 });

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -64,4 +64,44 @@ describe('atomicify rules', () => {
       ]
     `);
   });
+
+  it('should atomicify a nested tag rule', () => {
+    const actual = transform`
+      div {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._1aij13q2 div{color:blue}"`);
+  });
+
+  it('should atomicify a nested tag rule', () => {
+    const actual = transform`
+      div {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._1aij13q2 div{color:blue}"`);
+  });
+
+  it('should atomicify a nested pseudo rule', () => {
+    const actual = transform`
+      :hover {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._1uhh13q2:hover{color:blue}"`);
+  });
+
+  it('should atomicify a nested tag pseudo rule', () => {
+    const actual = transform`
+      div:hover {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._15mr13q2 div:hover{color:blue}"`);
+  });
 });

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -75,6 +75,38 @@ describe('atomicify rules', () => {
     expect(actual).toMatchInlineSnapshot(`"._k2hc13q2 div{color:blue}"`);
   });
 
+  it('should atomicify a nested tag with class rule', () => {
+    const actual = transform`
+      div.primary {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._yjs513q2 div.primary{color:blue}"`);
+  });
+
+  it('should atomicify a nested multi selector rule', () => {
+    const actual = transform`
+      div, span, li {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(
+      `"._k2hc13q2 div, ._ijgx13q2 span, ._1jah13q2 li{color:blue}"`
+    );
+  });
+
+  it('should atomicify a multi dangling pseudo rule', () => {
+    const actual = transform`
+      :hover, :focus {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._1uhh13q2:hover, ._t5gl13q2:focus{color:blue}"`);
+  });
+
   it('should atomicify a nested tag rule', () => {
     const actual = transform`
       div {

--- a/packages/css/src/plugins/atomicify-rules.tsx
+++ b/packages/css/src/plugins/atomicify-rules.tsx
@@ -29,6 +29,12 @@ const atomicClassName = (propName: string, value: string, opts: AtomicifyOpts) =
   return `_${group}${valueHash}`;
 };
 
+/**
+ * Returns a normalized selector.
+ * This will handle immediate dangling pseudos `:` as well as the nesting operator `&`.
+ *
+ * @param selector
+ */
 const normalizeSelector = (selector: string | undefined) => {
   if (!selector) {
     return '';
@@ -50,10 +56,22 @@ const normalizeSelector = (selector: string | undefined) => {
   }
 };
 
+/**
+ * Replaces all instances of a nesting operator `&` with the parent class name.
+ *
+ * @param selector
+ * @param parentClassName
+ */
 const replaceNestingSelector = (selector: string, parentClassName: string) => {
   return selector.replace(/ &/g, ` .${parentClassName}`);
 };
 
+/**
+ * Transforms a declaration into an atomic rule.
+ *
+ * @param node
+ * @param opts
+ */
 const atomicifyDecl = (node: Declaration, opts: AtomicifyOpts) => {
   const initialSelector = normalizeSelector(opts.selector);
   const className = atomicClassName(node.prop, node.value, {
@@ -75,6 +93,12 @@ const atomicifyDecl = (node: Declaration, opts: AtomicifyOpts) => {
   return newRule;
 };
 
+/**
+ * Transforms a rule into atomic rules.
+ *
+ * @param node
+ * @param opts
+ */
 const atomicifyRule = (node: Rule, opts: AtomicifyOpts) => {
   if (!node.nodes) {
     return [];
@@ -92,6 +116,12 @@ const atomicifyRule = (node: Rule, opts: AtomicifyOpts) => {
   });
 };
 
+/**
+ * Transforms an atrule into atomic rules.
+ *
+ * @param node
+ * @param opts
+ */
 const atomicifyAtRule = (node: AtRule, opts: AtomicifyOpts): AtRule => {
   let children: Node[] = [];
   const atRuleLabel = `${opts.atRule || ''}${node.name}${node.params}`;
@@ -128,7 +158,7 @@ const atomicifyAtRule = (node: AtRule, opts: AtomicifyOpts): AtRule => {
  *
  * Preconditions:
  *
- * 1. No nested rules allowed - normalized them with the `parent-orphaned-pseudos` and `nested` plugins.
+ * 1. No nested rules allowed - normalize them with the `parent-orphaned-pseudos` and `nested` plugins first.
  */
 export const atomicifyRules = plugin<PluginOpts>('atomicify-rules', (opts = {}) => {
   return (root) => {

--- a/packages/css/src/plugins/atomicify-rules.tsx
+++ b/packages/css/src/plugins/atomicify-rules.tsx
@@ -196,7 +196,11 @@ export const atomicifyRules = plugin<PluginOpts>('atomicify-rules', (opts = {}) 
     root.each((node) => {
       switch (node.type) {
         case 'atrule':
-          node.replaceWith(atomicifyAtRule(node, opts));
+          const supported = ['media', 'supports', 'document'];
+          if (supported.includes(node.name)) {
+            node.replaceWith(atomicifyAtRule(node, opts));
+          }
+
           break;
 
         case 'rule':

--- a/packages/css/src/plugins/atomicify-rules.tsx
+++ b/packages/css/src/plugins/atomicify-rules.tsx
@@ -42,9 +42,16 @@ const normalizeSelector = (selector: string | undefined) => {
     case ':':
       return trimmed;
 
+    case '&':
+      return trimmed.replace('&', '');
+
     default:
       return ` ${trimmed}`;
   }
+};
+
+const replaceNestingSelector = (selector: string, parentClassName: string) => {
+  return selector.replace(/ &/g, ` .${parentClassName}`);
 };
 
 const atomicifyDecl = (node: Declaration, opts: AtomicifyOpts) => {
@@ -53,7 +60,7 @@ const atomicifyDecl = (node: Declaration, opts: AtomicifyOpts) => {
     ...opts,
     selector: initialSelector,
   });
-  const selector = `.${className}${initialSelector}`;
+  const selector = `.${className}${replaceNestingSelector(initialSelector, className)}`;
   const newDecl = decl({ prop: node.prop, value: node.value });
   const newRule = rule({ selector, nodes: [newDecl] });
 

--- a/packages/css/src/plugins/atomicify-rules.tsx
+++ b/packages/css/src/plugins/atomicify-rules.tsx
@@ -1,0 +1,58 @@
+import { plugin, Declaration, decl, rule, Root } from 'postcss';
+import { hash } from '@compiled/utils';
+
+interface AtomicifyOpts {
+  root: Root;
+  selector?: string;
+  atRule?: string;
+}
+
+/**
+ * Returns an atomic rule class name using this form:
+ *
+ * ```
+ * "_{atrules}{selectors}{propertyname}"
+ * ```
+ *
+ * Atomic rules are always prepended with an underscore.
+ *
+ * @param group
+ * @param value
+ */
+const atomicClassName = (propName: string, value: string, opts: AtomicifyOpts) => {
+  const group = hash(`${opts.atRule}${opts.selector}${propName}`).slice(0, 4);
+  const valueHash = hash(value).slice(0, 4);
+
+  return `_${group}${valueHash}`;
+};
+
+const atomicifyDecl = (node: Declaration, opts: AtomicifyOpts) => {
+  const normalizedSelector = opts.selector || '';
+  const className = atomicClassName(node.prop, node.value, opts);
+  const selector = `.${className}${normalizedSelector}`;
+  const newDecl = decl({ prop: node.prop, value: node.value });
+  const newRule = rule({ selector, nodes: [newDecl] });
+
+  newDecl.parent = newRule;
+  newDecl.raws.before = '';
+
+  return newRule;
+};
+
+/**
+ * PostCSS plugin which will callback when traversing through each root declaration.
+ */
+export const atomicifyRules = plugin('atomicify-rules', () => {
+  return (root) => {
+    root.walk((node) => {
+      switch (node.type) {
+        case 'decl':
+          node.replaceWith(atomicifyDecl(node, { root }));
+          break;
+
+        default:
+          break;
+      }
+    });
+  };
+});

--- a/packages/css/src/plugins/atomicify-rules.tsx
+++ b/packages/css/src/plugins/atomicify-rules.tsx
@@ -68,7 +68,7 @@ const atomicifyRule = (node: Rule, opts: AtomicifyOpts) => {
 
   return node.nodes.map((childNode) => {
     if (childNode.type !== 'decl') {
-      throw new Error('Only decls are allowed inside a rule.');
+      throw childNode.error(`Nested ${childNode.type}s are not allowed.`);
     }
 
     return atomicifyDecl(childNode, {

--- a/packages/css/src/plugins/atomicify-rules.tsx
+++ b/packages/css/src/plugins/atomicify-rules.tsx
@@ -196,7 +196,7 @@ export const atomicifyRules = plugin<PluginOpts>('atomicify-rules', (opts = {}) 
     root.each((node) => {
       switch (node.type) {
         case 'atrule':
-          node.replaceWith(atomicifyAtRule(node, {}));
+          node.replaceWith(atomicifyAtRule(node, opts));
           break;
 
         case 'rule':

--- a/packages/css/tsconfig.json
+++ b/packages/css/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist",
     "module": "commonjs"
   },
-  "references": []
+  "references": [{ "path": "../utils" }]
 }


### PR DESCRIPTION
Look at tests for example input and outputs.

Closes #286 

**TODO**

- [x] top level property inside an at rule
- [x] properties in nested selectors in an at rule
- [x] top level property
- [x] properties in nested selectors
- [x] should callback with all created class names to be used later on
- [x] ensure if any property that needs prefixing has it in the atomic declaration
- [x] nested at rules
- [x] nested at rules with nested selectors
- [x] multi selector support (`div, span { display: block }`)
- [x] fix nested at rules autoprefixing blowing up

**TODO FOLLOW UP PR**

- [ ] reduce duplicate declarations #303 