### PR TITLE
fix(codemod): restore comments attached to transformed node paths

### DIFF
--- a/packages/react/src/codemods/codemods-helpers.tsx
+++ b/packages/react/src/codemods/codemods-helpers.tsx
@@ -110,6 +110,9 @@ export const buildDefaultImportDeclaration = ({
     );
 
     if (importDefaultSpecifierCollection.length > 0) {
+      const oldNode = importDeclarationPath.node;
+      const { comments } = oldNode;
+
       j(importDeclarationPath).replaceWith([
         j.importDeclaration(
           [
@@ -121,6 +124,12 @@ export const buildDefaultImportDeclaration = ({
           j.literal(importPathTo)
         ),
       ]);
+
+      const newNode = importDeclarationPath.node;
+
+      if (newNode !== oldNode) {
+        newNode.comments = comments;
+      }
     }
   });
 };

--- a/packages/react/src/codemods/emotion-to-compiled/__tests__/emotion-to-compiled.test.tsx
+++ b/packages/react/src/codemods/emotion-to-compiled/__tests__/emotion-to-compiled.test.tsx
@@ -380,6 +380,54 @@ describe('emotion-to-compiled transformer', () => {
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
     {},
+    `
+    // @top-level comment
+
+    /** @jsx jsx */
+    import { ClassNames, CSSObject, css as c, jsx } from '@emotion/core';
+    // comment 1
+    import * as React from 'react';
+    `,
+    `
+    /* TODO: (from codemod) "ClassNames" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    /* TODO: (from codemod) "CSSObject" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    // @top-level comment
+
+    import '@compiled/react';
+
+    // comment 1
+    import * as React from 'react';
+    `,
+    'it should not remove top level comments when transformed'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    {},
+    `
+    // @top-level comment
+
+    /** @jsx jsx */
+    import * as React from 'react';
+    // comment 1
+    import { ClassNames, CSSObject, css as c, jsx } from '@emotion/core';
+    `,
+    `
+    /* TODO: (from codemod) "ClassNames" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    /* TODO: (from codemod) "CSSObject" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    // @top-level comment
+
+    import * as React from 'react';
+
+    // comment 1
+    import '@compiled/react';
+    `,
+    'it should not remove comments before transformed statement when not on top'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    {},
     "import * as React from 'react';",
     "import * as React from 'react';",
     'it should not transform when emotion imports are not present'

--- a/packages/react/src/codemods/emotion-to-compiled/emotion-to-compiled.tsx
+++ b/packages/react/src/codemods/emotion-to-compiled/emotion-to-compiled.tsx
@@ -174,9 +174,18 @@ const buildCompiledImportDeclaration = (j: core.JSCodeshift, collection: Collect
   });
 
   importDeclarationCollection.forEach((importDeclarationPath) => {
+    const oldNode = importDeclarationPath.node;
+    const { comments } = oldNode;
+
     j(importDeclarationPath).replaceWith([
       j.importDeclaration([], j.literal(imports.compiledPackageName)),
     ]);
+
+    const newNode = importDeclarationPath.node;
+
+    if (newNode !== oldNode) {
+      newNode.comments = comments;
+    }
   });
 };
 

--- a/packages/react/src/codemods/styled-components-to-compiled/__tests__/styled-components-to-compiled.test.tsx
+++ b/packages/react/src/codemods/styled-components-to-compiled/__tests__/styled-components-to-compiled.test.tsx
@@ -38,6 +38,50 @@ describe('styled-components-to-compiled transformer', () => {
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
     {},
+    `
+    // @top-level comment
+
+    // comment 1
+    import styled from 'styled-components';
+    // comment 2
+    import * as React from 'react';
+    `,
+    `
+    // @top-level comment
+
+    // comment 1
+    import { styled } from '@compiled/react';
+    // comment 2
+    import * as React from 'react';
+    `,
+    'it should not remove top level comments when transformed'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    {},
+    `
+    // @top-level comment
+
+    // comment 1
+    import * as React from 'react';
+    // comment 2
+    import styled from 'styled-components';
+    `,
+    `
+    // @top-level comment
+
+    // comment 1
+    import * as React from 'react';
+    // comment 2
+    import { styled } from '@compiled/react';
+    `,
+    'it should not remove comments before transformed statement when not on top'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    {},
     "import * as React from 'react';",
     "import * as React from 'react';",
     'it should not transform when styled-components imports are not present'


### PR DESCRIPTION
The [recipe](https://github.com/facebook/jscodeshift/blob/master/recipes/retain-first-comment.md) mentioned in jscodeshift docs was only working for top level node paths.

This fix ensures they (comments) will get restored even when transformed node paths lies in between the statements.