### PR TITLE
feat: CSS multi args

### DIFF
--- a/examples/class-names-static.tsx
+++ b/examples/class-names-static.tsx
@@ -44,3 +44,16 @@ export const Array = () => (
     {({ css }) => <div className={css([{ fontSize: 20 }, `color: green;`])}>hello world</div>}
   </ClassNames>
 );
+
+export const CNArgs = () => (
+  <ClassNames>
+    {({ css }) => (
+      <div
+        className={css({ fontSize: 20 }, `color: blue;`, [{ padding: 20 }], {
+          backgroundColor: 'red',
+        })}>
+        hello world
+      </div>
+    )}
+  </ClassNames>
+);

--- a/examples/styled-static-object.tsx
+++ b/examples/styled-static-object.tsx
@@ -10,4 +10,10 @@ const Thing = styled.div({
   color: 'red',
 });
 
+const Box = styled.div({ fontSize: 20 }, `color: blue;`, [{ padding: 20 }], {
+  backgroundColor: 'red',
+});
+
 export const ObjectLiteral = () => <Thing>hello world</Thing>;
+
+export const StyledArgs = () => <Box>HELLO WORLD</Box>;

--- a/packages/babel-plugin/src/class-names/index.tsx
+++ b/packages/babel-plugin/src/class-names/index.tsx
@@ -12,7 +12,7 @@ import { CSSOutput } from '../utils/types';
  *
  * @param path Expression node
  */
