### PR TITLE
Classnames codemod

### DIFF
--- a/packages/react/src/codemods/constants.tsx
+++ b/packages/react/src/codemods/constants.tsx
@@ -1,0 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const pkgJson = require('../../package.json');
+
+export const COMPILED_IMPORT_PATH = pkgJson.name;
+
+export const REACT_IMPORT_PATH = 'react';
+
+export const REACT_IMPORT_NAME = 'React';

--- a/packages/react/src/codemods/emotion-to-compiled/__tests__/emotion-to-compiled.test.tsx
+++ b/packages/react/src/codemods/emotion-to-compiled/__tests__/emotion-to-compiled.test.tsx
@@ -25,12 +25,24 @@ describe('emotion-to-compiled transformer', () => {
     { default: transformer, parser: 'tsx' },
     {},
     `
+    import { ClassNames } from '@emotion/core';
+    `,
+    `
+    import { ClassNames } from '@compiled/react';
+    `,
+    'it transforms ClassNames named @emotion/core import'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    {},
+    `
     /** @jsx jsx */
-    import { css, jsx } from '@emotion/core';
+    import { css, jsx, ClassNames } from '@emotion/core';
     `,
     `
     import * as React from 'react';
-    import '@compiled/react';
+    import { ClassNames } from '@compiled/react';
     `,
     'it transforms all named @emotion/core imports'
   );
@@ -40,11 +52,11 @@ describe('emotion-to-compiled transformer', () => {
     {},
     `
     /** @jsx jsx */
-    import { css as c, jsx } from '@emotion/core';
+    import { css as c, jsx, ClassNames as CN } from '@emotion/core';
     `,
     `
     import * as React from 'react';
-    import '@compiled/react';
+    import { ClassNames as CN } from '@compiled/react';
     `,
     'it transforms all named @emotion/core imports with different imported name'
   );
@@ -54,12 +66,12 @@ describe('emotion-to-compiled transformer', () => {
     {},
     `
     /** @jsx jsx */
-    import { css, jsx } from '@emotion/core';
+    import { css, jsx, ClassNames } from '@emotion/core';
     import styled from '@emotion/styled';
     `,
     `
     import * as React from 'react';
-    import { styled } from '@compiled/react';
+    import { ClassNames, styled } from '@compiled/react';
     `,
     'it transforms all named @emotion/core and default @emotion/styled imports'
   );
@@ -69,12 +81,12 @@ describe('emotion-to-compiled transformer', () => {
     {},
     `
     /** @jsx jsx */
-    import { css as c, jsx } from '@emotion/core';
+    import { css as c, jsx, ClassNames as CN } from '@emotion/core';
     import sc from '@emotion/styled';
     `,
     `
     import * as React from 'react';
-    import { styled as sc } from '@compiled/react';
+    import { ClassNames as CN, styled as sc } from '@compiled/react';
     `,
     'it transforms all named @emotion/core with different imported name and default with different name than "styled" @emotion/styled imports'
   );
@@ -351,10 +363,9 @@ describe('emotion-to-compiled transformer', () => {
     );
     `,
     `
-    /* TODO(@compiled/react codemod): "ClassNames" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
     /* TODO(@compiled/react codemod): "CSSObject" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
     import * as React from 'react';
-    import '@compiled/react';
+    import { ClassNames } from '@compiled/react';
 
     let cssObject: CSSObject = {};
 
@@ -389,11 +400,10 @@ describe('emotion-to-compiled transformer', () => {
     import * as React from 'react';
     `,
     `
-    /* TODO(@compiled/react codemod): "ClassNames" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
     /* TODO(@compiled/react codemod): "CSSObject" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
     // @top-level comment
 
-    import '@compiled/react';
+    import { ClassNames } from '@compiled/react';
 
     // comment 1
     import * as React from 'react';
@@ -413,14 +423,13 @@ describe('emotion-to-compiled transformer', () => {
     import { ClassNames, CSSObject, css as c, jsx } from '@emotion/core';
     `,
     `
-    /* TODO(@compiled/react codemod): "ClassNames" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
     /* TODO(@compiled/react codemod): "CSSObject" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
     // @top-level comment
 
     import * as React from 'react';
 
     // comment 1
-    import '@compiled/react';
+    import { ClassNames } from '@compiled/react';
     `,
     'it should not remove comments before transformed statement when not on top'
   );

--- a/packages/react/src/codemods/emotion-to-compiled/__tests__/emotion-to-compiled.test.tsx
+++ b/packages/react/src/codemods/emotion-to-compiled/__tests__/emotion-to-compiled.test.tsx
@@ -97,6 +97,20 @@ describe('emotion-to-compiled transformer', () => {
     `
     /** @jsx jsx */
     import { css, jsx } from '@emotion/core';
+    `,
+    `
+    import * as React from 'react';
+    import '@compiled/react';
+    `,
+    'it handles the case when no api is imported from compiled package'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    {},
+    `
+    /** @jsx jsx */
+    import { css, jsx } from '@emotion/core';
     import styled from '@emotion/styled';
 
     const Component = (props) => (
@@ -446,10 +460,10 @@ describe('emotion-to-compiled transformer', () => {
     {},
     `
     /** @jsx jsx */
-    import { ClassNames, css as c, jsx } from '@emotion/core';
+    import { ClassNames as CN, css as c, jsx } from '@emotion/core';
 
     const Component = () => (
-      <ClassNames>
+      <CN>
         {({ css, cx }) => (
           <SomeComponent
             wrapperClassName={css({ color: 'green' })}
@@ -459,15 +473,15 @@ describe('emotion-to-compiled transformer', () => {
             Hello
           </SomeComponent>
         )}
-      </ClassNames>
+      </CN>
     );
     `,
     `
     import * as React from 'react';
-    import { ClassNames } from '@compiled/react';
+    import { ClassNames as CN } from '@compiled/react';
 
     const Component = () => (
-      <ClassNames>
+      <CN>
         {({
           css,
 
@@ -495,7 +509,7 @@ describe('emotion-to-compiled transformer', () => {
             Hello
           </SomeComponent>
         )}
-      </ClassNames>
+      </CN>
     );
     `,
     'it should handle "ClassNames" behavior'

--- a/packages/react/src/codemods/emotion-to-compiled/emotion-to-compiled.tsx
+++ b/packages/react/src/codemods/emotion-to-compiled/emotion-to-compiled.tsx
@@ -4,63 +4,19 @@ import {
   hasImportDeclaration,
   getImportDeclarationCollection,
   findImportSpecifierName,
-  buildDefaultImportDeclaration,
-  addCommentToStartOfFile,
-  getAllImportSpecifiers,
+  addCommentForUnresolvedImportSpecifiers,
+  addReactIdentifier,
+  convertDefaultImportToNamedImport,
+  replaceImportDeclaration,
+  mergeImportSpecifiersAlongWithTheirComments,
 } from '../codemods-helpers';
 
 const imports = {
-  compiledPackageName: '@compiled/react',
-  compiledImportName: 'styled',
+  compiledStyledImportName: 'styled',
   emotionStyledPackageName: '@emotion/styled',
   emotionCoreJSXPragma: '@jsx jsx',
-  emotionCoreImportNames: { jsx: 'jsx', css: 'css' },
+  emotionCoreImportNames: { jsx: 'jsx', css: 'css', ClassNames: 'ClassNames' },
   emotionCorePackageName: '@emotion/core',
-  reactImportName: 'React',
-  reactPackageName: 'react',
-};
-
-const addReactIdentifier = (j: core.JSCodeshift, collection: Collection) => {
-  const hasReactImportDeclaration = hasImportDeclaration({
-    j,
-    collection,
-    importPath: imports.reactPackageName,
-  });
-
-  if (!hasReactImportDeclaration) {
-    collection.find(j.Program).forEach((programPath) => {
-      programPath.node.body.unshift(
-        j.importDeclaration(
-          [j.importNamespaceSpecifier(j.identifier(imports.reactImportName))],
-          j.literal(imports.reactPackageName)
-        )
-      );
-    });
-  } else {
-    const importDeclarationCollection = getImportDeclarationCollection({
-      j,
-      collection,
-      importPath: imports.reactPackageName,
-    });
-
-    importDeclarationCollection.forEach((importDeclarationPath) => {
-      const importDefaultSpecifierCollection = j(importDeclarationPath).find(
-        j.ImportDefaultSpecifier
-      );
-      const importNamespaceSpecifierCollection = j(importDeclarationPath).find(
-        j.ImportNamespaceSpecifier
-      );
-
-      const hasNoDefaultReactImportDeclaration = importDefaultSpecifierCollection.length === 0;
-      const hasNoNamespaceReactImportDeclaration = importNamespaceSpecifierCollection.length === 0;
-
-      if (hasNoDefaultReactImportDeclaration && hasNoNamespaceReactImportDeclaration) {
-        importDeclarationPath.node.specifiers.unshift(
-          j.importDefaultSpecifier(j.identifier(imports.reactImportName))
-        );
-      }
-    });
-  }
 };
 
 const removeEmotionCoreJSXPragma = (j: core.JSCodeshift, collection: Collection) => {
@@ -76,7 +32,7 @@ const removeEmotionCoreJSXPragma = (j: core.JSCodeshift, collection: Collection)
     commentBlockCollection.forEach((commentBlockPath) => {
       j(commentBlockPath).remove();
 
-      addReactIdentifier(j, collection);
+      addReactIdentifier({ j, collection });
     });
   });
 };
@@ -116,76 +72,19 @@ const replaceEmotionCoreCSSTaggedTemplateExpression = (
     });
 };
 
-const addCommentBeforeUnresolvedIdentifiers = (j: core.JSCodeshift, collection: Collection) => {
-  const importDeclarationCollection = getImportDeclarationCollection({
+const mergeCompiledImportSpecifiers = (j: core.JSCodeshift, collection: Collection) => {
+  const allowedCompiledNames = [
+    imports.compiledStyledImportName,
+    ...Object.values(imports.emotionCoreImportNames),
+  ].filter(
+    (name) =>
+      ![imports.emotionCoreImportNames.jsx, imports.emotionCoreImportNames.css].includes(name)
+  );
+
+  mergeImportSpecifiersAlongWithTheirComments({
     j,
     collection,
-    importPath: imports.emotionCorePackageName,
-  });
-  const importSpecifiers = getAllImportSpecifiers({
-    j,
-    importDeclarationCollection,
-  });
-
-  const emotionCoreImportValues = Object.values(imports.emotionCoreImportNames);
-
-  importSpecifiers
-    .filter((identifierPath) => !emotionCoreImportValues.includes(identifierPath.name))
-    .forEach((importSpecifierPath) => {
-      collection.find(j.Identifier).some((identifierPath) => {
-        const name = identifierPath.node.name;
-
-        const isValidIdentiferFound = name === importSpecifierPath.name;
-
-        if (isValidIdentiferFound) {
-          addCommentToStartOfFile({
-            j,
-            collection,
-            message: `
-              "${name}" is not exported from "${imports.compiledPackageName}" at the moment. Please find an alternative for it.
-            `,
-          });
-
-          return true;
-        }
-
-        return false;
-      });
-    });
-};
-
-const removeEmotionCoreImportDeclaration = (j: core.JSCodeshift, collection: Collection) => {
-  const importDeclarationCollection = getImportDeclarationCollection({
-    j,
-    collection,
-    importPath: imports.emotionCorePackageName,
-  });
-
-  importDeclarationCollection.forEach((importDeclarationPath) => {
-    j(importDeclarationPath).remove();
-  });
-};
-
-const buildCompiledImportDeclaration = (j: core.JSCodeshift, collection: Collection) => {
-  const importDeclarationCollection = getImportDeclarationCollection({
-    j,
-    collection,
-    importPath: imports.emotionCorePackageName,
-  });
-
-  importDeclarationCollection.forEach((importDeclarationPath) => {
-    const oldNode = importDeclarationPath.node;
-    const { comments } = oldNode;
-
-    j(importDeclarationPath).replaceWith([
-      j.importDeclaration([], j.literal(imports.compiledPackageName)),
-    ]);
-
-    const newNode = importDeclarationPath.node;
-
-    if (newNode !== oldNode) {
-      newNode.comments = comments;
-    }
+    filter: (name) => !!(name && allowedCompiledNames.includes(name)),
   });
 };
 
@@ -208,25 +107,28 @@ const transformer = (fileInfo: FileInfo, { jscodeshift: j }: API, options: Optio
     return source;
   }
 
-  if (hasEmotionCoreImportDeclaration) {
-    removeEmotionCoreJSXPragma(j, collection);
-    addCommentBeforeUnresolvedIdentifiers(j, collection);
-    replaceEmotionCoreCSSTaggedTemplateExpression(j, collection);
-
-    hasEmotionStyledImportDeclaration
-      ? removeEmotionCoreImportDeclaration(j, collection)
-      : buildCompiledImportDeclaration(j, collection);
-  }
-
   if (hasEmotionStyledImportDeclaration) {
-    buildDefaultImportDeclaration({
+    convertDefaultImportToNamedImport({
       j,
       collection,
-      importPathFrom: imports.emotionStyledPackageName,
-      importPathTo: imports.compiledPackageName,
-      importPathToName: imports.compiledImportName,
+      importPath: imports.emotionStyledPackageName,
+      namedImport: imports.compiledStyledImportName,
     });
   }
+
+  if (hasEmotionCoreImportDeclaration) {
+    removeEmotionCoreJSXPragma(j, collection);
+    addCommentForUnresolvedImportSpecifiers({
+      j,
+      collection,
+      importPath: imports.emotionCorePackageName,
+      allowedImportSpecifierNames: Object.values(imports.emotionCoreImportNames),
+    });
+    replaceEmotionCoreCSSTaggedTemplateExpression(j, collection);
+    replaceImportDeclaration({ j, collection, importPath: imports.emotionCorePackageName });
+  }
+
+  mergeCompiledImportSpecifiers(j, collection);
 
   return collection.toSource(options.printOptions || { quote: 'single' });
 };

--- a/packages/react/src/codemods/styled-components-to-compiled/__tests__/styled-components-to-compiled.test.tsx
+++ b/packages/react/src/codemods/styled-components-to-compiled/__tests__/styled-components-to-compiled.test.tsx
@@ -82,6 +82,25 @@ describe('styled-components-to-compiled transformer', () => {
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
     {},
+    `
+    import styled, { css, keyframes, createGlobalStyle, ThemeProvider, withTheme } from 'styled-components';
+    import * as React from 'react';
+    `,
+    `
+    /* TODO(@compiled/react codemod): "css" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    /* TODO(@compiled/react codemod): "keyframes" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    /* TODO(@compiled/react codemod): "createGlobalStyle" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    /* TODO(@compiled/react codemod): "ThemeProvider" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    /* TODO(@compiled/react codemod): "withTheme" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    import { styled } from '@compiled/react';
+    import * as React from 'react';
+    `,
+    'it adds TODO comment for imports which are not resolved'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    {},
     "import * as React from 'react';",
     "import * as React from 'react';",
     'it should not transform when styled-components imports are not present'

--- a/packages/react/src/codemods/styled-components-to-compiled/styled-components-to-compiled.tsx
+++ b/packages/react/src/codemods/styled-components-to-compiled/styled-components-to-compiled.tsx
@@ -1,10 +1,13 @@
 import { FileInfo, API, Options } from 'jscodeshift';
 
-import { hasImportDeclaration, buildDefaultImportDeclaration } from '../codemods-helpers';
+import {
+  hasImportDeclaration,
+  convertDefaultImportToNamedImport,
+  addCommentForUnresolvedImportSpecifiers,
+} from '../codemods-helpers';
 
 const imports = {
-  compiledPackageName: '@compiled/react',
-  compiledImportName: 'styled',
+  compiledStyledImportName: 'styled',
   styledComponentsPackageName: 'styled-components',
 };
 
@@ -22,12 +25,18 @@ const transformer = (fileInfo: FileInfo, { jscodeshift: j }: API, options: Optio
     return source;
   }
 
-  buildDefaultImportDeclaration({
+  addCommentForUnresolvedImportSpecifiers({
     j,
     collection,
-    importPathFrom: imports.styledComponentsPackageName,
-    importPathTo: imports.compiledPackageName,
-    importPathToName: imports.compiledImportName,
+    importPath: imports.styledComponentsPackageName,
+    allowedImportSpecifierNames: [],
+  });
+
+  convertDefaultImportToNamedImport({
+    j,
+    collection,
+    importPath: imports.styledComponentsPackageName,
+    namedImport: imports.compiledStyledImportName,
   });
 
   return collection.toSource(options.printOptions || { quote: 'single' });


### PR DESCRIPTION
@madou: Just go through the test case once. Added TODO's for `ClassNames` props so that consumers can easily replace them. Also added logic for adding TODO's for missing `styled-components` api's. Did some cleanup too 😅 