### PR TITLE
feat: add object destructuring support

### DIFF
--- a/examples/module-traversal.tsx
+++ b/examples/module-traversal.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
 import { styled } from '@compiled/core';
-import { colors } from 'module-a';
+import { colors, objectStyles } from 'module-a';
 import { hover } from './mixins/mixins';
 
 export default {
   title: 'module traversal',
 };
 
+const { backgroundColor: borderColor } = objectStyles;
+
 const Thing = styled.div<{ bg: 'blue' }>({
   fontSize: '20px',
   color: colors.primary,
   ':hover': hover,
   backgroundColor: (props) => props.bg,
+  border: `5px dashed ${borderColor()}`,
 });
 
 export const Example = () => <Thing bg="blue">hello world</Thing>;

--- a/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
+++ b/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
@@ -187,4 +187,77 @@ describe('import specifiers', () => {
       );
     }).not.toThrow();
   });
+
+  it('handles object destructuring', () => {
+    const actual = transform(`
+      import '@compiled/core';
+      import React from 'react';
+
+      const { foo, color } = { foo: 14, color: 'blue' };
+
+      function Component() {
+        return (
+          <span css={{ fontSize: foo, color: color, backgroundColor: 'blue' }} />
+        );
+      };
+    `);
+
+    expect(actual).toInclude('.cc-hash-test{font-size:14px;color:blue;background-color:blue}');
+  });
+
+  it('handles the destructuring coming from an identifier', () => {
+    const actual = transform(`
+      import '@compiled/core';
+      import React from 'react';
+
+      const obj = { foo: 14, color: 'blue' };
+      const { foo, color } = obj;
+
+      function Component() {
+        return (
+          <span css={{ fontSize: foo, color: color, backgroundColor: 'blue' }} />
+        );
+      };
+    `);
+
+    expect(actual).toInclude('.cc-hash-test{font-size:14px;color:blue;background-color:blue}');
+  });
+
+  it('handles the destructuring coming from a referenced identifier', () => {
+    const actual = transform(`
+      import '@compiled/core';
+      import React from 'react';
+
+      const obj = { foo: 14, color: 'blue' };
+      const bar = obj;
+      const { foo, color } = bar;
+
+      function Component() {
+        return (
+          <span css={{ fontSize: foo, color: color, backgroundColor: 'blue' }} />
+        );
+      };
+    `);
+
+    expect(actual).toInclude('.cc-hash-test{font-size:14px;color:blue;background-color:blue}');
+  });
+
+  it('handles the function call destructuring coming from a referenced identifier', () => {
+    const actual = transform(`
+      import '@compiled/core';
+      import React from 'react';
+
+      const obj = { foo: () => ({ bar: 14 }), color: 'blue' };
+      const bar = obj;
+      const { foo, color } = bar;
+
+      function Component() {
+        return (
+          <span css={{ fontSize: foo().bar, color: color, backgroundColor: 'blue' }} />
+        );
+      };
+    `);
+
+    expect(actual).toInclude('.cc-hash-test{font-size:14px;color:blue;background-color:blue}');
+  });
 });

--- a/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
+++ b/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
@@ -202,7 +202,11 @@ describe('import specifiers', () => {
       };
     `);
 
-    expect(actual).toInclude('.cc-hash-test{font-size:14px;color:blue;background-color:blue}');
+    expect(actual).toIncludeMultiple([
+      '{font-size:14px}',
+      '{color:blue}',
+      '{background-color:blue}',
+    ]);
   });
 
   it('handles the destructuring coming from an identifier', () => {
@@ -220,7 +224,11 @@ describe('import specifiers', () => {
       };
     `);
 
-    expect(actual).toInclude('.cc-hash-test{font-size:14px;color:blue;background-color:blue}');
+    expect(actual).toIncludeMultiple([
+      '{font-size:14px}',
+      '{color:blue}',
+      '{background-color:blue}',
+    ]);
   });
 
   it('handles the destructuring coming from a referenced identifier', () => {
@@ -239,7 +247,11 @@ describe('import specifiers', () => {
       };
     `);
 
-    expect(actual).toInclude('.cc-hash-test{font-size:14px;color:blue;background-color:blue}');
+    expect(actual).toIncludeMultiple([
+      '{font-size:14px}',
+      '{color:blue}',
+      '{background-color:blue}',
+    ]);
   });
 
   it('handles the function call destructuring coming from a referenced identifier', () => {
@@ -258,6 +270,10 @@ describe('import specifiers', () => {
       };
     `);
 
-    expect(actual).toInclude('.cc-hash-test{font-size:14px;color:blue;background-color:blue}');
+    expect(actual).toIncludeMultiple([
+      '{font-size:14px}',
+      '{color:blue}',
+      '{background-color:blue}',
+    ]);
   });
 });