-const extractStyles = (path: NodePath<t.Expression>) => {
+const extractStyles = (path: NodePath<t.Expression>): t.Expression[] | t.Expression | undefined => {
   if (
     t.isCallExpression(path.node) &&
     t.isIdentifier(path.node.callee) &&
@@ -20,7 +20,7 @@ const extractStyles = (path: NodePath<t.Expression>) => {
     t.isExpression(path.node.arguments[0])
   ) {
     // css({}) call
-    const styles = path.node.arguments[0];
+    const styles = path.node.arguments as t.Expression[];
     return styles;
   }
 
@@ -32,7 +32,7 @@ const extractStyles = (path: NodePath<t.Expression>) => {
     t.isExpression(path.node.arguments[0])
   ) {
     // props.css({}) call
-    const styles = path.node.arguments[0];
+    const styles = path.node.arguments as t.Expression[];
     return styles;
   }
 

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
@@ -272,8 +272,9 @@ describe('styled component behaviour', () => {
     ]);
   });
 
-  it('should add missing semicolon', () => {
-    const actual = transform(`
+  it('should not throw when template literal CSS has no terminating semi colon', () => {
+    expect(() => {
+      transform(`
       import { styled } from '@compiled/react';
 
       const ListItem = styled.div(
@@ -281,11 +282,6 @@ describe('styled component behaviour', () => {
         { fontSize: 20 }
       );
     `);
-
-    expect(actual).toIncludeMultiple([
-      '{color:red}',
-      '{font-size:20px}',
-      'ax(["_syaz5scu _1wybgktf",props.className])',
-    ]);
+    }).not.toThrow();
   });
 });

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
@@ -254,4 +254,21 @@ describe('styled component behaviour', () => {
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
     expect(actual).toInclude('"--_1j0t240":"super"+((()=>{return textSize;})()||"")+"big"');
   });
+
+  it('should collect args as styles', () => {
+    const actual = transform(`
+      import { styled } from '@compiled/react';
+
+      const ListItem = styled.div(
+        { color: 'darkorchid' },
+        { fontSize: 12 },
+      );
+    `);
+
+    expect(actual).toIncludeMultiple([
+      '{color:darkorchid}',
+      '{font-size:12px}',
+      'ax(["_syaz1paq _1wyb1fwx",props.className])',
+    ]);
+  });
 });

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
@@ -271,4 +271,21 @@ describe('styled component behaviour', () => {
       'ax(["_syaz1paq _1wyb1fwx",props.className])',
     ]);
   });
+
+  it('should add missing semicolon', () => {
+    const actual = transform(`
+      import { styled } from '@compiled/react';
+
+      const ListItem = styled.div(
+        \`color: red\`,
+        { fontSize: 20 }
+      );
+    `);
+
+    expect(actual).toIncludeMultiple([
+      '{color:red}',
+      '{font-size:20px}',
+      'ax(["_syaz5scu _1wybgktf",props.className])',
+    ]);
+  });
 });

--- a/packages/babel-plugin/src/styled/index.tsx
+++ b/packages/babel-plugin/src/styled/index.tsx
@@ -5,10 +5,7 @@ import { buildCss } from '../utils/css-builders';
 import { Metadata, Tag } from '../types';
 
 interface StyledData {
-  tag: {
-    name: string;
-    type: Tag['type'];
-  };
+  tag: Tag;
   cssNode: t.Expression | t.Expression[];
 }
 

--- a/packages/babel-plugin/src/styled/index.tsx
+++ b/packages/babel-plugin/src/styled/index.tsx
@@ -4,6 +4,14 @@ import { buildStyledComponent } from '../utils/ast-builders';
 import { buildCss } from '../utils/css-builders';
 import { Metadata, Tag } from '../types';
 
+interface StyledData {
+  tag: {
+    name: string;
+    type: Tag['type'];
+  };
+  cssNode: t.Expression | t.Expression[];
+}
+
 const createStyledDataPair = ({
   tagName,
   tagType,
@@ -11,7 +19,7 @@ const createStyledDataPair = ({
 }: {
   tagName: string;
   tagType: Tag['type'];
-  cssNode: t.Expression;
+  cssNode: t.Expression | t.Expression[];
 }) => ({
   tag: {
     name: tagName,
@@ -23,7 +31,7 @@ const createStyledDataPair = ({
 const extractStyledDataFromTemplateLiteral = (
   node: t.TaggedTemplateExpression,
   meta: Metadata
-): { tag: Tag; cssNode: t.Expression } | undefined => {
+): StyledData | undefined => {
   if (
     t.isMemberExpression(node.tag) &&
     t.isIdentifier(node.tag.object) &&
@@ -54,7 +62,7 @@ const extractStyledDataFromTemplateLiteral = (
 const extractStyledDataFromObjectLiteral = (
   node: t.CallExpression,
   meta: Metadata
-): { tag: Tag; cssNode: t.Expression } | undefined => {
+): StyledData | undefined => {
   if (
     t.isMemberExpression(node.callee) &&
     t.isIdentifier(node.callee.object) &&
@@ -63,7 +71,7 @@ const extractStyledDataFromObjectLiteral = (
     t.isIdentifier(node.callee.property)
   ) {
     const tagName = node.callee.property.name;
-    const cssNode = node.arguments[0];
+    const cssNode = node.arguments as t.Expression[];
 
     return createStyledDataPair({ tagName, tagType: 'InBuiltComponent', cssNode });
   }
@@ -76,7 +84,7 @@ const extractStyledDataFromObjectLiteral = (
     t.isIdentifier(node.callee.arguments[0])
   ) {
     const tagName = node.callee.arguments[0].name;
-    const cssNode = node.arguments[0];
+    const cssNode = node.arguments as t.Expression[];
 
     return createStyledDataPair({ tagName, tagType: 'UserDefinedComponent', cssNode });
   }
@@ -91,7 +99,7 @@ const extractStyledDataFromObjectLiteral = (
 const extractStyledDataFromNode = (
   node: t.TaggedTemplateExpression | t.CallExpression,
   meta: Metadata
-): { tag: Tag; cssNode: t.Expression } | undefined => {
+) => {
   if (t.isTaggedTemplateExpression(node)) {
     return extractStyledDataFromTemplateLiteral(node, meta);
   }

--- a/packages/babel-plugin/src/utils/ast.tsx
+++ b/packages/babel-plugin/src/utils/ast.tsx
@@ -44,7 +44,15 @@ export const getPathOfNode = <TNode extends {}>(
  * @param node
  * @param parentPath
  */
-export const buildCodeFrameError = (error: string, node: t.Node, parentPath: NodePath<any>) => {
+export const buildCodeFrameError = (
+  error: string,
+  node: t.Node | null,
+  parentPath: NodePath<any>
+) => {
+  if (!node) {
+    throw parentPath.buildCodeFrameError(error);
+  }
+
   const startLoc = node.loc ? ` (${node.loc.start.line}:${node.loc.start.column})` : '';
 
   return getPathOfNode(node, parentPath).buildCodeFrameError(`${error}${startLoc}.`);

--- a/packages/babel-plugin/src/utils/css-builders.tsx
+++ b/packages/babel-plugin/src/utils/css-builders.tsx
@@ -247,7 +247,7 @@ const extractTemplateLiteral = (node: t.TemplateLiteral, meta: Metadata): CSSOut
       return acc + before.css + `var(${variableName})`;
     }
 
-    return acc + q.value.raw;
+    return acc + q.value.raw + ';';
   }, '');
 
   css.push({ type: 'unconditional', css: literalResult });

--- a/packages/babel-plugin/src/utils/css-builders.tsx
+++ b/packages/babel-plugin/src/utils/css-builders.tsx
@@ -261,7 +261,7 @@ const extractTemplateLiteral = (node: t.TemplateLiteral, meta: Metadata): CSSOut
  * @param node Node we're interested in extracting CSS from.
  * @param state Babel state - should house options and meta data used during the transformation.
  */
-export const buildCss = (node: t.Expression, meta: Metadata): CSSOutput => {
+export const buildCss = (node: t.Expression | t.Expression[], meta: Metadata): CSSOutput => {
   if (t.isStringLiteral(node)) {
     return { css: [{ type: 'unconditional', css: node.value }], variables: [] };
   }
@@ -307,15 +307,16 @@ export const buildCss = (node: t.Expression, meta: Metadata): CSSOutput => {
     return result;
   }
 
-  if (t.isArrayExpression(node)) {
+  if (t.isArrayExpression(node) || Array.isArray(node)) {
     const css: CSSOutput['css'] = [];
     const variables: CSSOutput['variables'] = [];
+    const elements = t.isArrayExpression(node) ? node.elements : node;
 
-    node.elements.forEach((element) => {
+    elements.forEach((element) => {
       if (!t.isExpression(element)) {
         throw buildCodeFrameError(
           `${element && element.type} isn't a supported CSS type - try using an object or string`,
-          node,
+          t.isArrayExpression(node) ? node : element,
           meta.parentPath
         );
       }

--- a/packages/react/src/class-names/__tests__/index.test.tsx
+++ b/packages/react/src/class-names/__tests__/index.test.tsx
@@ -111,4 +111,28 @@ describe('class names component', () => {
 
     expect(getByText('hello world')).toHaveCompiledCss('font-size', '13px');
   });
+
+  it('should accept css args', () => {
+    const { getByText } = render(
+      <ClassNames>
+        {({ css }) => (
+          <div
+            className={css(
+              { fontSize: 12 },
+              `font-size: 15px;`,
+              { color: 'blue', display: 'none' },
+              [{ color: 'red' }]
+            )}>
+            hello world
+          </div>
+        )}
+      </ClassNames>
+    );
+
+    expect(getByText('hello world')).toHaveCompiledCss({
+      fontSize: '15px',
+      color: 'red',
+      display: 'none',
+    });
+  });
 });

--- a/packages/react/src/class-names/index.tsx
+++ b/packages/react/src/class-names/index.tsx
@@ -2,12 +2,11 @@ import { ReactNode } from 'react';
 import { createSetupError } from '../utils/error';
 import { CssFunction, BasicTemplateInterpolations } from '../types';
 
+export type Interpolations = (BasicTemplateInterpolations | CssFunction | CssFunction[])[];
+
 export interface ClassNamesProps {
   children: (opts: {
-    css: (
-      css: CssFunction | CssFunction[],
-      ...interpoltations: BasicTemplateInterpolations[]
-    ) => string;
+    css: (css: CssFunction | CssFunction[], ...interpolations: Interpolations) => string;
     style: { [key: string]: string };
   }) => ReactNode;
 }

--- a/packages/react/src/styled/__tests__/index.test.tsx
+++ b/packages/react/src/styled/__tests__/index.test.tsx
@@ -302,4 +302,21 @@ describe('styled component', () => {
 
     expect(getByText('hello world')).toHaveCompiledCss('font-size', '15px');
   });
+
+  it('should accept css args', () => {
+    const StyledDiv = styled.div(
+      { fontSize: 12 },
+      `font-size: 15px;`,
+      { color: 'blue', display: 'none' },
+      [{ color: 'red' }]
+    );
+
+    const { getByText } = render(<StyledDiv>hello world</StyledDiv>);
+
+    expect(getByText('hello world')).toHaveCompiledCss({
+      fontSize: '15px',
+      color: 'red',
+      display: 'none',
+    });
+  });
 });

--- a/packages/react/src/styled/index.tsx
+++ b/packages/react/src/styled/index.tsx
@@ -18,6 +18,13 @@ export interface StyledProps {
   as?: keyof JSX.IntrinsicElements;
 }
 
+export type Interpolations<TProps extends {}> = (
+  | BasicTemplateInterpolations
+  | FunctionIterpolation<TProps>
+  | CssObject<TProps>
+  | CssObject<TProps>[]
+)[];
+
 /**
  * This allows us to take the generic `TTag` (that will be a valid `DOM` tag) and then use it to
  * define correct props based on it from `JSX.IntrinsicElements`, while also injecting our own
@@ -27,7 +34,7 @@ export interface StyledFunctionFromTag<TTag extends keyof JSX.IntrinsicElements>
   <TProps extends {}>(
     // Allows either string or object (`` or ({}))
     css: CssObject<TProps> | CssObject<TProps>[],
-    ...interpoltations: (BasicTemplateInterpolations | FunctionIterpolation<TProps>)[]
+    ...interpoltations: Interpolations<TProps>
   ): React.ComponentType<TProps & JSX.IntrinsicElements[TTag] & StyledProps>;
 }
 
@@ -35,7 +42,7 @@ export interface StyledFunctionFromComponent<TInheritedProps extends {}> {
   <TProps extends {}>(
     // Allows either string or object (`` or ({}))
     css: CssObject<TProps> | TemplateStringsArray,
-    ...interpoltations: (BasicTemplateInterpolations | FunctionIterpolation<TProps>)[]
+    ...interpoltations: Interpolations<TProps>
   ): React.ComponentType<TProps & StyledProps & TInheritedProps>;
 }
 


### PR DESCRIPTION
This PR enables support for multiple args in the styled and ClassNames apis:

```js
styled.div(
  { color: 'red' },
  ` font-size: 20 `,
  [{ backgroundColor: 'blue', padding: 10 }]
);

<ClassNames>
  {({ css }) => (
    <div
      className={css({ fontSize: 20 }, `color: blue;`, [{ padding: 20 }], {
        backgroundColor: 'red',
      })}>
      hello world
    </div>
  )}
</ClassNames>
```

Needed to update types and a little bit of the CSS builder, but for the most part no major architecture changes were needed.

Closes #352

**TODO**

- [x] styled api
- [x] ClassNames api