### PR TITLE
fix: fixes nesting selector behaviour across plugins

### DIFF
--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -34,14 +34,14 @@ describe('babel plugin', () => {
     expect(output?.code).toMatchInlineSnapshot(`
       "import * as React from 'react';
       import { ax, CC, CS } from '@compiled/core';
-      const _ = \\"._36l61fwx{font-size:12px}\\";
+      const _ = \\"._1wyb1fwx{font-size:12px}\\";
       const MyDiv = React.forwardRef(({
         as: C = \\"div\\",
         style,
         ...props
       }, ref) => <CC>
             <CS>{[_]}</CS>
-            <C {...props} style={style} ref={ref} className={ax([\\"_36l61fwx\\", props.className])} />
+            <C {...props} style={style} ref={ref} className={ax([\\"_1wyb1fwx\\", props.className])} />
           </CC>);"
     `);
   });
@@ -61,12 +61,12 @@ describe('babel plugin', () => {
     expect(output?.code).toMatchInlineSnapshot(`
       "import * as React from 'react';
       import { ax, CC, CS } from '@compiled/core';
-      const _ = \\"._36l61fwx{font-size:12px}\\";
+      const _ = \\"._1wyb1fwx{font-size:12px}\\";
 
       const MyDiv = () => {
         return <CC>
           <CS>{[_]}</CS>
-          {<div className={ax([\\"_36l61fwx\\"])}>hello</div>}
+          {<div className={ax([\\"_1wyb1fwx\\"])}>hello</div>}
         </CC>;
       };"
     `);

--- a/packages/babel-plugin/src/__tests__/module-imports.test.tsx
+++ b/packages/babel-plugin/src/__tests__/module-imports.test.tsx
@@ -67,9 +67,9 @@ describe('import specifiers', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import*as React from'react';import{ThemeProvider,ax,CC,CS}from'@compiled/core';const _=\\"._36l6gktf{font-size:20px}\\";const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{ThemeProvider,ax,CC,CS}from'@compiled/core';const _=\\"._1wybgktf{font-size:20px}\\";const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS>{[_]}</CS>
-            <C{...props}style={style}ref={ref}className={ax([\\"_36l6gktf\\",props.className])}/>
+            <C{...props}style={style}ref={ref}className={ax([\\"_1wybgktf\\",props.className])}/>
           </CC>);"
     `);
   });

--- a/packages/babel-plugin/src/__tests__/rule-hoisting.test.tsx
+++ b/packages/babel-plugin/src/__tests__/rule-hoisting.test.tsx
@@ -25,14 +25,14 @@ describe('rule hoisting', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import{ax,CC,CS}from'@compiled/core';import React from'react';const _2=\\"._36l61tcg{font-size:24px}\\";const _=\\"._36l61fwx{font-size:12px}\\";const Component=()=><>
+      "import{ax,CC,CS}from'@compiled/core';import React from'react';const _2=\\"._1wyb1tcg{font-size:24px}\\";const _=\\"._1wyb1fwx{font-size:12px}\\";const Component=()=><>
                 <CC>
           <CS>{[_]}</CS>
-          {<div className={ax([\\"_36l61fwx\\"])}>hello world</div>}
+          {<div className={ax([\\"_1wyb1fwx\\"])}>hello world</div>}
         </CC>
                 <CC>
           <CS>{[_2]}</CS>
-          {<div className={ax([\\"_36l61tcg\\"])}>hello world</div>}
+          {<div className={ax([\\"_1wyb1tcg\\"])}>hello world</div>}
         </CC>
               </>;"
     `);
@@ -52,14 +52,14 @@ describe('rule hoisting', () => {
   `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import{ax,CC,CS}from'@compiled/core';import React from'react';const _=\\"._36l61fwx{font-size:12px}\\";const Component=()=><>
+      "import{ax,CC,CS}from'@compiled/core';import React from'react';const _=\\"._1wyb1fwx{font-size:12px}\\";const Component=()=><>
               <CC>
           <CS>{[_]}</CS>
-          {<div className={ax([\\"_36l61fwx\\"])}>hello world</div>}
+          {<div className={ax([\\"_1wyb1fwx\\"])}>hello world</div>}
         </CC>
               <CC>
           <CS>{[_]}</CS>
-          {<div className={ax([\\"_36l61fwx\\"])}>hello world</div>}
+          {<div className={ax([\\"_1wyb1fwx\\"])}>hello world</div>}
         </CC>
             </>;"
     `);

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
@@ -133,7 +133,7 @@ describe('css prop behaviour', () => {
       />
     `);
 
-    expect(actual).toInclude('<div{...props}className={ax(["_36l6gktf"])}/>');
+    expect(actual).toInclude('<div{...props}className={ax(["_1wybgktf"])}/>');
   });
 
   it('should pass through static props', () => {
@@ -149,7 +149,7 @@ describe('css prop behaviour', () => {
       />
     `);
 
-    expect(actual).toInclude('<div role="menu"className={ax(["_36l6gktf"])}/>');
+    expect(actual).toInclude('<div role="menu"className={ax(["_1wybgktf"])}/>');
   });
 
   it('should concat explicit use of class name prop from an identifier on an element', () => {
@@ -175,8 +175,8 @@ describe('css prop behaviour', () => {
       <div css={[base, top]}>hello world</div>
     `);
 
-    expect(actual).toInclude('._1doq11x8{color:black}');
-    expect(actual).toInclude('._1doq5scu{color:red}');
+    expect(actual).toInclude('{color:black}');
+    expect(actual).toInclude('{color:red}');
   });
 
   it('should persist static style prop', () => {
@@ -189,7 +189,7 @@ describe('css prop behaviour', () => {
 
     expect(actual).toInclude(`{color:blue}`);
     expect(actual).toInclude(
-      `<div style={{display:'block'}}className={ax([\"_1doq13q2\"])}>hello world</div>`
+      `<div style={{display:'block'}}className={ax([\"_syaz13q2\"])}>hello world</div>`
     );
   });
 

--- a/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
@@ -522,10 +522,10 @@ describe('css prop object literal', () => {
       `);
 
     expect(actual).toInclude('style={{"--var-1xlms2h":HORIZONTAL_SPACING}}');
-    expect(actual).toInclude('._1cheidpf{padding-top:0}');
-    expect(actual).toInclude('._11vjrjbm{padding-right:var(--var-1xlms2h)}');
-    expect(actual).toInclude('._1ed7idpf{padding-bottom:0}');
-    expect(actual).toInclude('._nkoarjbm{padding-left:var(--var-1xlms2h)}');
+    expect(actual).toInclude('{padding-top:0}');
+    expect(actual).toInclude('{padding-right:var(--var-1xlms2h)}');
+    expect(actual).toInclude('{padding-bottom:0}');
+    expect(actual).toInclude('{padding-left:var(--var-1xlms2h)}');
   });
 
   it('should parse an inline string interpolation delimited by multiple spaces', () => {
@@ -542,10 +542,10 @@ describe('css prop object literal', () => {
          }}>hello world</div>
       `);
 
-    expect(actual).toInclude('._1cheidpf{padding-top:0}');
-    expect(actual).toInclude('._11vjrjbm{padding-right:var(--var-1xlms2h)}');
-    expect(actual).toInclude('._1ed7idpf{padding-bottom:0}');
-    expect(actual).toInclude('._nkoaidpf{padding-left:0}');
+    expect(actual).toInclude('{padding-top:0}');
+    expect(actual).toInclude('{padding-right:var(--var-1xlms2h)}');
+    expect(actual).toInclude('{padding-bottom:0}');
+    expect(actual).toInclude('{padding-left:0}');
     expect(actual).toInclude('style={{"--var-1xlms2h":HORIZONTAL_SPACING}}');
   });
 
@@ -563,11 +563,11 @@ describe('css prop object literal', () => {
          }}>hello world</div>
       `);
 
-    expect(actual).toInclude('._1cheidpf{padding-top:0}');
-    expect(actual).toInclude('._11vjftgi{padding-right:8px}');
-    expect(actual).toInclude('._1ed7idpf{padding-bottom:0}');
-    expect(actual).toInclude('._nkoaidpf{padding-left:0}');
-    expect(actual).toInclude('._1doq5scu{color:red}');
+    expect(actual).toInclude('{padding-top:0}');
+    expect(actual).toInclude('{padding-right:8px}');
+    expect(actual).toInclude('{padding-bottom:0}');
+    expect(actual).toInclude('{padding-left:0}');
+    expect(actual).toInclude('{color:red}');
   });
 
   it('should parse an inline string interpolation delimited by multiple spaces and multiple suffix', () => {
@@ -584,11 +584,11 @@ describe('css prop object literal', () => {
          }}>hello world</div>
       `);
 
-    expect(actual).toInclude('._1cheftgi{padding-top:8px}');
-    expect(actual).toInclude('._11vjftgi{padding-right:8px}');
-    expect(actual).toInclude('._1ed7ftgi{padding-bottom:8px}');
-    expect(actual).toInclude('._nkoaftgi{padding-left:8px}');
-    expect(actual).toInclude('._1doq5scu{color:red}');
+    expect(actual).toInclude('{padding-top:8px}');
+    expect(actual).toInclude('{padding-right:8px}');
+    expect(actual).toInclude('{padding-bottom:8px}');
+    expect(actual).toInclude('{padding-left:8px}');
+    expect(actual).toInclude('{color:red}');
   });
 
   it('should do nothing when content already has single quotes', () => {

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
@@ -21,9 +21,9 @@ describe('styled component behaviour', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import*as React from'react';import{ThemeProvider,ax,CC,CS}from'@compiled/core';const _=\\"._36l6gktf{font-size:20px}\\";const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{ThemeProvider,ax,CC,CS}from'@compiled/core';const _=\\"._1wybgktf{font-size:20px}\\";const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS>{[_]}</CS>
-            <C{...props}style={style}ref={ref}className={ax([\\"_36l6gktf\\",props.className])}/>
+            <C{...props}style={style}ref={ref}className={ax([\\"_1wybgktf\\",props.className])}/>
           </CC>);"
     `);
   });
@@ -38,9 +38,9 @@ describe('styled component behaviour', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import*as React from'react';import{ax,CC,CS}from'@compiled/core';const _=\\"._36l6gktf{font-size:20px}\\";const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{ax,CC,CS}from'@compiled/core';const _=\\"._1wybgktf{font-size:20px}\\";const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS>{[_]}</CS>
-            <C{...props}style={style}ref={ref}className={ax([\\"_36l6gktf\\",props.className])}/>
+            <C{...props}style={style}ref={ref}className={ax([\\"_1wybgktf\\",props.className])}/>
           </CC>);"
     `);
   });