--- a/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
+++ b/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
@@ -343,4 +343,19 @@ describe('module traversal', () => {
 
     expect(result).toInclude(':hover{padding-top:10px}');
   });
+
+  it('should inline css when destructuring an identifier from another module', () => {
+    const result = transform(
+      `
+      import '@compiled/core';
+      import { spacingMixin } from '../__fixtures__/mixins/objects';
+
+      const { padding: { top } } = spacingMixin;
+
+      <div css={{':hover': { paddingTop: top() }}} />
+    `
+    );
+
+    expect(result).toInclude('.cc-hash-test:hover{padding-top:10px}');
+  });
 });

--- a/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
+++ b/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
@@ -356,6 +356,6 @@ describe('module traversal', () => {
     `
     );
 
-    expect(result).toInclude('.cc-hash-test:hover{padding-top:10px}');
+    expect(result).toInclude(':hover{padding-top:10px}');
   });
 });

--- a/packages/babel-plugin/src/utils/css-builders.tsx
+++ b/packages/babel-plugin/src/utils/css-builders.tsx
@@ -84,8 +84,7 @@ const extractObjectExpression = (node: t.ObjectExpression, meta: Metadata): CSSO
       let resolvedBinding = undefined;
 
       if (t.isIdentifier(prop.argument)) {
-        const binding = meta.parentPath.scope.getBinding(prop.argument.name);
-        resolvedBinding = resolveBindingNode(binding, meta);
+        resolvedBinding = resolveBindingNode(prop.argument.name, meta);
 
         if (!resolvedBinding) {
           throw buildCodeFrameError('Variable could not be found', prop.argument, meta.parentPath);
@@ -207,8 +206,7 @@ export const buildCss = (node: t.Expression, meta: Metadata): CSSOutput => {
   }
 
   if (t.isIdentifier(node)) {
-    const binding = meta.parentPath.scope.getBinding(node.name);
-    const resolvedBinding = resolveBindingNode(binding, meta);
+    const resolvedBinding = resolveBindingNode(node.name, meta);
 
     if (!resolvedBinding) {
       throw buildCodeFrameError('Variable could not be found', node, meta.parentPath);

--- a/packages/babel-plugin/src/utils/evaluate-expression.tsx
+++ b/packages/babel-plugin/src/utils/evaluate-expression.tsx
@@ -31,13 +31,7 @@ const traverseIdentifier = (expression: t.Identifier, meta: Metadata) => {
   let value: t.Node | undefined | null = undefined;
   let updatedMeta: Metadata = meta;
 
-  const binding = updatedMeta.parentPath.scope.getBinding(expression.name);
-  const resolvedBinding = resolveBindingNode(binding, updatedMeta);
-
-  if (binding?.path.node === expression) {
-    // We resolved to the same node - bail out!
-    return { value: expression, meta: updatedMeta };
-  }
+  const resolvedBinding = resolveBindingNode(expression.name, updatedMeta);
 
   if (resolvedBinding && resolvedBinding.constant) {
     // We recursively call get interpolation until it not longer returns an identifier or member expression
@@ -156,8 +150,7 @@ const traverseMemberExpression = (expression: t.MemberExpression, meta: Metadata
   const { accessPath, bindingIdentifier, originalBindingType } = getMemberExpressionMeta(
     expression
   );
-  const binding = updatedMeta.parentPath.scope.getBinding(bindingIdentifier.name);
-  const resolvedBinding = resolveBindingNode(binding, updatedMeta);
+  const resolvedBinding = resolveBindingNode(bindingIdentifier.name, updatedMeta);
 
   if (resolvedBinding && resolvedBinding.constant && t.isExpression(resolvedBinding.node)) {
     if (originalBindingType === 'Identifier') {


### PR DESCRIPTION
This closes #283 

- add variable declaration object destructuring support
- will work for referenced identifiers too
- will work across different modules
- fallback to variable if it can't be resolved
- refactor #resolveBindingNode to accept reference name instead of binding.
It will get binding by reference name now and resolves its node