### PR TITLE
Runtime optimizations

### DIFF
--- a/examples/compiled.tsx
+++ b/examples/compiled.tsx
@@ -1,41 +1,46 @@
 import * as React from 'react';
 import '@compiled/react';
+import { InteractionTaskArgs, PublicInteractionTask } from 'storybook-addon-performance';
+import { fireEvent, findAllByText } from '@testing-library/dom';
 
 export default {
   title: 'benchmarks | compiled',
 };
 
-export const Static = () => (
-  <span
-    css={{
-      backgroundColor: 'rgb(66, 82, 110)',
-      borderRadius: 3,
-      boxSizing: 'border-box',
-      color: 'rgb(255, 255, 255)',
-      display: 'inline-block',
-      fontSize: '11px',
-      fontWeight: 700,
-      lineHeight: 1,
-      maxWidth: '100%',
-      padding: '2px 0 3px 0',
-      textTransform: 'uppercase',
-      verticalAlign: 'baseline',
-    }}>
-    <span
-      css={{
-        display: 'inline-block',
-        verticalAlign: 'top',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-        boxSizing: 'border-box',
-        padding: `0 4px`,
-        maxWidth: 100,
-        width: '100%',
-      }}>
-      Lozenge
-    </span>
-  </span>
+const APPEARANCES = [
+  { bg: 'red', color: 'white' },
+  { bg: 'blue', color: 'white' },
+  { bg: 'green', color: 'black' },
+  { bg: 'grey', color: 'white' },
+  { bg: 'yellow', color: 'black' },
+  { bg: 'orange', color: 'white' },
+];
+
+const interactionTasks: PublicInteractionTask[] = [
+  {
+    name: 'Display lozenge',
+    run: async ({ container }: InteractionTaskArgs): Promise<void> => {
+      window.location.reload();
+
+      const buttonAll = container.querySelectorAll('button')!;
+
+      buttonAll.forEach((button) => {
+        fireEvent.click(button);
+      });
+
+      await findAllByText(container, 'Lozenge', undefined, {
+        timeout: 2000,
+      });
+    },
+  },
+];
+
+const Row: React.FunctionComponent<React.ReactNode> = ({ children }) => (
+  <div style={{ display: 'flex' }}>{children}</div>
+);
+
+const Col: React.FunctionComponent<React.ReactNode> = ({ children }) => (
+  <div style={{ flex: '1 1 auto' }}>{children}</div>
 );
 
 const Lozenge = (props: { bg: string; color: string }) => (
@@ -71,4 +76,35 @@ const Lozenge = (props: { bg: string; color: string }) => (
   </span>
 );
 
-export const Dynamic = () => <Lozenge bg="rgb(227, 252, 239)" color="rgb(0, 102, 68)" />;
+export const Dynamic = () => {
+  const [toggle, setToggle] = React.useState(false);
+
+  return (
+    <React.Fragment>
+      <button onClick={() => setToggle(!toggle)}>Toggle</button>
+      {toggle && (
+        <div>
+          <Row>
+            <Col>
+              <p>Colors</p>
+              {APPEARANCES.map((a) => (
+                <p key={a.bg as string}>
+                  <Lozenge bg={a.bg} color={a.color} />
+                </p>
+              ))}
+            </Col>
+          </Row>
+        </div>
+      )}
+    </React.Fragment>
+  );
+};
+
+Dynamic.story = {
+  name: 'Compiled Dynamic',
+  parameters: {
+    performance: {
+      interactions: interactionTasks,
+    },
+  },
+};

--- a/examples/compiled.tsx
+++ b/examples/compiled.tsx
@@ -77,12 +77,12 @@ const Lozenge = (props: { bg: string; color: string }) => (
 );
 
 export const Dynamic = () => {
-  const [toggle, setToggle] = React.useState(false);
+  const [toggle, setToggle] = React.useState<boolean[]>([]);
 
-  return (
-    <React.Fragment>
-      <button onClick={() => setToggle(!toggle)}>Toggle</button>
-      {toggle && (
+  return Array.from(new Array(100)).map((_, index) => (
+    <React.Fragment key={index}>
+      <button onClick={() => setToggle([...toggle, !toggle[index]])}>Toggle</button>
+      {toggle[index] && (
         <div>
           <Row>
             <Col>
@@ -97,7 +97,7 @@ export const Dynamic = () => {
         </div>
       )}
     </React.Fragment>
-  );
+  ));
 };
 
 Dynamic.story = {

--- a/examples/emotion.tsx
+++ b/examples/emotion.tsx
@@ -78,12 +78,12 @@ const Lozenge = (props: { bg: string; color: string }) => (
 );
 
 export const Dynamic = () => {
-  const [toggle, setToggle] = React.useState(false);
+  const [toggle, setToggle] = React.useState<boolean[]>([]);
 
-  return (
-    <React.Fragment>
-      <button onClick={() => setToggle(!toggle)}>Toggle</button>
-      {toggle && (
+  return Array.from(new Array(100)).map((_, index) => (
+    <React.Fragment key={index}>
+      <button onClick={() => setToggle([...toggle, !toggle[index]])}>Toggle</button>
+      {toggle[index] && (
         <div>
           <Row>
             <Col>
@@ -98,7 +98,7 @@ export const Dynamic = () => {
         </div>
       )}
     </React.Fragment>
-  );
+  ));
 };
 
 Dynamic.story = {

--- a/examples/emotion.tsx
+++ b/examples/emotion.tsx
@@ -1,41 +1,47 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
+import * as React from 'react';
+import { InteractionTaskArgs, PublicInteractionTask } from 'storybook-addon-performance';
+import { fireEvent, findAllByText } from '@testing-library/dom';
 
 export default {
   title: 'benchmarks | emotion',
 };
 
-export const Static = () => (
-  <span
-    css={{
-      backgroundColor: 'rgb(223, 225, 230)',
-      borderRadius: 3,
-      boxSizing: 'border-box',
-      color: 'rgb(66, 82, 110)',
-      display: 'inline-block',
-      fontSize: '11px',
-      fontWeight: 700,
-      lineHeight: 1,
-      maxWidth: '100%',
-      padding: '2px 0 3px 0',
-      textTransform: 'uppercase',
-      verticalAlign: 'baseline',
-    }}>
-    <span
-      css={{
-        display: 'inline-block',
-        verticalAlign: 'top',
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-        boxSizing: 'border-box',
-        padding: `0 4px`,
-        maxWidth: 100,
-        width: '100%',
-      }}>
-      Lozenge
-    </span>
-  </span>
+const APPEARANCES = [
+  { bg: 'red', color: 'white' },
+  { bg: 'blue', color: 'white' },
+  { bg: 'green', color: 'black' },
+  { bg: 'grey', color: 'white' },
+  { bg: 'yellow', color: 'black' },
+  { bg: 'orange', color: 'white' },
+];
+
+const interactionTasks: PublicInteractionTask[] = [
+  {
+    name: 'Display lozenge',
+    run: async ({ container }: InteractionTaskArgs): Promise<void> => {
+      window.location.reload();
+
+      const buttonAll = container.querySelectorAll('button')!;
+
+      buttonAll.forEach((button) => {
+        fireEvent.click(button);
+      });
+
+      await findAllByText(container, 'Lozenge', undefined, {
+        timeout: 2000,
+      });
+    },
+  },
+];
+
+const Row: React.FunctionComponent<React.ReactNode> = ({ children }) => (
+  <div style={{ display: 'flex' }}>{children}</div>
+);
+
+const Col: React.FunctionComponent<React.ReactNode> = ({ children }) => (
+  <div style={{ flex: '1 1 auto' }}>{children}</div>
 );
 
 const Lozenge = (props: { bg: string; color: string }) => (
@@ -71,4 +77,35 @@ const Lozenge = (props: { bg: string; color: string }) => (
   </span>
 );
 
-export const Dynamic = () => <Lozenge bg="rgb(0, 135, 90)" color="rgb(255, 255, 255)" />;
+export const Dynamic = () => {
+  const [toggle, setToggle] = React.useState(false);
+
+  return (
+    <React.Fragment>
+      <button onClick={() => setToggle(!toggle)}>Toggle</button>
+      {toggle && (
+        <div>
+          <Row>
+            <Col>
+              <p>Colors</p>
+              {APPEARANCES.map((a) => (
+                <p key={a.bg as string}>
+                  <Lozenge bg={a.bg} color={a.color} />
+                </p>
+              ))}
+            </Col>
+          </Row>
+        </div>
+      )}
+    </React.Fragment>
+  );
+};
+
+Dynamic.story = {
+  name: 'Emotion Dynamic',
+  parameters: {
+    performance: {
+      interactions: interactionTasks,
+    },
+  },
+};

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
@@ -175,7 +175,6 @@ describe('css prop behaviour', () => {
       <div css={[base, top]}>hello world</div>
     `);
 
-    expect(actual).toInclude('{color:black}');
     expect(actual).toInclude('{color:red}');
   });
 

--- a/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
@@ -240,7 +240,6 @@ describe('css prop object literal', () => {
         <div css={{ color: 'blue', ...mixin }}>hello world</div>
       `);
 
-    expect(actual).toInclude('{color:blue}');
     expect(actual).toInclude('{color:red}');
   });
 
@@ -304,7 +303,6 @@ describe('css prop object literal', () => {
         <div css={{ color: 'blue', ...mixin() }}>hello world</div>
       `);
 
-    expect(actual).toInclude(`{color:blue}`);
     expect(actual).toInclude(`{color:red}`);
   });
 
@@ -329,7 +327,6 @@ describe('css prop object literal', () => {
         <div css={{ color: 'blue', ...mixin() }}>hello world</div>
       `);
 
-    expect(actual).toInclude('{color:blue}');
     expect(actual).toInclude('{color:red}');
   });
 
@@ -364,7 +361,6 @@ describe('css prop object literal', () => {
         <div css={{ color: 'blue', ...mixin() }}>hello world</div>
       `);
 
-    expect(actual).toInclude(`{color:blue}`);
     expect(actual).toInclude(`{color:red}`);
   });
 
@@ -503,7 +499,6 @@ describe('css prop object literal', () => {
         <div css={{ color: 'blue', ...mixin() }}>hello world</div>
       `);
 
-    expect(actual).toInclude('{color:blue}');
     expect(actual).toInclude('{color:red}');
   });
 

--- a/packages/babel-plugin/src/css-prop/__tests__/string-literal.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/string-literal.test.tsx
@@ -203,7 +203,6 @@ describe('css prop string literal', () => {
         <div css={\`\${style};color: red;\`}>hello world</div>
       `);
 
-    expect(actual).toInclude('{color:blue}');
     expect(actual).toInclude('{color:red}');
     expect(actual).toInclude('{font-size:30px}');
   });

--- a/packages/babel-plugin/src/utils/ast-builders.tsx
+++ b/packages/babel-plugin/src/utils/ast-builders.tsx
@@ -199,9 +199,7 @@ const styledTemplate = (opts: StyledTemplateOpts, meta: Metadata): t.Node => {
         {...props}
         style={%%styleProp%%}
         ref={ref}
-        className={ax([${opts.classNames
-          .map((className) => `"${className}"`)
-          .join(',')}, props.className])}
+        className={ax(["${opts.classNames.join(' ')}", props.className])}
       />
     </CC>
   ));
@@ -346,9 +344,9 @@ export const buildCompiledComponent = (
     // the class name we're going to put on it.
     const classNameExpression = getPropValue(classNameProp.value);
 
-    const values: t.Expression[] = classNames
-      .map((className) => t.stringLiteral(className) as t.Expression)
-      .concat(classNameExpression);
+    const values: t.Expression[] = [t.stringLiteral(classNames.join(' ')) as t.Expression].concat(
+      classNameExpression
+    );
 
     classNameProp.value = t.jsxExpressionContainer(
       t.callExpression(t.identifier('ax'), [t.arrayExpression(values)])
@@ -360,7 +358,7 @@ export const buildCompiledComponent = (
         t.jsxIdentifier('className'),
         t.jsxExpressionContainer(
           t.callExpression(t.identifier('ax'), [
-            t.arrayExpression(classNames.map((name) => t.stringLiteral(name))),
+            t.arrayExpression([t.stringLiteral(classNames.join(' '))]),
           ])
         )
       )

--- a/packages/css/src/plugins/__tests__/discard-duplicates.test.tsx
+++ b/packages/css/src/plugins/__tests__/discard-duplicates.test.tsx
@@ -1,0 +1,35 @@
+import postcss from 'postcss';
+import { discardDuplicates } from '../discard-duplicates';
+
+const transform = (css: TemplateStringsArray) => {
+  const result = postcss([discardDuplicates()]).process(css[0], {
+    from: undefined,
+  });
+
+  return result.css;
+};
+
+describe('discard dupicates plugin', () => {
+  it('should do nothing if no duplicates', () => {
+    expect(transform`
+      display: block;
+      margin: 0 auto;
+    `).toMatchInlineSnapshot(`
+      "
+            display: block;
+            margin: 0 auto;
+          "
+    `);
+  });
+
+  it('should discard duplicates', () => {
+    expect(transform`
+      display: block;
+      display: flex;
+    `).toMatchInlineSnapshot(`
+      "
+            display: flex;
+          "
+    `);
+  });
+});

--- a/packages/css/src/plugins/discard-duplicates.tsx
+++ b/packages/css/src/plugins/discard-duplicates.tsx
@@ -1,0 +1,27 @@
+import { plugin, Declaration } from 'postcss';
+
+/**
+ * Discards top level duplicate declarations.
+ */
+export const discardDuplicates = plugin<{ callback: (sheet: string) => void }>(
+  'discard-duplicates',
+  () => {
+    const decls: Record<string, Declaration[]> = {};
+
+    return (root) => {
+      root.each((node) => {
+        if (node.type === 'decl') {
+          decls[node.prop] = decls[node.prop] || [];
+          decls[node.prop].push(node);
+        }
+      });
+
+      for (const key in decls) {
+        const found = decls[key];
+        for (let i = 0; i < found.length - 1; i++) {
+          found[i].remove();
+        }
+      }
+    };
+  }
+);

--- a/packages/css/src/utils/__tests__/css-transform.test.tsx
+++ b/packages/css/src/utils/__tests__/css-transform.test.tsx
@@ -14,6 +14,17 @@ describe('#css-transform', () => {
       expect(actual.join('\n')).toMatchInlineSnapshot(`"._f8pj1q9v:focus{color:hotpink}"`);
     });
 
+    it('should discard duplicates', () => {
+      const { sheets: actual } = transformCss(
+        `
+      display: block;
+      display: flex;
+    `
+      );
+
+      expect(actual.join('\n')).toMatchInlineSnapshot(`"._1e0c1txw{display:flex}"`);
+    });
+
     it('should not reparent when parent has a combinator', () => {
       const { sheets: actual } = transformCss(
         `
@@ -28,9 +39,9 @@ describe('#css-transform', () => {
       );
 
       expect(actual.join('\n')).toMatchInlineSnapshot(`
-      "._169r1j6v._169r1j6v > *{margin-bottom:1rem}
-      ._1wzbidpf._1wzbidpf > *:last-child{margin-bottom:0}"
-    `);
+              "._169r1j6v._169r1j6v > *{margin-bottom:1rem}
+              ._1wzbidpf._1wzbidpf > *:last-child{margin-bottom:0}"
+          `);
     });
 
     it('should parent multiple pseduos in a group', () => {

--- a/packages/css/src/utils/css-transform.tsx
+++ b/packages/css/src/utils/css-transform.tsx
@@ -3,6 +3,7 @@ import autoprefixer from 'autoprefixer';
 import nested from 'postcss-nested';
 import whitespace from 'postcss-normalize-whitespace';
 import { unique } from '@compiled/utils';
+import { discardDuplicates } from '../plugins/discard-duplicates';
 import { parentOrphanedPseudos } from '../plugins/parent-orphaned-pseudos';
 import { minify } from '../plugins/minify';
 import { extractStyleSheets } from '../plugins/extract-stylesheets';
@@ -29,6 +30,7 @@ export const transformCss = (css: string, opts: Opts = { minify: false }) => {
   const classNames: string[] = [];
 
   const result = postcss([
+    discardDuplicates(),
     parentOrphanedPseudos(),
     nested(),
     expandShorthands(),

--- a/packages/react/src/runtime/ax.tsx
+++ b/packages/react/src/runtime/ax.tsx
@@ -27,27 +27,38 @@ const ATOMIC_GROUP_LENGTH = 5;
  *
  * @param classes
  */
-export default function ax(classNames: (string | undefined | false)[]): string {
-  const atomicGroups: Record<string, string> = {};
-  let i = -1;
+export default function ax(classNames: (string | undefined | false)[]): string | undefined {
+  if (classNames.length <= 1) {
+    // short circuit if theres no custom class names.
+    return classNames[0] || undefined;
+  }
 
-  while (++i < classNames.length) {
-    if (!classNames[i]) {
+  const atomicGroups: Record<string, string> = {};
+
+  for (let i = 0; i < classNames.length; i++) {
+    const cls = classNames[i];
+    if (!cls) {
       continue;
     }
 
-    const groups = (classNames[i] as string).split(' ');
-    let x = -1;
+    const groups = cls.split(' ');
 
-    while (++x < groups.length) {
-      atomicGroups[
-        groups[x].slice(
-          0,
-          groups[x].charCodeAt(0) === UNDERSCORE_UNICODE ? ATOMIC_GROUP_LENGTH : undefined
-        )
-      ] = groups[x];
+    for (let x = 0; x < groups.length; x++) {
+      const atomic = groups[x];
+      const atomicGroupName = atomic.slice(
+        0,
+        atomic.charCodeAt(0) === UNDERSCORE_UNICODE ? ATOMIC_GROUP_LENGTH : undefined
+      );
+      atomicGroups[atomicGroupName] = atomic;
     }
   }
 
-  return Object.values(atomicGroups).join(' ');
+  let str = '';
+
+  for (const key in atomicGroups) {
+    const value = atomicGroups[key];
+    str += value + ' ';
+  }
+
+  return str;
 }

--- a/packages/react/src/runtime/ax.tsx
+++ b/packages/react/src/runtime/ax.tsx
@@ -60,5 +60,5 @@ export default function ax(classNames: (string | undefined | false)[]): string |
     str += value + ' ';
   }
 
-  return str;
+  return str.slice(0, -1);
 }

--- a/packages/react/src/runtime/sheet.tsx
+++ b/packages/react/src/runtime/sheet.tsx
@@ -62,11 +62,11 @@ const pseudosMap: Record<string, Bucket | undefined> = {
  */
 function lazyAddStyleBucketToHead(bucketName: Bucket, opts: StyleSheetOpts): HTMLStyleElement {
   if (!styleBucketsInHead[bucketName]) {
-    let currentBucketIndex = styleBucketOrdering.indexOf(bucketName);
+    let currentBucketIndex = styleBucketOrdering.indexOf(bucketName) + 1;
     let nextBucketFromCache = null;
 
     // Find the next bucket which we will add our new style bucket before.
-    while (++currentBucketIndex < styleBucketOrdering.length) {
+    for (; currentBucketIndex < styleBucketOrdering.length; currentBucketIndex++) {
       const nextBucket = styleBucketsInHead[styleBucketOrdering[currentBucketIndex]];
       if (nextBucket) {
         nextBucketFromCache = nextBucket;

--- a/packages/react/src/runtime/sheet.tsx
+++ b/packages/react/src/runtime/sheet.tsx
@@ -102,7 +102,7 @@ function lazyAddStyleBucketToHead(bucketName: Bucket, opts: StyleSheetOpts): HTM
  *
  * @param sheet styles for which we are getting the bucket
  */
-const getStyleBucketName = (sheet: string): Bucket => {
+export const getStyleBucketName = (sheet: string): Bucket => {
   // We are grouping all the at-rules like @media, @supports etc under `m` bucket.
   if (sheet.charCodeAt(0) === 64 /* "@" */) {
     return 'm';
@@ -121,21 +121,6 @@ const getStyleBucketName = (sheet: string): Bucket => {
 
   // Return default catch all bucket
   return '';
-};
-
-/**
- * Group sheets by bucket.
- *
- * @returns { 'h': ['._a1234567:hover{ color: red; }', '._a1234567:hover{ color: green; }'] }
- * @param sheets styles which are grouping under bucket
- */
-export const groupSheetsByBucket = (sheets: string[]) => {
-  return sheets.reduce<Record<Bucket, string[]>>((accum, sheet) => {
-    const bucketName = getStyleBucketName(sheet);
-    accum[bucketName] = accum[bucketName] || [];
-    accum[bucketName].push(sheet);
-    return accum;
-  }, {} as Record<Bucket, string[]>);
 };
 
 /**


### PR DESCRIPTION
This PR optimizes some of the HOT paths for the runtime. @pgmanutd can you see any more opportunities?

## Changes

**ax func**

- [x] change transform to group classNames as much as possible (from `['a', 'b', 'c']` to `['abc']`
- [x] use for loops
- [x] use for in instead of `Object.values`
- [x] short circuit if array length is 1

**stylesheet func**

- [x] use for loops

**style component**

- [x] for loops instead of filter
- [x] memo re-renders (should never re-render)

**css pkg**

- [x] remove duplicates in post css plugin (needed because of `ax` short circuit)