### PR TITLE
fix: reverts fallback dynamic css decl value

### DIFF
--- a/examples/default-css-variables.tsx
+++ b/examples/default-css-variables.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { styled } from '@compiled/react';
+
+const Container = styled.div<{ open: boolean; inherentHeight: number }>`
+  max-height: ${(props) => (props.open ? props.inherentHeight : 0)}px;
+  overflow: hidden;
+`;
+
+export default {
+  title: 'dynamic | CSS declarations',
+};
+
+export const ShouldNotBeVisible = () => {
+  return (
+    <Container open={false} inherentHeight={200}>
+      <div css={{ background: 'blue', height: 200, width: 200 }}>SHOULD NOT BE SEEN</div>
+    </Container>
+  );
+};

--- a/packages/babel-plugin/src/class-names/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/class-names/__tests__/object-literal.test.tsx
@@ -26,7 +26,7 @@ describe('class names object literal', () => {
       `);
 
     expect(actual).toIncludeMultiple([
-      'style={{"--_1j2e0s2":(fontSize||"")+"px"}}',
+      'style={{"--_1j2e0s2":fontSize+"px"}}',
       'font-size:var(--_1j2e0s2)',
     ]);
   });

--- a/packages/babel-plugin/src/class-names/__tests__/string-literal.test.tsx
+++ b/packages/babel-plugin/src/class-names/__tests__/string-literal.test.tsx
@@ -25,7 +25,7 @@ describe('class names string literal', () => {
 
     expect(actual).toIncludeMultiple([
       'font-size:var(--_1j2e0s2)',
-      'style={{"--_1j2e0s2":(fontSize||"")+"px"}}',
+      'style={{"--_1j2e0s2":fontSize+"px"}}',
     ]);
   });
 

--- a/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
@@ -88,7 +88,7 @@ describe('css prop object literal', () => {
 
     expect(actual).toInclude('{margin-left:var(--_5un9uz)}');
     expect(actual).toInclude('{color:red}');
-    expect(actual).toInclude('style={{"--_5un9uz":(heading.depth||"")+"rem"}}');
+    expect(actual).toInclude('style={{"--_5un9uz":heading.depth+"rem"}}');
   });
 
   it('should persist prefix of dynamic property value into inline styles', () => {
@@ -104,7 +104,7 @@ describe('css prop object literal', () => {
 
     expect(actual).toInclude('{font-size:calc(100% - var(--_1j2e0s2))}');
     expect(actual).toInclude('{color:red}');
-    expect(actual).toInclude('style={{"--_1j2e0s2":(fontSize||"")+"px"}}');
+    expect(actual).toInclude('style={{"--_1j2e0s2":fontSize+"px"}}');
   });
 
   it('should move prefix of grouped interpolation into inline styles', () => {
@@ -120,7 +120,7 @@ describe('css prop object literal', () => {
       `);
 
     expect(actual).toInclude('{margin-left:calc(100% - var(--_5un9uz))}');
-    expect(actual).toInclude('style={{"--_5un9uz":(heading.depth||"")+"rem"}}');
+    expect(actual).toInclude('style={{"--_5un9uz":heading.depth+"rem"}}');
   });
 
   it('should move multiple groups of interpolations into inline styles', () => {

--- a/packages/babel-plugin/src/css-prop/__tests__/string-literal.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/string-literal.test.tsx
@@ -23,7 +23,7 @@ describe('css prop string literal', () => {
       `);
 
     expect(actual).toInclude('{font-size:var(--_1j2e0s2)}');
-    expect(actual).toInclude('style={{"--_1j2e0s2":(fontSize||"")+"px"}}');
+    expect(actual).toInclude('style={{"--_1j2e0s2":fontSize+"px"}}');
   });
 
   it('should persist suffix of constant value', () => {
@@ -351,7 +351,7 @@ describe('css prop string literal', () => {
       `);
 
     expect(actual).toIncludeMultiple([
-      'style={{"--_65u76s":(x||"")+"px","--_1ohot4b":y}}',
+      'style={{"--_65u76s":x+"px","--_1ohot4b":y}}',
       '{transform:translate3d(var(--_65u76s),var(--_1ohot4b),0)}',
     ]);
   });

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
@@ -131,7 +131,7 @@ describe('styled component behaviour', () => {
       \`;
     `);
 
-    expect(actual).toInclude('"--_1p69eoh":(props.color||"")+"px"');
+    expect(actual).toInclude('"--_1p69eoh":props.color+"px"');
   });
 
   it('should spread down props to element', () => {
@@ -238,7 +238,7 @@ describe('styled component behaviour', () => {
     `);
 
     expect(actual).toInclude('{color:var(--_1poneq5)}');
-    expect(actual).toInclude('"--_1poneq5":"very"+((()=>{return props.color;})()||"")+"dark"');
+    expect(actual).toInclude('"--_1poneq5":"very"+(()=>{return props.color;})()+"dark"');
   });
 
   it('should move suffix and prefix of a dynamic arrow function with a body into an IIFE by preventing passing down invalid html attributes to the node', () => {
@@ -252,7 +252,7 @@ describe('styled component behaviour', () => {
 
     expect(actual).toInclude('{font-size:var(--_1j0t240)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--_1j0t240":"super"+((()=>{return textSize;})()||"")+"big"');
+    expect(actual).toInclude('"--_1j0t240":"super"+(()=>{return textSize;})()+"big"');
   });
 
   it('should collect args as styles', () => {

--- a/packages/babel-plugin/src/styled/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/object-literal.test.tsx
@@ -112,7 +112,7 @@ describe('styled component object literal', () => {
 
     expect(actual).toInclude('{font-size:var(--_fb92co)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--_fb92co":(textSize||"")+"px"');
+    expect(actual).toInclude('"--_fb92co":textSize+"px"');
   });
 
   it('should transform object with simple values', () => {

--- a/packages/babel-plugin/src/styled/__tests__/string-literal.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/string-literal.test.tsx
@@ -32,7 +32,7 @@ describe('styled component string literal', () => {
 
     expect(actual).toInclude('{font-size:var(--_fb92co)}');
     expect(actual).toInclude('textSize,...props}');
-    expect(actual).toInclude('"--_fb92co":(textSize||"")+"px"');
+    expect(actual).toInclude('"--_fb92co":textSize+"px"');
   });
 
   it('should inline constant numeric literal', () => {
@@ -61,7 +61,7 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('"--_1j2e0s2":(fontSize||"")+"px"');
+    expect(actual).toInclude('"--_1j2e0s2":fontSize+"px"');
     expect(actual).toInclude('{font-size:var(--_1j2e0s2)}');
   });
 
@@ -77,7 +77,7 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('"--_1j2e0s2":(fontSize||"")+"px"');
+    expect(actual).toInclude('"--_1j2e0s2":fontSize+"px"');
     expect(actual).toInclude('{font-size:var(--_1j2e0s2)}');
   });
 
@@ -157,7 +157,7 @@ describe('styled component string literal', () => {
       `);
 
     expect(actual).toInclude('{color:var(--_1poneq5)}');
-    expect(actual).toInclude('"--_1poneq5":"very"+((()=>{return props.color;})()||"")+"dark"');
+    expect(actual).toInclude('"--_1poneq5":"very"+(()=>{return props.color;})()+"dark"');
   });
 
   it('should move suffix and prefix of a dynamic arrow function with a body into an IIFE by preventing passing down invalid html attributes to the node', () => {
@@ -171,7 +171,7 @@ describe('styled component string literal', () => {
 
     expect(actual).toInclude('{font-size:var(--_1j0t240)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--_1j0t240":"super"+((()=>{return textSize;})()||"")+"big"');
+    expect(actual).toInclude('"--_1j0t240":"super"+(()=>{return textSize;})()+"big"');
   });
 
   it('should transform template string literal with obj variable', () => {
@@ -317,7 +317,7 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('"--_1p69eoh":"super"+(props.color||"")+"big"');
+    expect(actual).toInclude('"--_1p69eoh":"super"+props.color+"big"');
   });
 
   it('should move any prefix of a dynamic arrow func property into the style property', () => {
@@ -329,7 +329,7 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('"--_1p69eoh":"super"+(props.color||"")');
+    expect(actual).toInclude('"--_1p69eoh":"super"+props.color');
   });
 
   it('should move any suffix of a dynamic arrow func property into the style property', () => {
@@ -341,7 +341,7 @@ describe('styled component string literal', () => {
         \`;
       `);
 
-    expect(actual).toInclude('"--_1p69eoh":(props.color||"")+"big"');
+    expect(actual).toInclude('"--_1p69eoh":props.color+"big"');
   });
 
   it('should move suffix and prefix of a dynamic property into the style property', () => {
@@ -358,7 +358,7 @@ describe('styled component string literal', () => {
       `);
 
     expect(actual).toInclude('{font-size:var(--_1ylxx6h)}');
-    expect(actual).toInclude('"--_1ylxx6h":"super"+(color||"")+"big"');
+    expect(actual).toInclude('"--_1ylxx6h":"super"+color+"big"');
   });
 
   it('should do nothing with suffix/prefix when referencing constant literal', () => {
@@ -424,7 +424,7 @@ describe('styled component string literal', () => {
       `);
 
     expect(actual).toInclude('{border-radius:var(--_1hwymmh)}');
-    expect(actual).toInclude('"--_1hwymmh":(br||"")+"px"');
+    expect(actual).toInclude('"--_1hwymmh":br+"px"');
   });
 
   it('should transform inline arrow function with suffix', () => {

--- a/packages/babel-plugin/src/utils/css-builders.tsx
+++ b/packages/babel-plugin/src/utils/css-builders.tsx
@@ -221,13 +221,7 @@ const extractTemplateLiteral = (node: t.TemplateLiteral, meta: Metadata): CSSOut
       const nextQuasis = node.quasis[index + 1];
       const before = cssBeforeInterpolation(css + q.value.raw);
       const after = cssAfterInterpolation(nextQuasis.value.raw);
-
-      let expression: t.Expression =
-        before.variablePrefix || after.variableSuffix
-          ? // When there is a prefix or suffix we want to ensure the interpolation at least
-            // resolves to an empty string - so we short circuit it to one.
-            t.logicalExpression('||', interpolation, t.stringLiteral(''))
-          : interpolation;
+      let expression = interpolation;
 
       if (before.variablePrefix) {
         // A prefix is defined - we want to add them together!


### PR DESCRIPTION
This introduces a regression which means `undefined` can show up. We need a more holistic approach when it comes to getting rid of dynamic values that have a suffix/prefix.

For now - this means `undefinedpx` will appear. But at least `0` values can work again. I'll create a follow up ticket to look at fixing this properly.

Closes #402.

Follow up: https://github.com/atlassian-labs/compiled/issues/346