### PR TITLE
fix(classnames): check if style is coming from inner scope only

### DIFF
--- a/packages/babel-plugin/src/class-names/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/class-names/__tests__/behaviour.test.tsx
@@ -278,4 +278,34 @@ describe('class names behaviour', () => {
         </CC>;"
     `);
   });
+
+  it('should not transform style identifier when its coming from outer scope', () => {
+    const actual = transform(`
+      import { ClassNames } from '@compiled/react';
+
+      const EmphasisText = ({ className, children, style }) => (
+        <ClassNames>
+          {({ css }) => (
+            <span
+              style={style}
+              className={
+                css({
+                  color: '#00b8d9',
+                  textTransform: 'uppercase',
+                  fontWeight: 700,
+                }) +
+                ' ' +
+                className
+              }>
+              {children}
+            </span>
+          )}
+        </ClassNames>
+      );
+  `);
+
+    console.log(actual);
+
+    expect(actual).toInclude(`style={style}`);
+  });
 });

--- a/packages/babel-plugin/src/class-names/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/class-names/__tests__/behaviour.test.tsx
@@ -304,8 +304,6 @@ describe('class names behaviour', () => {
       );
   `);
 
-    console.log(actual);
-
     expect(actual).toInclude(`style={style}`);
   });
 });

--- a/packages/babel-plugin/src/class-names/index.tsx
+++ b/packages/babel-plugin/src/class-names/index.tsx
@@ -108,7 +108,11 @@ export const visitClassNamesPath = (path: NodePath<t.JSXElement>, meta: Metadata
   // Second pass to replace all usages of `style`.
   path.traverse({
     Identifier(path) {
-      if (path.node.name !== 'style' || path.parentPath.isProperty()) {
+      if (
+        path.node.name !== 'style' ||
+        path.parentPath.isProperty() ||
+        !path.scope.hasOwnBinding('style')
+      ) {
         // Nothing to do - skip.
         return;
       }


### PR DESCRIPTION
This closes #378 

@madou: Is this that simple? We are now just checking inner scope. And that will be children function expression.