### PR TITLE
fix: add null check when unhandled

### DIFF
--- a/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
+++ b/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
@@ -276,4 +276,19 @@ describe('import specifiers', () => {
       '{background-color:blue}',
     ]);
   });
+
+  it('should not blow up when member expression object is other than "Identifier" or "Call Expression"', () => {
+    expect(() => {
+      transform(`
+      import '@compiled/core';
+      import React from 'react';
+
+      function Component() {
+        return (
+          <span css={{ width: [{ bar: 10 }][0].bar }} />
+        );
+      };
+    `);
+    }).not.toThrow();
+  });
 });

--- a/packages/babel-plugin/src/utils/ast.tsx
+++ b/packages/babel-plugin/src/utils/ast.tsx
@@ -61,7 +61,13 @@ export const buildCodeFrameError = (error: string, node: t.Node, parentPath: Nod
  *
  * @param expression - Member expression node.
  */
-export const getMemberExpressionMeta = (expression: t.MemberExpression) => {
+export const getMemberExpressionMeta = (
+  expression: t.MemberExpression
+): {
+  accessPath: t.Identifier[];
+  bindingIdentifier: t.Identifier | null;
+  originalBindingType: t.Expression['type'];
+} => {
   const accessPath: t.Identifier[] = [];
   let bindingIdentifier: t.Identifier | null = null;
   let originalBindingType: t.Expression['type'] = 'Identifier';
@@ -91,7 +97,7 @@ export const getMemberExpressionMeta = (expression: t.MemberExpression) => {
 
   return {
     accessPath: accessPath.reverse(),
-    bindingIdentifier: bindingIdentifier!,
+    bindingIdentifier,
     originalBindingType,
   };
 };

--- a/packages/babel-plugin/src/utils/evaluate-expression.tsx
+++ b/packages/babel-plugin/src/utils/evaluate-expression.tsx
@@ -150,21 +150,24 @@ const traverseMemberExpression = (expression: t.MemberExpression, meta: Metadata
   const { accessPath, bindingIdentifier, originalBindingType } = getMemberExpressionMeta(
     expression
   );
-  const resolvedBinding = resolveBindingNode(bindingIdentifier.name, updatedMeta);
 
-  if (resolvedBinding && resolvedBinding.constant && t.isExpression(resolvedBinding.node)) {
-    if (originalBindingType === 'Identifier') {
-      ({ value, meta: updatedMeta } = evaluateIdentifierBindingMemberExpression(
-        resolvedBinding.node,
-        accessPath,
-        resolvedBinding.meta
-      ));
-    } else if (originalBindingType === 'CallExpression') {
-      ({ value, meta: updatedMeta } = evaluateCallExpressionBindingMemberExpression(
-        resolvedBinding.node,
-        accessPath,
-        resolvedBinding.meta
-      ));
+  if (bindingIdentifier) {
+    const resolvedBinding = resolveBindingNode(bindingIdentifier.name, updatedMeta);
+
+    if (resolvedBinding && resolvedBinding.constant && t.isExpression(resolvedBinding.node)) {
+      if (originalBindingType === 'Identifier') {
+        ({ value, meta: updatedMeta } = evaluateIdentifierBindingMemberExpression(
+          resolvedBinding.node,
+          accessPath,
+          resolvedBinding.meta
+        ));
+      } else if (originalBindingType === 'CallExpression') {
+        ({ value, meta: updatedMeta } = evaluateCallExpressionBindingMemberExpression(
+          resolvedBinding.node,
+          accessPath,
+          resolvedBinding.meta
+        ));
+      }
     }
   }
 


### PR DESCRIPTION
We are not supporting complex `MemberExpression` object as of now. Only `Identifier` and `CallExpression` are supported as explained below:

 1. Member expression `foo.bar.baz` will return the `foo` identifier along with `originalBindingType` as `Identifier`.
 2. Member expression with function call `foo().bar.baz` will return the `foo` identifier along with `originalBindingType` as `CallExpression`.