### PR TITLE
browser/server providers now use isNodeEnvironment

### DIFF
--- a/packages/runtime/src/__tests__/__snapshots__/provider.test.tsx.snap
+++ b/packages/runtime/src/__tests__/__snapshots__/provider.test.tsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Browser Provider should throw when "isNodeEnvironment" returns true 1`] = `
+"
+ ██████╗ ██████╗ ███╗   ███╗██████╗ ██╗██╗     ███████╗██████╗
+██╔════╝██╔═══██╗████╗ ████║██╔══██╗██║██║     ██╔════╝██╔══██╗
+██║     ██║   ██║██╔████╔██║██████╔╝██║██║     █████╗  ██║  ██║
+██║     ██║   ██║██║╚██╔╝██║██╔═══╝ ██║██║     ██╔══╝  ██║  ██║
+╚██████╗╚██████╔╝██║ ╚═╝ ██║██║     ██║███████╗███████╗██████╔╝
+ ╚═════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝╚═════╝
+
+  @compiled/runtime - ERROR
+
+  This code should only run on the client. You might need to configure your bundler to respect the \\"browser\\" field in package json.
+"
+`;
+
+exports[`Server Provider should throw when "isNodeEnvironment" returns false 1`] = `
+"
+ ██████╗ ██████╗ ███╗   ███╗██████╗ ██╗██╗     ███████╗██████╗
+██╔════╝██╔═══██╗████╗ ████║██╔══██╗██║██║     ██╔════╝██╔══██╗
+██║     ██║   ██║██╔████╔██║██████╔╝██║██║     █████╗  ██║  ██║
+██║     ██║   ██║██║╚██╔╝██║██╔═══╝ ██║██║     ██╔══╝  ██║  ██║
+╚██████╗╚██████╔╝██║ ╚═╝ ██║██║     ██║███████╗███████╗██████╔╝
+ ╚═════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝     ╚═╝╚══════╝╚══════╝╚═════╝
+
+  @compiled/runtime - ERROR
+
+  This code should only run on the server. You might need to configure your bundler to respect the \\"browser\\" field in package json.
+"
+`;

--- a/packages/runtime/src/__tests__/provider.test.tsx
+++ b/packages/runtime/src/__tests__/provider.test.tsx
@@ -1,7 +1,7 @@
-const mockFunction = jest.fn();
+const mockNodeEnvFunction = jest.fn();
 
 jest.mock('../is-node', () => ({
-  isNodeEnvironment: mockFunction,
+  isNodeEnvironment: mockNodeEnvFunction,
 }));
 
 const OLD_ENV = process.env;
@@ -12,33 +12,26 @@ describe('Provider index.tsx', () => {
     process.env = { ...OLD_ENV }; // make a copy
     process.env.NODE_ENV = 'development';
   });
+
   afterAll(() => {
     process.env = OLD_ENV; // restore old env
   });
+
   it('returns the browser provider when isNodeEnvironment returns false', () => {
-    mockFunction.mockImplementation(() => false);
-    const loadComp = (path, name = 'default') => {
-      let comp = undefined;
-      try {
-        comp = require(path)[name];
-      } catch (_) {}
-      return comp;
-    };
-    const BrowserProvider = loadComp('../provider/provider-browser');
-    const Provider = loadComp('../provider');
+    mockNodeEnvFunction.mockImplementation(() => false);
+
+    const BrowserProvider = require('../provider/provider-browser').default;
+    const Provider = require('../provider').default;
+
     expect(Provider).toEqual(BrowserProvider);
   });
+
   it('returns the server provider when isNodeEnvironment returns true', () => {
-    mockFunction.mockImplementation(() => true);
-    const loadComp = (path, name = 'default') => {
-      let comp = undefined;
-      try {
-        comp = require(path)[name];
-      } catch (_) {}
-      return comp;
-    };
-    const ServerProvider = loadComp('../provider/provider-server');
-    const Provider = loadComp('../provider');
+    mockNodeEnvFunction.mockImplementation(() => true);
+
+    const ServerProvider = require('../provider/provider-server').default;
+    const Provider = require('../provider').default;
+
     expect(Provider).toEqual(ServerProvider);
   });
 });
@@ -49,38 +42,21 @@ describe('Server Provider', () => {
     process.env = { ...OLD_ENV }; // make a copy
     process.env.NODE_ENV = 'development';
   });
+
   afterAll(() => {
     process.env = OLD_ENV; // restore old env
   });
+
   it('should throw when "isNodeEnvironment" returns false', () => {
-    mockFunction.mockImplementation(() => false);
+    mockNodeEnvFunction.mockImplementation(() => false);
 
-    const loadComp = (path, name = 'default') => {
-      let comp = undefined;
-      try {
-        comp = require(path)[name];
-      } catch (error) {
-        expect(error).toBeDefined();
-      }
-      return comp;
-    };
-
-    loadComp('../provider/provider-server');
+    expect(() => require('../provider/provider-server')).toThrowErrorMatchingSnapshot();
   });
+
   it('should not throw when "isNodeEnvironment" returns true', () => {
-    mockFunction.mockImplementation(() => true);
+    mockNodeEnvFunction.mockImplementation(() => true);
 
-    const loadComp = (path, name = 'default') => {
-      let comp = undefined;
-      try {
-        comp = require(path)[name];
-      } catch (error) {
-        expect(error).toBeFalsy();
-      }
-      return comp;
-    };
-
-    loadComp('../provider/provider-server');
+    expect(() => require('../provider/provider-server')).not.toThrowError();
   });
 });
 
@@ -90,37 +66,20 @@ describe('Browser Provider', () => {
     process.env = { ...OLD_ENV }; // make a copy
     process.env.NODE_ENV = 'development';
   });
+
   afterAll(() => {
     process.env = OLD_ENV; // restore old env
   });
+
   it('should throw when "isNodeEnvironment" returns true', () => {
-    mockFunction.mockImplementation(() => true);
+    mockNodeEnvFunction.mockImplementation(() => true);
 
-    const loadComp = (path, name = 'default') => {
-      let comp = undefined;
-      try {
-        comp = require(path)[name];
-      } catch (error) {
-        expect(error).toBeDefined();
-      }
-      return comp;
-    };
-
-    loadComp('../provider/provider-browser');
+    expect(() => require('../provider/provider-browser')).toThrowErrorMatchingSnapshot();
   });
+
   it('should not throw when "isNodeEnvironment" returns false', () => {
-    mockFunction.mockImplementation(() => false);
+    mockNodeEnvFunction.mockImplementation(() => false);
 
-    const loadComp = (path, name = 'default') => {
-      let comp = undefined;
-      try {
-        comp = require(path)[name];
-      } catch (error) {
-        expect(error).toBeFalsy();
-      }
-      return comp;
-    };
-
-    loadComp('../provider/provider-browser');
+    expect(() => require('../provider/provider-browser')).not.toThrowError();
   });
 });

--- a/packages/runtime/src/__tests__/provider.test.tsx
+++ b/packages/runtime/src/__tests__/provider.test.tsx
@@ -1,0 +1,126 @@
+const mockFunction = jest.fn();
+
+jest.mock('../is-node', () => ({
+  isNodeEnvironment: mockFunction,
+}));
+
+const OLD_ENV = process.env;
+
+describe('Provider index.tsx', () => {
+  beforeEach(() => {
+    jest.resetModules(); // most important - it clears the cache
+    process.env = { ...OLD_ENV }; // make a copy
+    process.env.NODE_ENV = 'development';
+  });
+  afterAll(() => {
+    process.env = OLD_ENV; // restore old env
+  });
+  it('returns the browser provider when isNodeEnvironment returns false', () => {
+    mockFunction.mockImplementation(() => false);
+    const loadComp = (path, name = 'default') => {
+      let comp = undefined;
+      try {
+        comp = require(path)[name];
+      } catch (_) {}
+      return comp;
+    };
+    const BrowserProvider = loadComp('../provider/provider-browser');
+    const Provider = loadComp('../provider');
+    expect(Provider).toEqual(BrowserProvider);
+  });
+  it('returns the server provider when isNodeEnvironment returns true', () => {
+    mockFunction.mockImplementation(() => true);
+    const loadComp = (path, name = 'default') => {
+      let comp = undefined;
+      try {
+        comp = require(path)[name];
+      } catch (_) {}
+      return comp;
+    };
+    const ServerProvider = loadComp('../provider/provider-server');
+    const Provider = loadComp('../provider');
+    expect(Provider).toEqual(ServerProvider);
+  });
+});
+
+describe('Server Provider', () => {
+  beforeEach(() => {
+    jest.resetModules(); // most important - it clears the cache
+    process.env = { ...OLD_ENV }; // make a copy
+    process.env.NODE_ENV = 'development';
+  });
+  afterAll(() => {
+    process.env = OLD_ENV; // restore old env
+  });
+  it('should throw when "isNodeEnvironment" returns false', () => {
+    mockFunction.mockImplementation(() => false);
+
+    const loadComp = (path, name = 'default') => {
+      let comp = undefined;
+      try {
+        comp = require(path)[name];
+      } catch (error) {
+        expect(error).toBeDefined();
+      }
+      return comp;
+    };
+
+    loadComp('../provider/provider-server');
+  });
+  it('should not throw when "isNodeEnvironment" returns true', () => {
+    mockFunction.mockImplementation(() => true);
+
+    const loadComp = (path, name = 'default') => {
+      let comp = undefined;
+      try {
+        comp = require(path)[name];
+      } catch (error) {
+        expect(error).toBeFalsy();
+      }
+      return comp;
+    };
+
+    loadComp('../provider/provider-server');
+  });
+});
+
+describe('Browser Provider', () => {
+  beforeEach(() => {
+    jest.resetModules(); // most important - it clears the cache
+    process.env = { ...OLD_ENV }; // make a copy
+    process.env.NODE_ENV = 'development';
+  });
+  afterAll(() => {
+    process.env = OLD_ENV; // restore old env
+  });
+  it('should throw when "isNodeEnvironment" returns true', () => {
+    mockFunction.mockImplementation(() => true);
+
+    const loadComp = (path, name = 'default') => {
+      let comp = undefined;
+      try {
+        comp = require(path)[name];
+      } catch (error) {
+        expect(error).toBeDefined();
+      }
+      return comp;
+    };
+
+    loadComp('../provider/provider-browser');
+  });
+  it('should not throw when "isNodeEnvironment" returns false', () => {
+    mockFunction.mockImplementation(() => false);
+
+    const loadComp = (path, name = 'default') => {
+      let comp = undefined;
+      try {
+        comp = require(path)[name];
+      } catch (error) {
+        expect(error).toBeFalsy();
+      }
+      return comp;
+    };
+
+    loadComp('../provider/provider-browser');
+  });
+});

--- a/packages/runtime/src/provider/provider-browser.tsx
+++ b/packages/runtime/src/provider/provider-browser.tsx
@@ -2,7 +2,7 @@ import { isNodeEnvironment } from '../is-node';
 
 import { ProviderComponent, UseCacheHook } from './types';
 
-if (process.env.NODE_ENV === 'development' && !isNodeEnvironment()) {
+if (process.env.NODE_ENV === 'development' && isNodeEnvironment()) {
   throw new Error(
     `
  ██████╗ ██████╗ ███╗   ███╗██████╗ ██╗██╗     ███████╗██████╗

