### PR TITLE
feat: expose babel plugin through core to simplify consumption experience

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: [['@compiled/babel-plugin', { nonce: '"k0Mp1lEd"' }]],
+  plugins: [['@compiled/core/babel-plugin', { nonce: '"k0Mp1lEd"' }]],
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }],
     '@babel/preset-typescript',

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -16,7 +16,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "src"
+    "src",
+    "README.md"
   ],
   "scripts": {
     "perf": "ts-node --files ./src/__perf__/module-traversal-caching"

--- a/packages/core/babel-plugin/README.md
+++ b/packages/core/babel-plugin/README.md
@@ -1,0 +1,5 @@
+# @compiled/core/babel-plugin
+
+This folder and `package.json` exists to add another entry point to `@compiled/core`.
+When the `exports` property is more widely used we can remove this (we've currently defined it in `package.json`,
+but it won't do much on node versions that don't support it).

--- a/packages/core/babel-plugin/package.json
+++ b/packages/core/babel-plugin/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../dist/babel-plugin.js",
+  "module": "../dist/babel-plugin.js",
+  "types": "../dist/babel-plugin.d.ts"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,9 +24,11 @@
   ],
   "files": [
     "dist",
-    "src"
+    "src",
+    "README.md"
   ],
   "dependencies": {
+    "@compiled/babel-plugin": "0.4.7",
     "@compiled/runtime": "0.4.7",
     "csstype": "^2.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,9 +22,14 @@
     "emotion-js",
     "typescript"
   ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./babel-plugin": "./dist/babel-plugin.js"
+  },
   "files": [
     "dist",
     "src",
+    "babel-plugin",
     "README.md"
   ],
   "dependencies": {

--- a/packages/core/src/babel-plugin.tsx
+++ b/packages/core/src/babel-plugin.tsx
@@ -1,0 +1,1 @@
+module.exports = require('@compiled/babel-plugin');

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,9 +5,8 @@
     "outDir": "dist",
     "baseUrl": "src",
     "paths": {
-      "@compiled/core": ["index.tsx"],
-      "@compiled/core/jsx": ["jsx.tsx"]
+      "@compiled/core": ["index.tsx"]
     }
   },
-  "references": [{ "path": "../runtime" }]
+  "references": [{ "path": "../babel-plugin" }, { "path": "../runtime" }]
 }

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -16,7 +16,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "src"
+    "src",
+    "README.md"
   ],
   "dependencies": {
     "@compiled/utils": "0.4.7",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -17,7 +17,8 @@
   "sideEffects": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "README.md"
   ],
   "dependencies": {
     "css": "^2.2.4"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -18,7 +18,8 @@
   "sideEffects": false,
   "files": [
     "dist",
-    "src"
+    "src",
+    "README.md"
   ],
   "peerDependencies": {
     "react": "^16.12.0"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,7 +16,8 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "src"
+    "src",
+    "README.md"
   ],
   "dependencies": {
     "convert-source-map": "^1.7.0",


### PR DESCRIPTION
I wanted to do this via the `exports` field in package.json but it wouldn't work for me, so I did it the old school way. This also adds back `README.md` to packages in npm.

**Before**

```
npm i @compiled/core @compiled/babel-plugin
```

```js
module.exports = {
  plugins: [['@compiled/babel-plugin'],
};
```

**After**

```
npm i @compiled/core
```

```js
module.exports = {
  plugins: [['@compiled/core/babel-plugin']],
};
```

The CLA bot seems to be having problems..