@@ -95,9 +95,9 @@ describe('styled component behaviour', () => {
     `);
 
     expect(actual).toMatchInlineSnapshot(`
-      "import*as React from'react';import{ax,CC,CS}from'@compiled/core';const _=\\"._36l6gktf{font-size:20px}\\";const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
+      "import*as React from'react';import{ax,CC,CS}from'@compiled/core';const _=\\"._1wybgktf{font-size:20px}\\";const ListItem=React.forwardRef(({as:C=\\"div\\",style,...props},ref)=><CC>
             <CS>{[_]}</CS>
-            <C{...props}style={style}ref={ref}className={ax([\\"_36l6gktf\\",props.className])}/>
+            <C{...props}style={style}ref={ref}className={ax([\\"_1wybgktf\\",props.className])}/>
           </CC>);"
     `);
   });
@@ -184,7 +184,7 @@ describe('styled component behaviour', () => {
       \`;
     `);
 
-    expect(actual).toInclude(`className={ax([\"_36l6gktf\",props.className])}`);
+    expect(actual).toInclude(`className={ax([\"_1wybgktf\",props.className])}`);
   });
 
   it('should inline constant identifier string literal', () => {

--- a/packages/core/src/__tests__/browser.test.tsx
+++ b/packages/core/src/__tests__/browser.test.tsx
@@ -15,7 +15,7 @@ describe('browser', () => {
     const { baseElement } = render(<StyledDiv>hello world</StyledDiv>);
 
     expect(baseElement.innerHTML).toMatchInlineSnapshot(
-      `"<div><div class=\\"_36l61fwx\\">hello world</div></div>"`
+      `"<div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
     );
   });
 
@@ -32,7 +32,7 @@ describe('browser', () => {
     );
 
     expect(document.head.innerHTML).toMatchInlineSnapshot(
-      `"<style nonce=\\"k0Mp1lEd\\">._36l61fwx{font-size:12px}</style>"`
+      `"<style nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style>"`
     );
   });
 });

--- a/packages/core/src/__tests__/ssr.test.tsx
+++ b/packages/core/src/__tests__/ssr.test.tsx
@@ -14,7 +14,7 @@ describe('SSR', () => {
     const result = renderToStaticMarkup(<StyledDiv>hello world</StyledDiv>);
 
     expect(result).toMatchInlineSnapshot(
-      `"<style nonce=\\"k0Mp1lEd\\">._36l61fwx{font-size:12px}</style><div class=\\"_36l61fwx\\">hello world</div>"`
+      `"<style nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div>"`
     );
   });
 
@@ -31,7 +31,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<style nonce=\\"k0Mp1lEd\\">._36l61fwx{font-size:12px}</style><div class=\\"_36l61fwx\\">hello world</div><div class=\\"_36l61fwx\\">hello world</div>"`
+      `"<style nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div>"`
     );
   });
 
@@ -55,7 +55,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<div><div><div><style nonce=\\"k0Mp1lEd\\">._36l61fwx{font-size:12px}</style><div class=\\"_36l61fwx\\">hello world</div></div></div><div class=\\"_36l61fwx\\">hello world</div></div>"`
+      `"<div><div><div><style nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div></div></div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
     );
   });
 
@@ -75,7 +75,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<style nonce=\\"k0Mp1lEd\\">._dj7i1txw{display:flex}</style><div class=\\"_dj7i1txw\\"><style nonce=\\"k0Mp1lEd\\">._36l61fwx{font-size:12px}</style><div class=\\"_36l61fwx\\">hello world</div><div class=\\"_36l61fwx\\">hello world</div></div>"`
+      `"<style nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}</style><div class=\\"_1e0c1txw\\"><style nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
     );
   });
 });

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -22,7 +22,17 @@ describe('atomicify rules', () => {
       color: blue;
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1doq13q2{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._syaz13q2{color:blue}"`);
+  });
+
+  it('should prepend atomic class when nesting selector is prepended', () => {
+    const actual = transform`
+      [data-look='h100']& {
+        display: block;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"[data-look='h100']._mi0g1ule{display:block}"`);
   });
 
   it('should should atomicify multiple declarations', () => {
@@ -31,7 +41,7 @@ describe('atomicify rules', () => {
       font-size: 12px;
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1doq13q2{color:blue}._36l61fwx{font-size:12px}"`);
+    expect(actual).toMatchInlineSnapshot(`"._syaz13q2{color:blue}._1wyb1fwx{font-size:12px}"`);
   });
 
   it('should autoprefix atomic rules', () => {
@@ -39,7 +49,7 @@ describe('atomicify rules', () => {
 
     const result = transform`user-select: none;`;
 
-    expect(result).toMatchInlineSnapshot(`"._q4hxglyw{-ms-user-select:none;user-select:none}"`);
+    expect(result).toMatchInlineSnapshot(`"._uiztglyw{-ms-user-select:none;user-select:none}"`);
   });
 
   it('should double up class selector when two nesting selectors are found', () => {
@@ -49,20 +59,20 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(result).toMatchInlineSnapshot(`"._1e0c1ule._1e0c1ule{display:block}"`);
+    expect(result).toMatchInlineSnapshot(`"._if291ule._if291ule{display:block}"`);
   });
 
   it('should autoprefix atomic rules with multiple selectors', () => {
     process.env.BROWSERSLIST = 'Edge 16';
 
     const result = transform`
-      :hover, :focus {
+      &:hover, &:focus {
         user-select: none;
       }
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"._1tclglyw:hover, ._16wpglyw:focus{-ms-user-select:none;user-select:none}"`
+      `"._180hglyw:hover, ._1j5pglyw:focus{-ms-user-select:none;user-select:none}"`
     );
   });
 
@@ -76,7 +86,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){._3r8kglyw{-ms-user-select:none;user-select:none}}"`
+      `"@media (min-width: 30rem){._ufx4glyw{-ms-user-select:none;user-select:none}}"`
     );
   });
 
