### PR TITLE
chore: reduce ax bundlesize

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "size-limit": [
     {
       "path": "./packages/runtime/dist/browser/index.js",
-      "limit": "75B",
+      "limit": "99B",
       "import": "{ ax }",
       "ignore": [
         "react"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "size-limit": [
     {
       "path": "./packages/runtime/dist/browser/index.js",
-      "limit": "105B",
+      "limit": "75B",
       "import": "{ ax }",
       "ignore": [
         "react"

--- a/packages/runtime/src/__tests__/ax.test.tsx
+++ b/packages/runtime/src/__tests__/ax.test.tsx
@@ -1,4 +1,4 @@
-import { ax } from '../ax';
+import ax from '../ax';
 
 describe('ax', () => {
   it('should join single classes together', () => {

--- a/packages/runtime/src/__tests__/ax.test.tsx
+++ b/packages/runtime/src/__tests__/ax.test.tsx
@@ -43,4 +43,10 @@ describe('ax', () => {
 
     expect(result).toEqual('bar');
   });
+
+  it('should ignore non atomic declarations', () => {
+    const result = ax(['hello_there', 'hello_world']);
+
+    expect(result).toEqual('hello_there hello_world');
+  });
 });

--- a/packages/runtime/src/ax.tsx
+++ b/packages/runtime/src/ax.tsx
@@ -19,23 +19,22 @@
  *
  * @param classes
  */
-export const ax = (classes: (string | undefined | false)[]): string => {
-  const found: Record<string, string> = {};
+export default function ax(classNames: (string | undefined | false)[]): string {
+  const atomicGroups: Record<string, string> = {};
+  let i = -1;
 
-  for (let i = 0; i < classes.length; i++) {
-    const cls = classes[i];
-    if (!cls) {
+  while (++i < classNames.length) {
+    if (!classNames[i]) {
       continue;
     }
 
-    const groups = cls.split(' ');
+    const groups = (classNames[i] as string).split(' ');
+    let x = -1;
 
-    for (let x = 0; x < groups.length; x++) {
-      const className = groups[x];
-      const group = className.slice(0, className.charCodeAt(0) === 95 ? 5 : undefined);
-      found[group] = className;
+    while (++x < groups.length) {
+      atomicGroups[groups[x].slice(0, 5)] = groups[x];
     }
   }
 
-  return Object.values(found).join(' ');
-};
+  return Object.values(atomicGroups).join(' ');
+}

--- a/packages/runtime/src/ax.tsx
+++ b/packages/runtime/src/ax.tsx
@@ -32,7 +32,7 @@ export default function ax(classNames: (string | undefined | false)[]): string {
     let x = -1;
 
     while (++x < groups.length) {
-      atomicGroups[groups[x].slice(0, 5)] = groups[x];
+      atomicGroups[groups[x].slice(0, groups[x].charCodeAt(0) === 95 ? 5 : undefined)] = groups[x];
     }
   }
 

--- a/packages/runtime/src/ax.tsx
+++ b/packages/runtime/src/ax.tsx
@@ -1,3 +1,11 @@
+const UNDERSCORE_UNICODE = 95;
+
+/**
+ * This length includes the underscore,
+ * e.g. `"_1s4A"` would be a valid atomic group hash.
+ */
+const ATOMIC_GROUP_LENGTH = 5;
+
 /**
  * Joins classes together and ensures atomic declarations of a single group exist.
  * Atomic declarations take the form of `_{group}{value}` (always prefixed with an underscore),
@@ -32,7 +40,12 @@ export default function ax(classNames: (string | undefined | false)[]): string {
     let x = -1;
 
     while (++x < groups.length) {
-      atomicGroups[groups[x].slice(0, groups[x].charCodeAt(0) === 95 ? 5 : undefined)] = groups[x];
+      atomicGroups[
+        groups[x].slice(
+          0,
+          groups[x].charCodeAt(0) === UNDERSCORE_UNICODE ? ATOMIC_GROUP_LENGTH : undefined
+        )
+      ] = groups[x];
     }
   }
 

--- a/packages/runtime/src/index.tsx
+++ b/packages/runtime/src/index.tsx
@@ -1,3 +1,3 @@
 export { default as CS } from './style';
 export { default as CC } from './provider';
-export { ax } from './ax';
+export { default as ax } from './ax';


### PR DESCRIPTION
Initially I had an implementation that did `join(' ').split(' ')` which allowed me to get the size down to `50B` but it was 30% slower than ax in master.

This PR has similar perf to ax in master.