--- a/packages/runtime/src/provider/provider-browser.tsx
+++ b/packages/runtime/src/provider/provider-browser.tsx
@@ -1,6 +1,8 @@
+import { isNodeEnvironment } from '../is-node';
+
 import { ProviderComponent, UseCacheHook } from './types';
 
-if (process.env.NODE_ENV === 'development' && typeof window === 'undefined') {
+if (process.env.NODE_ENV === 'development' && !isNodeEnvironment()) {
   throw new Error(
     `
  ██████╗ ██████╗ ███╗   ███╗██████╗ ██╗██╗     ███████╗██████╗
@@ -12,7 +14,7 @@ if (process.env.NODE_ENV === 'development' && typeof window === 'undefined') {
 
   @compiled/runtime - ERROR
 
-  This code should only run on the client. You might need to configure your bunder to respect the "browser" field in package json.
+  This code should only run on the client. You might need to configure your bundler to respect the "browser" field in package json.
 `
   );
 }

--- a/packages/runtime/src/provider/provider-server.tsx
+++ b/packages/runtime/src/provider/provider-server.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useContext, createContext } from 'react';
 import { isNodeEnvironment } from '../is-node';
 import { ProviderComponent, UseCacheHook } from './types';
 
-if (process.env.NODE_ENV === 'development' && isNodeEnvironment()) {
+if (process.env.NODE_ENV === 'development' && !isNodeEnvironment()) {
   throw new Error(
     `
  ██████╗ ██████╗ ███╗   ███╗██████╗ ██╗██╗     ███████╗██████╗

--- a/packages/runtime/src/provider/provider-server.tsx
+++ b/packages/runtime/src/provider/provider-server.tsx
@@ -1,7 +1,8 @@
 import React, { useRef, useContext, createContext } from 'react';
+import { isNodeEnvironment } from '../is-node';
 import { ProviderComponent, UseCacheHook } from './types';
 
-if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
+if (process.env.NODE_ENV === 'development' && isNodeEnvironment()) {
   throw new Error(
     `
  ██████╗ ██████╗ ███╗   ███╗██████╗ ██╗██╗     ███████╗██████╗
@@ -13,7 +14,7 @@ if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
 
   @compiled/runtime - ERROR
 
-  This code should only run on the server. You might need to configure your bunder to respect the "browser" field in package json.
+  This code should only run on the server. You might need to configure your bundler to respect the "browser" field in package json.
 `
   );
 }


### PR DESCRIPTION
Updated the `provider-browser` and `provider-server` files to use the `isNodeEnvironment` check as per the discussion here - https://github.com/atlassian-labs/compiled/issues/353

Closes #353 