@@ -92,7 +102,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){._1a7jglyw div{-ms-user-select:none;user-select:none}}"`
+      `"@media (min-width: 30rem){._195xglyw div{-ms-user-select:none;user-select:none}}"`
     );
   });
 
@@ -108,7 +118,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){._1cg4glyw{-ms-user-select:none;user-select:none}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._uf5eglyw{-ms-user-select:none;user-select:none}}}"`
     );
   });
 
@@ -141,12 +151,12 @@ describe('atomicify rules', () => {
 
     expect(classes).toMatchInlineSnapshot(`
       Array [
-        "_dj7i1ule",
-        "_o3nk1h6o",
-        "_1cg4glyw",
-        "_1qcvglyw",
-        "_1uoyglyw",
-        "_1tclglyw",
+        "_1e0c1ule",
+        "_y3gn1h6o",
+        "_uf5eglyw",
+        "_2a8pglyw",
+        "_18i0glyw",
+        "_9iqnglyw",
       ]
     `);
   });
@@ -158,7 +168,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._yjs513q2 div.primary{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._13ml13q2 div.primary{color:blue}"`);
   });
 
   it('should atomicify a nested multi selector rule', () => {
@@ -169,18 +179,19 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"._k2hc13q2 div, ._ijgx13q2 span, ._1jah13q2 li{color:blue}"`
+      `"._65g013q2 div, ._1tjq13q2 span, ._thoc13q2 li{color:blue}"`
     );
   });
 
-  it('should atomicify a multi dangling pseudo rule', () => {
+  it('should atomicify a multi nesting pseudo rule', () => {
+    // Its assumed the pseudos will get a nesting selector from the nested plugin.
     const actual = transform`
-      :hover, :focus {
+      &:hover, &:focus {
         color: blue;
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1uhh13q2:hover, ._t5gl13q2:focus{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._30l313q2:hover, ._f8pj13q2:focus{color:blue}"`);
   });
 
   it('should atomicify a nested tag rule', () => {
@@ -190,7 +201,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._k2hc13q2 div{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._65g013q2 div{color:blue}"`);
   });
 
   it('should generate the same class hash for semantically same but different rules', () => {
@@ -200,14 +211,12 @@ describe('atomicify rules', () => {
       }
     `;
     const secondActual = transform`
-      :first-child {
+      &:first-child {
         color: blue;
       }
     `;
 
-    const expected = '._roi113q2:first-child{color:blue}';
-    expect(firstActual).toEqual(expected);
-    expect(secondActual).toEqual(expected);
+    expect(firstActual).toEqual(secondActual);
   });
 
   it('should double up selectors when using parent selector', () => {
@@ -222,20 +231,21 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual.split('}').join('}\n')).toMatchInlineSnapshot(`
-      "._14rh1j6v._14rh1j6v > *{margin-bottom:1rem}
-      ._it8pidpf._it8pidpf > *:last-child{margin-bottom:0}
+      "._169r1j6v._169r1j6v > *{margin-bottom:1rem}
+      ._1wzbidpf._1wzbidpf > *:last-child{margin-bottom:0}
       "
     `);
   });
 
   it('should atomicify a rule when its selector has a nesting at the end', () => {
+    // Its assumed the pseudos will get a nesting selector from the nested plugin.
     const actual = transform`
-      :first-child & {
+      &:first-child & {
         color: hotpink;
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1qab1q9v:first-child ._1qab1q9v{color:hotpink}"`);
+    expect(actual).toMatchInlineSnapshot(`"._ngwg1q9v:first-child ._ngwg1q9v{color:hotpink}"`);
   });
 
   it('should reference the atomic class with the nesting selector', () => {
@@ -245,7 +255,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._p9sj13q2 :first-child{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._prp213q2 :first-child{color:blue}"`);
   });
 
   it('should atomicify a double tag rule', () => {
@@ -255,7 +265,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._m59i13q2 div span{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._8gsp13q2 div span{color:blue}"`);
   });
 
   it('should atomicify a double tag with pseudos rule', () => {
@@ -265,7 +275,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._107g13q2 div:hover span:active{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._f1kd13q2 div:hover span:active{color:blue}"`);
   });
 
   it('should atomicify a nested tag pseudo rule', () => {
@@ -275,7 +285,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._5tvz13q2 div:hover{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._1tui13q2 div:hover{color:blue}"`);
   });
 
   it('should skip comments', () => {
@@ -293,7 +303,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"._5tvz13q2 div:hover{color:blue}@media screen{._gli45scu{color:red}}"`
+      `"._1tui13q2 div:hover{color:blue}@media screen{._43475scu{color:red}}"`
     );
   });
 
@@ -325,7 +335,7 @@ describe('atomicify rules', () => {
       }
     );
 
-    expect(result.css).toMatchInlineSnapshot(`"._1qan1fwx div div{font-size:12px}"`);
+    expect(result.css).toMatchInlineSnapshot(`"._73mn1fwx div div{font-size:12px}"`);
   });
 
   it('should atomicify at rule styles', () => {
@@ -337,7 +347,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){._1ie31ule{display:block}._4ubngktf{font-size:20px}}"`
+      `"@media (min-width: 30rem){._hi7c1ule{display:block}._1l5zgktf{font-size:20px}}"`
     );
   });
 
@@ -351,7 +361,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){._16pr1ule{display:block}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._1l9l1ule{display:block}}}"`
     );
   });
 
@@ -365,7 +375,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){._166e1ule div{display:block}}"`
+      `"@media (min-width: 30rem){._1v9q1ule div{display:block}}"`
     );
   });
 
@@ -381,7 +391,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){._15ac1ule div{display:block}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._1acs1ule div{display:block}}}"`
     );
   });
 

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -42,6 +42,16 @@ describe('atomicify rules', () => {
     expect(result).toMatchInlineSnapshot(`"._q4hxglyw{-ms-user-select:none;user-select:none}"`);
   });
 
