### PR TITLE
fix: fixes doubling up nesting selector

### DIFF
--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -42,6 +42,16 @@ describe('atomicify rules', () => {
     expect(result).toMatchInlineSnapshot(`"._q4hxglyw{-ms-user-select:none;user-select:none}"`);
   });
 
+  it('should double up class selector when two nesting selectors are found', () => {
+    const result = transform`
+      && {
+        display: block;
+      }
+    `;
+
+    expect(result).toMatchInlineSnapshot(`"._1e0c1ule._1e0c1ule{display:block}"`);
+  });
+
   it('should autoprefix atomic rules with multiple selectors', () => {
     process.env.BROWSERSLIST = 'Edge 16';
 

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -200,6 +200,24 @@ describe('atomicify rules', () => {
     expect(secondActual).toEqual(expected);
   });
 
+  it('should double up selectors when using parent selector', () => {
+    const actual = transform`
+      && > * {
+        margin-bottom: 1rem;
+      }
+
+      && > *:last-child {
+        margin-bottom: 0;
+      }
+    `;
+
+    expect(actual.split('}').join('}\n')).toMatchInlineSnapshot(`
+      "._14rh1j6v._14rh1j6v > *{margin-bottom:1rem}
+      ._it8pidpf._it8pidpf > *:last-child{margin-bottom:0}
+      "
+    `);
+  });
+
   it('should atomicify a rule when its selector has a nesting at the end', () => {
     const actual = transform`
       :first-child & {

--- a/packages/css/src/plugins/__tests__/parent-orphaned-pseudos.test.tsx
+++ b/packages/css/src/plugins/__tests__/parent-orphaned-pseudos.test.tsx
@@ -1,0 +1,88 @@
+import postcss from 'postcss';
+import { parentOrphanedPseudos } from '../parent-orphaned-pseudos';
+
+const transform = (css: TemplateStringsArray) => {
+  const result = postcss([parentOrphanedPseudos()]).process(css[0], {
+    from: undefined,
+  });
+
+  return result.css;
+};
+
+describe('parent orphaned pseudos', () => {
+  it('should not parent a psuedo that already has a nesting selector', () => {
+    const actual = transform`
+      div {
+        &:hover {
+          display: block;
+        }
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            div {
+              &:hover {
+                display: block;
+              }
+            }
+          "
+    `);
+  });
+
+  it('should parent an orphened pseudo', () => {
+    const actual = transform`
+      div {
+        :hover {
+          display: block;
+        }
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            div {
+              &:hover {
+                display: block;
+              }
+            }
+          "
+    `);
+  });
+
+  it('should do nothing if preceding selector is a combinator', () => {
+    const actual = transform`
+      div {
+        div > :hover {
+          display: block;
+        }
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            div {
+              div > :hover {
+                display: block;
+              }
+            }
+          "
+    `);
+  });
+
+  it('should add nesting selector to top level psuedo', () => {
+    const actual = transform`
+      :hover {
+        display: block;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            &:hover {
+              display: block;
+            }
+          "
+    `);
+  });
+});

--- a/packages/css/src/plugins/atomicify-rules.tsx
+++ b/packages/css/src/plugins/atomicify-rules.tsx
@@ -69,7 +69,7 @@ const normalizeSelector = (selector: string | undefined) => {
  * @param parentClassName
  */
 const replaceNestingSelector = (selector: string, parentClassName: string) => {
-  return selector.replace(/ &/g, ` .${parentClassName}`);
+  return selector.replace(/&/g, `.${parentClassName}`);
 };
 
 /**

--- a/packages/css/src/plugins/parent-orphaned-pseudos.tsx
+++ b/packages/css/src/plugins/parent-orphaned-pseudos.tsx
@@ -36,6 +36,11 @@ export const parentOrphanedPseudos = plugin('parent-orphened-pseudos', () => {
         return;
       }
 
+      if (rule.parent.type === 'rule' && rule.parent.selector.includes('>')) {
+        // Skip reparenting if the direct parent is a combinator.
+        return;
+      }
+
       const selectorParserRoot = selectorParser((selectors) => {
         selectors.walkPseudos((selector) => {
           if (isPreviousSelectorCombinatorType(selector)) {

--- a/packages/css/src/plugins/parent-orphaned-pseudos.tsx
+++ b/packages/css/src/plugins/parent-orphaned-pseudos.tsx
@@ -32,12 +32,7 @@ export const parentOrphanedPseudos = plugin('parent-orphened-pseudos', () => {
     root.walkRules((rule) => {
       const { selector: ruleSelector } = rule;
 
-      if (!ruleSelector.includes(':')) {
-        return;
-      }
-
-      if (rule.parent.type === 'rule' && rule.parent.selector.includes('>')) {
-        // Skip reparenting if the direct parent is a combinator.
+      if (!ruleSelector.startsWith(':')) {
         return;
       }
 

--- a/packages/css/src/utils/__tests__/css-transform.test.tsx
+++ b/packages/css/src/utils/__tests__/css-transform.test.tsx
@@ -151,7 +151,7 @@ describe('leading pseduos in css', () => {
     `
     );
 
-    expect(actual.join('\n')).toMatchInlineSnapshot(`"._12t41q9v >:first-child{color:hotpink}"`);
+    expect(actual.join('\n')).toMatchInlineSnapshot(`"._gkte1q9v > :first-child{color:hotpink}"`);
   });
 
   it('should not affect the output css if theres nothing to do', () => {

--- a/packages/css/src/utils/__tests__/css-transform.test.tsx
+++ b/packages/css/src/utils/__tests__/css-transform.test.tsx
@@ -13,7 +13,7 @@ describe('leading pseduos in css', () => {
     expect(actual.join('\n')).toMatchInlineSnapshot(`"._t5gl1q9v:focus{color:hotpink}"`);
   });
 
-  it('should double up selectors when using parent selector', () => {
+  it('should not reparent when parent has a combinator', () => {
     const { sheets: actual } = transformCss(
       `
       && > * {

--- a/packages/css/src/utils/__tests__/css-transform.test.tsx
+++ b/packages/css/src/utils/__tests__/css-transform.test.tsx
@@ -13,6 +13,25 @@ describe('leading pseduos in css', () => {
     expect(actual.join('\n')).toMatchInlineSnapshot(`"._t5gl1q9v:focus{color:hotpink}"`);
   });
 
+  it('should double up selectors when using parent selector', () => {
+    const { sheets: actual } = transformCss(
+      `
+      && > * {
+        margin-bottom: 1rem;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    `
+    );
+
+    expect(actual.join('\n')).toMatchInlineSnapshot(`
+      "._14rh1j6v._14rh1j6v > *{margin-bottom:1rem}
+      ._it8pidpf._it8pidpf > *:last-child{margin-bottom:0}"
+    `);
+  });
+
   it('should parent multiple pseduos in a group', () => {
     const { sheets: actual } = transformCss(
       `


### PR DESCRIPTION
Previously  when re-parenting dangling pseudos who already had a nested selector - it would incorrectly double up the selectors.

```
&& > * {
  margin-bottom: 1rem;

  &:last-child {
    margin-bottom: 0;
  }
}
```

Would end up transforming to:

```diff
&& > * {
  margin-bottom: 1rem;

+  &&:last-child
-  &:last-child {
    margin-bottom: 0;
  }
}
```

The code to generate a double selector was also not working:

```
.hash& > * { // <-- second & not replaced
  margin-bottom: 1rem;

  &:last-child {
    margin-bottom: 0;
  }
}
```
