### PR TITLE
chore: simplify css var name

### DIFF
--- a/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
+++ b/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
@@ -46,7 +46,7 @@ describe('import specifiers', () => {
       <div css={{ fontSize: mutable }}>hello world</div>
     `);
 
-    expect(actual).toInclude('{font-size:var(--var-i47brp)}');
+    expect(actual).toInclude('{font-size:var(--_i47brp)}');
   });
 
   it('should bail out evaluating identifier expression referencing a mutated identifier', () => {
@@ -61,7 +61,7 @@ describe('import specifiers', () => {
       <div css={{ fontSize: dontchange }}>hello world</div>
     `);
 
-    expect(actual).toInclude('{font-size:var(--var-uta6jk)}');
+    expect(actual).toInclude('{font-size:var(--_uta6jk)}');
   });
 
   it('should not exhaust the stack when an identifier references itself', () => {
@@ -89,7 +89,7 @@ describe('import specifiers', () => {
       <div css={{ fontSize: dontchange }}>hello world</div>
     `);
 
-    expect(actual).toInclude('{font-size:var(--var-uta6jk)}');
+    expect(actual).toInclude('{font-size:var(--_uta6jk)}');
   });
 
   it('should bail out evaluating a binary expression referencing a mutated identifier', () => {
@@ -103,7 +103,7 @@ describe('import specifiers', () => {
       <div css={{ fontSize: mutable * 2 }}>hello world</div>
     `);
 
-    expect(actual).toInclude('{font-size:var(--var-1bs2x4k)}');
+    expect(actual).toInclude('{font-size:var(--_1bs2x4k)}');
   });
 
   it('should not blow up when referencing local destructured args in arrow func', () => {

--- a/packages/babel-plugin/src/class-names/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/class-names/__tests__/object-literal.test.tsx
@@ -26,9 +26,9 @@ describe('class names object literal', () => {
       `);
 
     expect(actual).toInclude(
-      '<div style={{ "--var-test-fontsize": (fontSize || "") + "px" }} className={"css-test"}>hello, world!</div>'
+      '<div style={{ "--_test-fontsize": (fontSize || "") + "px" }} className={"css-test"}>hello, world!</div>'
     );
-    expect(actual).toInclude('.css-test{font-size:var(--var-test-fontsize)}');
+    expect(actual).toInclude('.css-test{font-size:var(--_test-fontsize)}');
   });
 
   xit('should transform object with simple values', () => {
@@ -107,9 +107,9 @@ describe('class names object literal', () => {
         );
       `);
 
-    expect(actual).toInclude('.css-test{color:blue;font-size:var(--var-test-fontsize)}');
+    expect(actual).toInclude('.css-test{color:blue;font-size:var(--_test-fontsize)}');
     expect(actual).toInclude(
-      '<div style={{ "--var-test-fontsize": fontSize }} className={"css-test"}>hello, world!</div>'
+      '<div style={{ "--_test-fontsize": fontSize }} className={"css-test"}>hello, world!</div>'
     );
   });
 

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
@@ -65,7 +65,7 @@ describe('css prop behaviour', () => {
       const Component = ({ className, style }) => <div className={className} style={style} css={{ fontSize, color: red }}>hello world</div>;
     `);
 
-    expect(actual).toInclude('style={{...style,"--var-1j2e0s2":fontSize}}');
+    expect(actual).toInclude('style={{...style,"--_1j2e0s2":fontSize}}');
   });
 
   it('should spread style property access when there is dynamic styles in the css', () => {
@@ -77,7 +77,7 @@ describe('css prop behaviour', () => {
       const Component = ({ className, ...props }) => <div className={className} style={props.style} css={{ fontSize: 12, color: red, background }}>hello world</div>;
     `);
 
-    expect(actual).toInclude('style={{...props.style,"--var-1k9t07z":background}}');
+    expect(actual).toInclude('style={{...props.style,"--_1k9t07z":background}}');
   });
 
   it('should spread style identifier when there is styles already set', () => {
@@ -102,7 +102,7 @@ describe('css prop behaviour', () => {
     `);
 
     expect(actual).toIncludeMultiple([
-      `style={{...style,display:'block',\"--var-1k9t07z\":background}}`,
+      `style={{...style,display:'block',\"--_1k9t07z\":background}}`,
       'color:red',
     ]);
   });
@@ -202,8 +202,8 @@ describe('css prop behaviour', () => {
       <div style={{ display: 'block' }} css={{ color: \`\${color}\` }}>hello world</div>
     `);
 
-    expect(actual).toInclude(`color:var(--var-1ylxx6h)`);
-    expect(actual).toInclude(`style={{display:'block',\"--var-1ylxx6h\":color}}`);
+    expect(actual).toInclude(`color:var(--_1ylxx6h)`);
+    expect(actual).toInclude(`style={{display:'block',\"--_1ylxx6h\":color}}`);
   });
 
   it('should concat implicit use of class name prop where class name is a jsx expression', () => {
@@ -229,9 +229,9 @@ describe('css prop behaviour', () => {
       <div css={{ color: hello ? 'red' : 'blue', fontSize: 10 }}>hello world</div>
     `);
 
-    expect(actual).toInclude('color:var(--var-15b8wfu)');
+    expect(actual).toInclude('color:var(--_15b8wfu)');
     expect(actual).toInclude('font-size:10px');
-    expect(actual).toInclude(`style={{\"--var-15b8wfu\":hello?'red':'blue'}}`);
+    expect(actual).toInclude(`style={{\"--_15b8wfu\":hello?'red':'blue'}}`);
   });
 
   it('should inline multi interpolation constant variable', () => {
@@ -272,9 +272,9 @@ describe('css prop behaviour', () => {
     `);
 
     expect(actual).toInclude(
-      `{background-image:linear-gradient(45deg,var(--var-1vrvste\) 25%,transparent 25%),linear-gradient(-45deg,var(--var-1vrvste\) 25%,transparent 25%),linear-gradient(45deg,transparent 75%,var(--var-1vrvste\) 75%),linear-gradient(-45deg,transparent 75%,var(--var-1vrvste\) 75%)}`
+      `{background-image:linear-gradient(45deg,var(--_1vrvste\) 25%,transparent 25%),linear-gradient(-45deg,var(--_1vrvste\) 25%,transparent 25%),linear-gradient(45deg,transparent 75%,var(--_1vrvste\) 75%),linear-gradient(-45deg,transparent 75%,var(--_1vrvste\) 75%)}`
     );
-    expect(actual).toInclude('style={{"--var-1vrvste":N30}}');
+    expect(actual).toInclude('style={{"--_1vrvste":N30}}');
   });
 
   it('should allow expressions stored in a variable as shorthand property values', () => {
@@ -288,8 +288,8 @@ describe('css prop behaviour', () => {
       <div css={{ color }}>hello world</div>
     `);
 
-    expect(actual).toInclude('{color:var(--var-1ylxx6h)}');
-    expect(actual).toInclude(`style={{\"--var-1ylxx6h\":color}}`);
+    expect(actual).toInclude('{color:var(--_1ylxx6h)}');
+    expect(actual).toInclude(`style={{\"--_1ylxx6h\":color}}`);
   });
 
   it('should allow expressions stored in a variable as property values', () => {
@@ -303,8 +303,8 @@ describe('css prop behaviour', () => {
       <div css={{ color: colorsz }}>hello world</div>
     `);
 
-    expect(actual).toInclude('{color:var(--var-19p4bcs)}');
-    expect(actual).toInclude(`style={{\"--var-19p4bcs\":colorsz}}`);
+    expect(actual).toInclude('{color:var(--_19p4bcs)}');
+    expect(actual).toInclude(`style={{\"--_19p4bcs\":colorsz}}`);
   });
 
   it('should remove css prop', () => {

--- a/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
@@ -23,9 +23,9 @@ describe('css prop object literal', () => {
       `);
 
     expect(actual).toInclude('{background-color:blue');
-    expect(actual).toInclude('{color:var(--var-bo0rwa)');
+    expect(actual).toInclude('{color:var(--_bo0rwa)');
     expect(actual).toInclude('text-decoration-line:none');
-    expect(actual).toInclude('style={{"--var-bo0rwa":cl}}');
+    expect(actual).toInclude('style={{"--_bo0rwa":cl}}');
   });
 
   it('should inline constant variable', () => {
@@ -86,9 +86,9 @@ describe('css prop object literal', () => {
         <div css={{ marginLeft: \`\${heading.depth}rem\`, color: 'red' }}>hello world</div>
       `);
 
-    expect(actual).toInclude('{margin-left:var(--var-5un9uz)}');
+    expect(actual).toInclude('{margin-left:var(--_5un9uz)}');
     expect(actual).toInclude('{color:red}');
-    expect(actual).toInclude('style={{"--var-5un9uz":(heading.depth||"")+"rem"}}');
+    expect(actual).toInclude('style={{"--_5un9uz":(heading.depth||"")+"rem"}}');
   });
 
   it('should persist prefix of dynamic property value into inline styles', () => {
@@ -102,9 +102,9 @@ describe('css prop object literal', () => {
         <div css={{ fontSize: \`calc(100% - \${fontSize}px)\`, color: 'red' }}>hello world</div>
       `);
 
-    expect(actual).toInclude('{font-size:calc(100% - var(--var-1j2e0s2))}');
+    expect(actual).toInclude('{font-size:calc(100% - var(--_1j2e0s2))}');
     expect(actual).toInclude('{color:red}');
-    expect(actual).toInclude('style={{"--var-1j2e0s2":(fontSize||"")+"px"}}');
+    expect(actual).toInclude('style={{"--_1j2e0s2":(fontSize||"")+"px"}}');
   });
 
   it('should move prefix of grouped interpolation into inline styles', () => {
@@ -119,8 +119,8 @@ describe('css prop object literal', () => {
         <div css={{ marginLeft: \`calc(100% - \${heading.depth}rem)\` }}>hello world</div>
       `);
 
-    expect(actual).toInclude('{margin-left:calc(100% - var(--var-5un9uz))}');
-    expect(actual).toInclude('style={{"--var-5un9uz":(heading.depth||"")+"rem"}}');
+    expect(actual).toInclude('{margin-left:calc(100% - var(--_5un9uz))}');
+    expect(actual).toInclude('style={{"--_5un9uz":(heading.depth||"")+"rem"}}');
   });
 
   it('should move multiple groups of interpolations into inline styles', () => {
@@ -160,9 +160,9 @@ describe('css prop object literal', () => {
         \`}>hello world</div>
       `);
 
-    expect(actual).toInclude('style={{"--var-1vrvste":N30}}');
+    expect(actual).toInclude('style={{"--_1vrvste":N30}}');
     expect(actual).toInclude(
-      'background-image:linear-gradient(45deg,var(--var-1vrvste) 25%,transparent 25%),linear-gradient(-45deg,var(--var-1vrvste) 25%,transparent 25%),linear-gradient(45deg,transparent 75%,var(--var-1vrvste) 75%),linear-gradient(-45deg,transparent 75%,var(--var-1vrvste) 75%)'
+      'background-image:linear-gradient(45deg,var(--_1vrvste) 25%,transparent 25%),linear-gradient(-45deg,var(--_1vrvste) 25%,transparent 25%),linear-gradient(45deg,transparent 75%,var(--_1vrvste) 75%),linear-gradient(-45deg,transparent 75%,var(--_1vrvste) 75%)'
     );
   });
 
@@ -213,8 +213,8 @@ describe('css prop object literal', () => {
         <div css={{ color: blue }}>hello world</div>
       `);
 
-    expect(actual).toInclude('{color:var(--var-13q2bts)}');
-    expect(actual).toInclude('style={{"--var-13q2bts":blue}}');
+    expect(actual).toInclude('{color:var(--_13q2bts)}');
+    expect(actual).toInclude('style={{"--_13q2bts":blue}}');
   });
 
   it('should transform object that has a destructured variable reference', () => {
@@ -227,8 +227,8 @@ describe('css prop object literal', () => {
         <div css={{ color }}>hello world</div>
       `);
 
-    expect(actual).toInclude('style={{"--var-1ylxx6h":color}}');
-    expect(actual).toInclude('{color:var(--var-1ylxx6h)}');
+    expect(actual).toInclude('style={{"--_1ylxx6h":color}}');
+    expect(actual).toInclude('{color:var(--_1ylxx6h)}');
   });
 
   it('should transform object spread from variable', () => {
@@ -521,11 +521,11 @@ describe('css prop object literal', () => {
          }}>hello world</div>
       `);
 
-    expect(actual).toInclude('style={{"--var-1xlms2h":HORIZONTAL_SPACING}}');
+    expect(actual).toInclude('style={{"--_1xlms2h":HORIZONTAL_SPACING}}');
     expect(actual).toInclude('{padding-top:0}');
-    expect(actual).toInclude('{padding-right:var(--var-1xlms2h)}');
+    expect(actual).toInclude('{padding-right:var(--_1xlms2h)}');
     expect(actual).toInclude('{padding-bottom:0}');
-    expect(actual).toInclude('{padding-left:var(--var-1xlms2h)}');
+    expect(actual).toInclude('{padding-left:var(--_1xlms2h)}');
   });
 
   it('should parse an inline string interpolation delimited by multiple spaces', () => {
@@ -543,10 +543,10 @@ describe('css prop object literal', () => {
       `);
 
     expect(actual).toInclude('{padding-top:0}');
-    expect(actual).toInclude('{padding-right:var(--var-1xlms2h)}');
+    expect(actual).toInclude('{padding-right:var(--_1xlms2h)}');
     expect(actual).toInclude('{padding-bottom:0}');
     expect(actual).toInclude('{padding-left:0}');
-    expect(actual).toInclude('style={{"--var-1xlms2h":HORIZONTAL_SPACING}}');
+    expect(actual).toInclude('style={{"--_1xlms2h":HORIZONTAL_SPACING}}');
   });
 
   it('should parse an inline string interpolation delimited by multiple spaces and suffix', () => {

--- a/packages/babel-plugin/src/css-prop/__tests__/string-literal.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/string-literal.test.tsx
@@ -22,8 +22,8 @@ describe('css prop string literal', () => {
         <div css={\`font-size: \${fontSize}px;color:red;\`}>hello world</div>
       `);
 
-    expect(actual).toInclude('{font-size:var(--var-1j2e0s2)}');
-    expect(actual).toInclude('style={{"--var-1j2e0s2":(fontSize||"")+"px"}}');
+    expect(actual).toInclude('{font-size:var(--_1j2e0s2)}');
+    expect(actual).toInclude('style={{"--_1j2e0s2":(fontSize||"")+"px"}}');
   });
 
   it('should persist suffix of constant value', () => {
@@ -138,10 +138,10 @@ describe('css prop string literal', () => {
         );
       `);
 
-    expect(actual).toInclude('{color:var(--var-kmurgp)');
+    expect(actual).toInclude('{color:var(--_kmurgp)');
     expect(actual).toInclude('{text-transform:uppercase}');
     expect(actual).toInclude('{font-weight:600}');
-    expect(actual).toInclude('style={{"--var-kmurgp":props.color}}');
+    expect(actual).toInclude('style={{"--_kmurgp":props.color}}');
   });
 
   it('should transform no template string literal', () => {
@@ -188,9 +188,9 @@ describe('css prop string literal', () => {
       `);
 
     expect(actual).toInclude('{display:grid}');
-    expect(actual).toInclude('{grid-template-areas:var(--var-1o3snts)}');
+    expect(actual).toInclude('{grid-template-areas:var(--_1o3snts)}');
     expect(actual).toInclude(
-      `style={{\"--var-1o3snts\":sidenav?\"'header header' 'sidebar content'\":\"'header header' 'content content'\"}}`
+      `style={{\"--_1o3snts\":sidenav?\"'header header' 'sidebar content'\":\"'header header' 'content content'\"}}`
     );
   });
 
@@ -352,8 +352,8 @@ describe('css prop string literal', () => {
       `);
 
     expect(actual).toIncludeMultiple([
-      'style={{"--var-65u76s":(x||"")+"px","--var-1ohot4b":y}}',
-      '{transform:translate3d(var(--var-65u76s),var(--var-1ohot4b),0)}',
+      'style={{"--_65u76s":(x||"")+"px","--_1ohot4b":y}}',
+      '{transform:translate3d(var(--_65u76s),var(--_1ohot4b),0)}',
     ]);
   });
 

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
@@ -72,7 +72,7 @@ describe('styled component behaviour', () => {
     `);
 
     expect(actual).toInclude('textSize,...props');
-    expect(actual).toInclude('"--var-fb92co":textSize');
+    expect(actual).toInclude('"--_fb92co":textSize');
   });
 
   it('should remove styled import', () => {
@@ -131,7 +131,7 @@ describe('styled component behaviour', () => {
       \`;
     `);
 
-    expect(actual).toInclude('"--var-1p69eoh":(props.color||"")+"px"');
+    expect(actual).toInclude('"--_1p69eoh":(props.color||"")+"px"');
   });
 
   it('should spread down props to element', () => {
@@ -210,8 +210,8 @@ describe('styled component behaviour', () => {
       });
     `);
 
-    expect(actual).toInclude('{color:var(--var-1poneq5)}');
-    expect(actual).toInclude('"--var-1poneq5":(()=>{return props.color;})()}}');
+    expect(actual).toInclude('{color:var(--_1poneq5)}');
+    expect(actual).toInclude('"--_1poneq5":(()=>{return props.color;})()}}');
   });
 
   it('should transform an arrow function with a body into an IIFE by preventing passing down invalid html attributes to the node', () => {
@@ -223,9 +223,9 @@ describe('styled component behaviour', () => {
       });
     `);
 
-    expect(actual).toInclude('{font-size:var(--var-1j0t240)}');
+    expect(actual).toInclude('{font-size:var(--_1j0t240)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--var-1j0t240":(()=>{return textSize;})()}}');
+    expect(actual).toInclude('"--_1j0t240":(()=>{return textSize;})()}}');
   });
 
   it('should move suffix and prefix of a dynamic arrow function with a body into an IIFE', () => {
@@ -237,8 +237,8 @@ describe('styled component behaviour', () => {
       });
     `);
 
-    expect(actual).toInclude('{color:var(--var-1poneq5)}');
-    expect(actual).toInclude('"--var-1poneq5":"very"+((()=>{return props.color;})()||"")+"dark"');
+    expect(actual).toInclude('{color:var(--_1poneq5)}');
+    expect(actual).toInclude('"--_1poneq5":"very"+((()=>{return props.color;})()||"")+"dark"');
   });
 
   it('should move suffix and prefix of a dynamic arrow function with a body into an IIFE by preventing passing down invalid html attributes to the node', () => {
@@ -250,8 +250,8 @@ describe('styled component behaviour', () => {
       });
     `);
 
-    expect(actual).toInclude('{font-size:var(--var-1j0t240)}');
+    expect(actual).toInclude('{font-size:var(--_1j0t240)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--var-1j0t240":"super"+((()=>{return textSize;})()||"")+"big"');
+    expect(actual).toInclude('"--_1j0t240":"super"+((()=>{return textSize;})()||"")+"big"');
   });
 });

--- a/packages/babel-plugin/src/styled/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/object-literal.test.tsx
@@ -85,8 +85,8 @@ describe('styled component object literal', () => {
         });
       `);
 
-    expect(actual).toInclude('{background:var(--var-1mkyvve)}');
-    expect(actual).toInclude('"--var-1mkyvve":color.blue');
+    expect(actual).toInclude('{background:var(--_1mkyvve)}');
+    expect(actual).toInclude('"--_1mkyvve":color.blue');
   });
 
   it('should not pass down invalid html attributes to the node when property has a suffix', () => {
@@ -97,9 +97,9 @@ describe('styled component object literal', () => {
         });
       `);
 
-    expect(actual).toInclude('{font-size:var(--var-7wpnv5)}');
+    expect(actual).toInclude('{font-size:var(--_7wpnv5)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--var-7wpnv5":`${textSize}px`');
+    expect(actual).toInclude('"--_7wpnv5":`${textSize}px`');
   });
 
   it('should not pass down invalid html attributes to the node when property has a suffix when func in template literal', () => {
@@ -110,9 +110,9 @@ describe('styled component object literal', () => {
         });
       `);
 
-    expect(actual).toInclude('{font-size:var(--var-fb92co)}');
+    expect(actual).toInclude('{font-size:var(--_fb92co)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--var-fb92co":(textSize||"")+"px"');
+    expect(actual).toInclude('"--_fb92co":(textSize||"")+"px"');
   });
 
   it('should transform object with simple values', () => {
@@ -157,8 +157,8 @@ describe('styled component object literal', () => {
         });
       `);
 
-    expect(actual).toInclude('{color:var(--var-1ylxx6h)}');
-    expect(actual).toInclude('"--var-1ylxx6h":color');
+    expect(actual).toInclude('{color:var(--_1ylxx6h)}');
+    expect(actual).toInclude('"--_1ylxx6h":color');
   });
 
   it('should inline call if it returns simple value', () => {
@@ -172,8 +172,8 @@ describe('styled component object literal', () => {
         });
       `);
 
-    expect(actual).toInclude('{color:var(--var-16ywsic)}');
-    expect(actual).toInclude('"--var-16ywsic":em(\'blue\')');
+    expect(actual).toInclude('{color:var(--_16ywsic)}');
+    expect(actual).toInclude('"--_16ywsic":em(\'blue\')');
   });
 
   it('should inline constant string literal', () => {
@@ -199,8 +199,8 @@ describe('styled component object literal', () => {
         });
       `);
 
-    expect(actual).toInclude('{color:var(--var-1p69eoh)}');
-    expect(actual).toInclude('"--var-1p69eoh":props.color');
+    expect(actual).toInclude('{color:var(--_1p69eoh)}');
+    expect(actual).toInclude('"--_1p69eoh":props.color');
   });
 
   it('should transform object spread from variable', () => {
@@ -231,8 +231,8 @@ describe('styled component object literal', () => {
         });
       `);
 
-    expect(actual).toInclude('{color:var(--var-1ylxx6h)}');
-    expect(actual).toInclude('"--var-1ylxx6h":color');
+    expect(actual).toInclude('{color:var(--_1ylxx6h)}');
+    expect(actual).toInclude('"--_1ylxx6h":color');
   });
 
   it('should transform object with obj variable', () => {

--- a/packages/babel-plugin/src/styled/__tests__/string-literal.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/string-literal.test.tsx
@@ -30,9 +30,9 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('{font-size:var(--var-fb92co)}');
+    expect(actual).toInclude('{font-size:var(--_fb92co)}');
     expect(actual).toInclude('textSize,...props}');
-    expect(actual).toInclude('"--var-fb92co":(textSize||"")+"px"');
+    expect(actual).toInclude('"--_fb92co":(textSize||"")+"px"');
   });
 
   it('should inline constant numeric literal', () => {
@@ -61,8 +61,8 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('"--var-1j2e0s2":(fontSize||"")+"px"');
-    expect(actual).toInclude('{font-size:var(--var-1j2e0s2)}');
+    expect(actual).toInclude('"--_1j2e0s2":(fontSize||"")+"px"');
+    expect(actual).toInclude('{font-size:var(--_1j2e0s2)}');
   });
 
   it('should move suffix to inline styles when referencing a mutable numeric literal when missing a semi colon', () => {
@@ -77,8 +77,8 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('"--var-1j2e0s2":(fontSize||"")+"px"');
-    expect(actual).toInclude('{font-size:var(--var-1j2e0s2)}');
+    expect(actual).toInclude('"--_1j2e0s2":(fontSize||"")+"px"');
+    expect(actual).toInclude('{font-size:var(--_1j2e0s2)}');
   });
 
   it('should transform a static template literal', () => {
@@ -116,8 +116,8 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('{color:var(--var-1p69eoh)');
-    expect(actual).toInclude('"--var-1p69eoh":props.color');
+    expect(actual).toInclude('{color:var(--_1p69eoh)');
+    expect(actual).toInclude('"--_1p69eoh":props.color');
   });
 
   it('should transform an arrow function with a body into an IIFE', () => {
@@ -129,8 +129,8 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('{color:var(--var-1poneq5)}');
-    expect(actual).toInclude('"--var-1poneq5":(()=>{return props.color;})()}}');
+    expect(actual).toInclude('{color:var(--_1poneq5)}');
+    expect(actual).toInclude('"--_1poneq5":(()=>{return props.color;})()}}');
   });
 
   it('should transform an arrow function with a body into an IIFE by preventing passing down invalid html attributes to the node', () => {
@@ -142,9 +142,9 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('{font-size:var(--var-1j0t240)}');
+    expect(actual).toInclude('{font-size:var(--_1j0t240)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--var-1j0t240":(()=>{return textSize;})()}}');
+    expect(actual).toInclude('"--_1j0t240":(()=>{return textSize;})()}}');
   });
 
   it('should move suffix and prefix of a dynamic arrow function with a body into an IIFE', () => {
@@ -156,8 +156,8 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('{color:var(--var-1poneq5)}');
-    expect(actual).toInclude('"--var-1poneq5":"very"+((()=>{return props.color;})()||"")+"dark"');
+    expect(actual).toInclude('{color:var(--_1poneq5)}');
+    expect(actual).toInclude('"--_1poneq5":"very"+((()=>{return props.color;})()||"")+"dark"');
   });
 
   it('should move suffix and prefix of a dynamic arrow function with a body into an IIFE by preventing passing down invalid html attributes to the node', () => {
@@ -169,9 +169,9 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('{font-size:var(--var-1j0t240)}');
+    expect(actual).toInclude('{font-size:var(--_1j0t240)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--var-1j0t240":"super"+((()=>{return textSize;})()||"")+"big"');
+    expect(actual).toInclude('"--_1j0t240":"super"+((()=>{return textSize;})()||"")+"big"');
   });
 
   it('should transform template string literal with obj variable', () => {
@@ -202,8 +202,8 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('{color:var(--var-1ylxx6h)');
-    expect(actual).toInclude('"--var-1ylxx6h":color');
+    expect(actual).toInclude('{color:var(--_1ylxx6h)');
+    expect(actual).toInclude('"--_1ylxx6h":color');
   });
 
   it('should inline call if it returns simple value', () => {
@@ -217,8 +217,8 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('{color:var(--var-16ywsic)}');
-    expect(actual).toInclude(`"--var-16ywsic":em('blue')`);
+    expect(actual).toInclude('{color:var(--_16ywsic)}');
+    expect(actual).toInclude(`"--_16ywsic":em('blue')`);
   });
 
   it('should transform template string with no argument arrow function variable', () => {
@@ -317,7 +317,7 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('"--var-1p69eoh":"super"+(props.color||"")+"big"');
+    expect(actual).toInclude('"--_1p69eoh":"super"+(props.color||"")+"big"');
   });
 
   it('should move any prefix of a dynamic arrow func property into the style property', () => {
@@ -329,7 +329,7 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('"--var-1p69eoh":"super"+(props.color||"")');
+    expect(actual).toInclude('"--_1p69eoh":"super"+(props.color||"")');
   });
 
   it('should move any suffix of a dynamic arrow func property into the style property', () => {
@@ -341,7 +341,7 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('"--var-1p69eoh":(props.color||"")+"big"');
+    expect(actual).toInclude('"--_1p69eoh":(props.color||"")+"big"');
   });
 
   it('should move suffix and prefix of a dynamic property into the style property', () => {
@@ -357,8 +357,8 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('{font-size:var(--var-1ylxx6h)}');
-    expect(actual).toInclude('"--var-1ylxx6h":"super"+(color||"")+"big"');
+    expect(actual).toInclude('{font-size:var(--_1ylxx6h)}');
+    expect(actual).toInclude('"--_1ylxx6h":"super"+(color||"")+"big"');
   });
 
   it('should do nothing with suffix/prefix when referencing constant literal', () => {
@@ -423,8 +423,8 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('{border-radius:var(--var-1hwymmh)}');
-    expect(actual).toInclude('"--var-1hwymmh":(br||"")+"px"');
+    expect(actual).toInclude('{border-radius:var(--_1hwymmh)}');
+    expect(actual).toInclude('"--_1hwymmh":(br||"")+"px"');
   });
 
   it('should transform inline arrow function with suffix', () => {

--- a/packages/babel-plugin/src/utils/css-builders.tsx
+++ b/packages/babel-plugin/src/utils/css-builders.tsx
@@ -73,7 +73,7 @@ const extractObjectExpression = (node: t.ObjectExpression, meta: Metadata): CSSO
       } else {
         // This is the catch all for any kind of expression.
         // We don't want to explicitly handle each expression node differently if we can avoid it!
-        const variableName = `--var-${hash(generate(propValue).code)}`;
+        const variableName = `--_${hash(generate(propValue).code)}`;
         variables.push({ name: variableName, expression: propValue });
         value = `var(${variableName})`;
       }
@@ -148,9 +148,9 @@ const extractTemplateLiteral = (node: t.TemplateLiteral, meta: Metadata): CSSOut
       // The only difficulty here is what we do around prefixes and suffixes.
       // CSS variables can't have them! So we need to move them to the inline style.
       // E.g. `font-size: ${fontSize}px` will end up needing to look like:
-      // `font-size: var(--var-font-size)`, with the suffix moved to inline styles
-      // style={{ '--var-font-size': fontSize + 'px' }}
-      const variableName = `--var-${hash(generate(interpolation).code)}`;
+      // `font-size: var(--_font-size)`, with the suffix moved to inline styles
+      // style={{ '--_font-size': fontSize + 'px' }}
+      const variableName = `--_${hash(generate(interpolation).code)}`;
       const nextQuasis = node.quasis[index + 1];
       const before = cssBeforeInterpolation(css + q.value.raw);
       const after = cssAfterInterpolation(nextQuasis.value.raw);

--- a/packages/css/src/utils/__tests__/string-iterpolations.test.tsx
+++ b/packages/css/src/utils/__tests__/string-iterpolations.test.tsx
@@ -114,13 +114,13 @@ describe('template literal to css', () => {
     });
 
     it('should get the before and after for the second part of a transform interpolation', () => {
-      const css = [`\n            transform: translate3d(var(--var-test), `, `, 0);`];
+      const css = [`\n            transform: translate3d(var(--_test), `, `, 0);`];
 
       const before = cssBeforeInterpolation(css[0]);
       const after = cssAfterInterpolation(css[1]);
 
       expect(before.variablePrefix).toEqual('');
-      expect(before.css).toEqual('\n            transform: translate3d(var(--var-test), ');
+      expect(before.css).toEqual('\n            transform: translate3d(var(--_test), ');
       expect(after.variableSuffix).toEqual('');
       expect(after.css).toEqual(', 0);');
     });
@@ -150,7 +150,7 @@ describe('template literal to css', () => {
 
     it('should extract the first part of the second group', () => {
       const parts = [
-        'background-image: linear-gradient(45deg, var(--var-test) 25%, transparent 25%),',
+        'background-image: linear-gradient(45deg, var(--_test) 25%, transparent 25%),',
         'linear-gradient(-45deg, ',
         ' 25%, transparent 25%),',
         'linear-gradient(45deg, transparent 75%, ',
@@ -170,7 +170,7 @@ describe('template literal to css', () => {
 
     it('should extract the first part of the third group', () => {
       const parts = [
-        'background-image: linear-gradient(45deg, var(--var-test) 25%, transparent 25%), linear-gradient(-45deg, var(--var-test) 25%, transparent 25%),',
+        'background-image: linear-gradient(45deg, var(--_test) 25%, transparent 25%), linear-gradient(-45deg, var(--_test) 25%, transparent 25%),',
         'linear-gradient(45deg, transparent 75%, ',
         ' 75%),',
         'linear-gradient(-45deg, transparent 75%, ',
@@ -188,7 +188,7 @@ describe('template literal to css', () => {
 
     it('should extract the first part of the fourth group', () => {
       const parts = [
-        'background-image: linear-gradient(45deg, var(--var-test) 25%, transparent 25%), linear-gradient(-45deg, var(--var-test) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, var(--var-test) 75%),',
+        'background-image: linear-gradient(45deg, var(--_test) 25%, transparent 25%), linear-gradient(-45deg, var(--_test) 25%, transparent 25%), linear-gradient(45deg, transparent 75%, var(--_test) 75%),',
         'linear-gradient(-45deg, transparent 75%, ',
         ' 75%);',
       ];


### PR DESCRIPTION
This ends up producing smaller bundlers because `var` isn't needed anymore.

**Before**

```css
--var-1As3op: blue;
```

**After**

Prefixed with an underscore because `--1` isn't a valid CSS variable name.

```css
--_1As3op: blue;
```