+  it('should double up class selector when two nesting selectors are found', () => {
+    const result = transform`
+      && {
+        display: block;
+      }
+    `;
+
+    expect(result).toMatchInlineSnapshot(`"._1e0c1ule._1e0c1ule{display:block}"`);
+  });
+
   it('should autoprefix atomic rules with multiple selectors', () => {
     process.env.BROWSERSLIST = 'Edge 16';
 

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.tsx
@@ -200,6 +200,24 @@ describe('atomicify rules', () => {
     expect(secondActual).toEqual(expected);
   });
 
+  it('should double up selectors when using parent selector', () => {
+    const actual = transform`
+      && > * {
+        margin-bottom: 1rem;
+      }
+
+      && > *:last-child {
+        margin-bottom: 0;
+      }
+    `;
+
+    expect(actual.split('}').join('}\n')).toMatchInlineSnapshot(`
+      "._14rh1j6v._14rh1j6v > *{margin-bottom:1rem}
+      ._it8pidpf._it8pidpf > *:last-child{margin-bottom:0}
+      "
+    `);
+  });
+
   it('should atomicify a rule when its selector has a nesting at the end', () => {
     const actual = transform`
       :first-child & {

--- a/packages/css/src/plugins/__tests__/parent-orphaned-pseudos.test.tsx
+++ b/packages/css/src/plugins/__tests__/parent-orphaned-pseudos.test.tsx
@@ -85,4 +85,68 @@ describe('parent orphaned pseudos', () => {
           "
     `);
   });
+
+  it('should add nesting selector to dangling pseudo that has a appended nesting selector', () => {
+    const actual = transform`
+      :first-child & {
+        color: hotpink;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            &:first-child & {
+              color: hotpink;
+            }
+          "
+    `);
+  });
+
+  it('should do nothing when a nesting selector is appended to selector', () => {
+    const actual = transform`
+      [data-look='h100']& {
+        display: block;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            [data-look='h100']& {
+              display: block;
+            }
+          "
+    `);
+  });
+
+  it('should prepend nesting selector to multiple selector groups', () => {
+    const actual = transform`
+      :hover, :active {
+        display: block;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            &:hover, &:active {
+              display: block;
+            }
+          "
+    `);
+  });
+
+  it('should prepend nesting selector to multiple selector groups', () => {
+    const actual = transform`
+      div, :active {
+        display: block;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            div, &:active {
+              display: block;
+            }
+          "
+    `);
+  });
 });

--- a/packages/css/src/plugins/__tests__/parent-orphaned-pseudos.test.tsx
+++ b/packages/css/src/plugins/__tests__/parent-orphaned-pseudos.test.tsx
@@ -1,0 +1,88 @@
+import postcss from 'postcss';
+import { parentOrphanedPseudos } from '../parent-orphaned-pseudos';
+
+const transform = (css: TemplateStringsArray) => {
+  const result = postcss([parentOrphanedPseudos()]).process(css[0], {
+    from: undefined,
+  });
+
+  return result.css;
+};
+
+describe('parent orphaned pseudos', () => {
+  it('should not parent a psuedo that already has a nesting selector', () => {
+    const actual = transform`
+      div {
+        &:hover {
+          display: block;
+        }
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            div {
+              &:hover {
+                display: block;
+              }
+            }
+          "
+    `);
+  });
+
+  it('should parent an orphened pseudo', () => {
+    const actual = transform`
+      div {
+        :hover {
+          display: block;
+        }
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            div {
+              &:hover {
+                display: block;
+              }
+            }
+          "
+    `);
+  });
+
+  it('should do nothing if preceding selector is a combinator', () => {
+    const actual = transform`
+      div {
+        div > :hover {
+          display: block;
+        }
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            div {
+              div > :hover {
+                display: block;
+              }
+            }
+          "
+    `);
+  });
+
+  it('should add nesting selector to top level psuedo', () => {
+    const actual = transform`
+      :hover {
+        display: block;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            &:hover {
+              display: block;
+            }
+          "
+    `);
+  });
+});

--- a/packages/css/src/plugins/atomicify-rules.tsx
+++ b/packages/css/src/plugins/atomicify-rules.tsx
@@ -69,7 +69,7 @@ const normalizeSelector = (selector: string | undefined) => {
  * @param parentClassName
  */
 const replaceNestingSelector = (selector: string, parentClassName: string) => {
-  return selector.replace(/ &/g, ` .${parentClassName}`);
+  return selector.replace(/&/g, `.${parentClassName}`);
 };
 
 /**

--- a/packages/css/src/plugins/atomicify-rules.tsx
+++ b/packages/css/src/plugins/atomicify-rules.tsx
@@ -33,33 +33,29 @@ const atomicClassName = (propName: string, value: string, opts: AtomicifyOpts) =
 
 /**
  * Returns a normalized selector.
- * This will handle immediate dangling pseudos `:` as well as the nesting operator `&`.
+ * The primary function is to get rid of white space and to place a nesting selector if one is missing.
+ * If the selector already has a nesting selector - we won't do anything to it.
+ *
+ * ---
+ * ASSUMPTION: Nesting and parent orphaned pseudos plugins should run before the atomicify plugin!
+ * ---
  *
  * @param selector
  */
 const normalizeSelector = (selector: string | undefined) => {
   if (!selector) {
-    // Nothing to see here - return early with an empty string!
-    return '';
+    // Nothing to see here - return early with a nesting selector!
+    return '&';
   }
 
   // We want to build a consistent selector that we will use to generate the group hash.
   // Because of that we trim whitespace as well as removing any top level nesting "&".
   const trimmed = selector.trim();
-
-  switch (trimmed.charAt(0)) {
-    case ':':
-      // Dangling pseudo - return immedately!
-      return trimmed;
-
-    case '&':
-      // Dangling nesting - replace it and return!
-      return trimmed.replace('&', '');
-
-    default:
-      // Must be a nested selector - add a space before it!
-      return ` ${trimmed}`;
+  if (trimmed.indexOf('&') === -1) {
+    return `& ${trimmed}`;
   }
+
+  return trimmed;
 };
 
 /**
@@ -88,7 +84,7 @@ const buildAtomicSelector = (node: Declaration, opts: AtomicifyOpts) => {
     });
     const replacedSelector = replaceNestingSelector(normalizedSelector, className);
 
-    selectors.push(`.${className}${replacedSelector}`);
+    selectors.push(replacedSelector);
 
     if (opts.callback) {
       opts.callback(className);

--- a/packages/css/src/plugins/parent-orphaned-pseudos.tsx
+++ b/packages/css/src/plugins/parent-orphaned-pseudos.tsx
@@ -36,6 +36,11 @@ export const parentOrphanedPseudos = plugin('parent-orphened-pseudos', () => {
         return;
       }
 
+      if (rule.parent.type === 'rule' && rule.parent.selector.includes('>')) {
+        // Skip reparenting if the direct parent is a combinator.
+        return;
+      }
+
       const selectorParserRoot = selectorParser((selectors) => {
         selectors.walkPseudos((selector) => {
           if (isPreviousSelectorCombinatorType(selector)) {

--- a/packages/css/src/plugins/parent-orphaned-pseudos.tsx
+++ b/packages/css/src/plugins/parent-orphaned-pseudos.tsx
@@ -1,11 +1,6 @@
 import { plugin } from 'postcss';
 import selectorParser from 'postcss-selector-parser';
 
-const isPreviousSelectorCombinatorType = (selector: selectorParser.Node) => {
-  const previousSelector = selector.prev();
-  return previousSelector && previousSelector.type === 'combinator';
-};
-
 const prependNestingTypeToSelector = (selector: selectorParser.Node) => {
   const { parent } = selector;
 
@@ -33,10 +28,6 @@ export const parentOrphanedPseudos = plugin('parent-orphened-pseudos', () => {
 
         const parser = selectorParser((root) => {
           root.walkPseudos((pseudoSelector) => {
-            if (isPreviousSelectorCombinatorType(pseudoSelector)) {
-              return;
-            }
-
             prependNestingTypeToSelector(pseudoSelector);
           });
         }).astSync(selector, { lossless: false });

--- a/packages/css/src/plugins/parent-orphaned-pseudos.tsx
+++ b/packages/css/src/plugins/parent-orphaned-pseudos.tsx
@@ -32,12 +32,7 @@ export const parentOrphanedPseudos = plugin('parent-orphened-pseudos', () => {
     root.walkRules((rule) => {
       const { selector: ruleSelector } = rule;
 
-      if (!ruleSelector.includes(':')) {
-        return;
-      }
-
-      if (rule.parent.type === 'rule' && rule.parent.selector.includes('>')) {
-        // Skip reparenting if the direct parent is a combinator.
+      if (!ruleSelector.startsWith(':')) {
         return;
       }
 

--- a/packages/css/src/utils/__tests__/css-transform.test.tsx
+++ b/packages/css/src/utils/__tests__/css-transform.test.tsx
@@ -151,7 +151,7 @@ describe('leading pseduos in css', () => {
     `
     );
 
-    expect(actual.join('\n')).toMatchInlineSnapshot(`"._12t41q9v >:first-child{color:hotpink}"`);
+    expect(actual.join('\n')).toMatchInlineSnapshot(`"._gkte1q9v > :first-child{color:hotpink}"`);
   });
 
   it('should not affect the output css if theres nothing to do', () => {

--- a/packages/css/src/utils/__tests__/css-transform.test.tsx
+++ b/packages/css/src/utils/__tests__/css-transform.test.tsx
@@ -10,7 +10,7 @@ describe('leading pseduos in css', () => {
     `
     );
 
-    expect(actual.join('\n')).toMatchInlineSnapshot(`"._t5gl1q9v:focus{color:hotpink}"`);
+    expect(actual.join('\n')).toMatchInlineSnapshot(`"._f8pj1q9v:focus{color:hotpink}"`);
   });
 
   it('should not reparent when parent has a combinator', () => {
@@ -27,8 +27,8 @@ describe('leading pseduos in css', () => {
     );
 
     expect(actual.join('\n')).toMatchInlineSnapshot(`
-      "._14rh1j6v._14rh1j6v > *{margin-bottom:1rem}
-      ._it8pidpf._it8pidpf > *:last-child{margin-bottom:0}"
+      "._169r1j6v._169r1j6v > *{margin-bottom:1rem}
+      ._1wzbidpf._1wzbidpf > *:last-child{margin-bottom:0}"
     `);
   });
 
@@ -43,7 +43,7 @@ describe('leading pseduos in css', () => {
     );
 
     expect(actual.join('\n')).toMatchInlineSnapshot(
-      `"._g1wc1q9v:hover div, ._t5gl1q9v:focus{color:hotpink}"`
+      `"._1sfm1q9v:hover div, ._f8pj1q9v:focus{color:hotpink}"`
     );
   });
 
@@ -64,18 +64,18 @@ describe('leading pseduos in css', () => {
     );
 
     expect(actual.join('\n').split(',').join(',\n')).toMatchInlineSnapshot(`
-      "._774z1q9v .foo:first-child,
-       ._1uu81q9v .foo div,
-       ._1t8r1q9v .foo span,
-       ._bucf1q9v .foo:last-child,
-       ._1j3t1q9v .bar div:first-child,
-       ._1dnx1q9v .bar div div,
-       ._t68y1q9v .bar div span,
-       ._3gpd1q9v .bar div:last-child,
-       ._9hpv1q9v .qwe:first-child,
-       ._uu4h1q9v .qwe div,
-       ._1u2l1q9v .qwe span,
-       ._11e01q9v .qwe:last-child{color:hotpink}"
+      "._t7rc1q9v .foo:first-child,
+       ._ppxs1q9v .foo div,
+       ._1fa31q9v .foo span,
+       ._1pdx1q9v .foo:last-child,
+       ._1sbr1q9v .bar div:first-child,
+       ._kq2v1q9v .bar div div,
+       ._11eb1q9v .bar div span,
+       ._15h31q9v .bar div:last-child,
+       ._1g8a1q9v .qwe:first-child,
+       ._1z9o1q9v .qwe div,
+       ._1qid1q9v .qwe span,
+       ._1j9g1q9v .qwe:last-child{color:hotpink}"
     `);
   });
 
@@ -88,7 +88,7 @@ describe('leading pseduos in css', () => {
     `
     );
 
-    expect(actual.join('\n')).toMatchInlineSnapshot(`"._19mq1q9v:nth-child(3){color:hotpink}"`);
+    expect(actual.join('\n')).toMatchInlineSnapshot(`"._2pem1q9v:nth-child(3){color:hotpink}"`);
   });
 
   it('should parent overlapping psuedos', () => {
@@ -103,7 +103,7 @@ describe('leading pseduos in css', () => {
     );
 
     expect(actual.join('\n')).toMatchInlineSnapshot(
-      `"._v39b1q9v :first-child:first-child{color:hotpink}"`
+      `"._1kys1q9v :first-child:first-child{color:hotpink}"`
     );
   });
 
@@ -119,7 +119,7 @@ describe('leading pseduos in css', () => {
     );
 
     expect(actual.join('\n')).toMatchInlineSnapshot(
-      `"._1aks1q9v :first-child:first-child ._1aks1q9v :first-child{color:hotpink}"`
+      `"._99g41q9v :first-child:first-child ._99g41q9v :first-child{color:hotpink}"`
     );
   });
 
@@ -138,7 +138,7 @@ describe('leading pseduos in css', () => {
     );
 
     expect(actual.join('\n')).toMatchInlineSnapshot(
-      `"@media (max-width: 400px){@supports (display: grid){._1bnp1q9v div, ._zqtk1q9v:first-child{color:hotpink}}}"`
+      `"@media (max-width: 400px){@supports (display: grid){._1vye1q9v div, ._18e01q9v:first-child{color:hotpink}}}"`
     );
   });
 
@@ -151,7 +151,7 @@ describe('leading pseduos in css', () => {
     `
     );
 
-    expect(actual.join('\n')).toMatchInlineSnapshot(`"._gkte1q9v > :first-child{color:hotpink}"`);
+    expect(actual.join('\n')).toMatchInlineSnapshot(`"._19601q9v > :first-child{color:hotpink}"`);
   });
 
   it('should not affect the output css if theres nothing to do', () => {
@@ -163,7 +163,7 @@ describe('leading pseduos in css', () => {
     `
     );
 
-    expect(actual.join('\n')).toMatchInlineSnapshot(`"._k2hc1q9v div{color:hotpink}"`);
+    expect(actual.join('\n')).toMatchInlineSnapshot(`"._65g01q9v div{color:hotpink}"`);
   });
 
   it('should ignore parsing a data attribute selector with a comma in it', () => {
@@ -176,7 +176,7 @@ describe('leading pseduos in css', () => {
     );
 
     expect(actual.join('\n')).toMatchInlineSnapshot(
-      `"._1j3i1q9v [data-foo=\\",\\"]{color:hotpink}"`
+      `"._qofj1q9v [data-foo=\\",\\"]{color:hotpink}"`
     );
   });
 
@@ -196,11 +196,11 @@ describe('leading pseduos in css', () => {
     );
 
     expect(actual.join('\n')).toMatchInlineSnapshot(`
-      "._1rvbh2mm{position:relative}
-      ._v8ua1dk0{text-transform:capitalize}
-      ._ehmw16l8:after{content:\\"›\\"}
-      ._1a4astnw:after{position:absolute}
-      ._og13lgv5:after{right:-2rem}"
+      "._kqswh2mm{position:relative}
+      ._1p1d1dk0{text-transform:capitalize}
+      ._aetr16l8:after{content:\\"›\\"}
+      ._18postnw:after{position:absolute}
+      ._32rxlgv5:after{right:-2rem}"
     `);
   });
 
@@ -220,11 +220,11 @@ describe('leading pseduos in css', () => {
 
     expect(classNames).toMatchInlineSnapshot(`
       Array [
-        "_1rvbh2mm",
-        "_v8ua1dk0",
-        "_ehmw16l8",
-        "_1a4astnw",
-        "_og13lgv5",
+        "_kqswh2mm",
+        "_1p1d1dk0",
+        "_aetr16l8",
+        "_18postnw",
+        "_32rxlgv5",
       ]
     `);
   });
@@ -244,7 +244,7 @@ describe('leading pseduos in css', () => {
         `
       );
       expect(actual.join('')).toMatchInlineSnapshot(
-        `"._1qcvglyw div{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}"`
+        `"._2a8pglyw div{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}"`
       );
     });
 
@@ -258,7 +258,7 @@ describe('leading pseduos in css', () => {
         `
       );
       expect(actual.join('')).toMatchInlineSnapshot(
-        `"._1qcvglyw div{-ms-user-select:none;user-select:none}"`
+        `"._2a8pglyw div{-ms-user-select:none;user-select:none}"`
       );
     });
 
@@ -271,7 +271,7 @@ describe('leading pseduos in css', () => {
         }
         `
       );
-      expect(actual.join('')).toMatchInlineSnapshot(`"._1qcvglyw div{user-select:none}"`);
+      expect(actual.join('')).toMatchInlineSnapshot(`"._2a8pglyw div{user-select:none}"`);
     });
 
     it('should generate ms prefixes for grid', () => {
@@ -284,7 +284,7 @@ describe('leading pseduos in css', () => {
         `
       );
       expect(actual.join('')).toMatchInlineSnapshot(
-        `"._fz6y11p5 div{display:-ms-grid;display:grid}"`
+        `"._tkqh11p5 div{display:-ms-grid;display:grid}"`
       );
     });
   });

--- a/packages/css/src/utils/__tests__/css-transform.test.tsx
+++ b/packages/css/src/utils/__tests__/css-transform.test.tsx
@@ -13,7 +13,7 @@ describe('leading pseduos in css', () => {
     expect(actual.join('\n')).toMatchInlineSnapshot(`"._t5gl1q9v:focus{color:hotpink}"`);
   });
 
-  it('should double up selectors when using parent selector', () => {
+  it('should not reparent when parent has a combinator', () => {
     const { sheets: actual } = transformCss(
       `
       && > * {

--- a/packages/css/src/utils/__tests__/css-transform.test.tsx
+++ b/packages/css/src/utils/__tests__/css-transform.test.tsx
@@ -13,6 +13,25 @@ describe('leading pseduos in css', () => {
     expect(actual.join('\n')).toMatchInlineSnapshot(`"._t5gl1q9v:focus{color:hotpink}"`);
   });
 
+  it('should double up selectors when using parent selector', () => {
+    const { sheets: actual } = transformCss(
+      `
+      && > * {
+        margin-bottom: 1rem;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    `
+    );
+
+    expect(actual.join('\n')).toMatchInlineSnapshot(`
+      "._14rh1j6v._14rh1j6v > *{margin-bottom:1rem}
+      ._it8pidpf._it8pidpf > *:last-child{margin-bottom:0}"
+    `);
+  });
+
   it('should parent multiple pseduos in a group', () => {
     const { sheets: actual } = transformCss(
       `


### PR DESCRIPTION
Previously this would break:

```
[data-hello-world]& {
  display: block;
}
```

This fixes the implementation of the atomic plugin and dangling psuedos. Have a look at their tests to see further.