### PR TITLE
fix: simplify interpolation handling

### DIFF
--- a/examples/styled-interpolation-function-behavior.tsx
+++ b/examples/styled-interpolation-function-behavior.tsx
@@ -58,3 +58,31 @@ export const TemplateLiteral = () => (
     hello world
   </FunctionStyledTemplateLiteral>
 );
+
+const HorizontalStack = styled.div<{ spacing?: number; gap?: number }>`
+  margin-top: ${(props) => props.spacing}rem;
+  margin-bottom: ${(props) => props.spacing}rem;
+  margin-right: ${(props) => props.gap}rem;
+
+  @media only screen and (min-width: 900px) {
+    && > * {
+      margin-right: ${(props) => props.gap}rem;
+
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+`;
+
+export const Stacking = () => (
+  <>
+    <div css={{ display: 'inline-block' }}>before</div>
+    <HorizontalStack gap={2} spacing={4}>
+      <div css={{ display: 'inline-block', color: 'red' }}>one</div>
+      <div css={{ display: 'inline-block', color: 'blue' }}>two</div>
+      <div css={{ display: 'inline-block', color: 'purple' }}>three</div>
+    </HorizontalStack>
+    <div css={{ display: 'inline-block' }}>after</div>
+  </>
+);

--- a/examples/styled-interpolation-function-behavior.tsx
+++ b/examples/styled-interpolation-function-behavior.tsx
@@ -79,9 +79,9 @@ export const Stacking = () => (
   <>
     <div css={{ display: 'inline-block' }}>before</div>
     <HorizontalStack gap={2} spacing={4}>
-      <div css={{ display: 'inline-block', color: 'red' }}>one</div>
-      <div css={{ display: 'inline-block', color: 'blue' }}>two</div>
-      <div css={{ display: 'inline-block', color: 'purple' }}>three</div>
+      <div css={{ display: 'inline-block', backgroundColor: 'red' }}>one</div>
+      <div css={{ display: 'inline-block', backgroundColor: 'blue' }}>two</div>
+      <div css={{ display: 'inline-block', backgroundColor: 'purple' }}>three</div>
     </HorizontalStack>
     <div css={{ display: 'inline-block' }}>after</div>
   </>

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
@@ -233,12 +233,12 @@ describe('styled component behaviour', () => {
       import { styled } from '@compiled/react';
 
       const ListItem = styled.div({
-        color: \`very$\{props => { return props.color; }}dark\`
+        content: \`"$\{props => { return props.color; }}"\`
       });
     `);
 
-    expect(actual).toInclude('{color:var(--_1poneq5)}');
-    expect(actual).toInclude('"--_1poneq5":"very"+(()=>{return props.color;})()+"dark"');
+    expect(actual).toInclude('{content:var(--_1poneq5)}');
+    expect(actual).toInclude('"--_1poneq5":"\\""+(()=>{return props.color;})()+"\\""');
   });
 
   it('should move suffix and prefix of a dynamic arrow function with a body into an IIFE by preventing passing down invalid html attributes to the node', () => {
@@ -246,13 +246,13 @@ describe('styled component behaviour', () => {
       import { styled } from '@compiled/react';
 
       const ListItem = styled.div({
-        fontSize: \`super$\{props => { return props.textSize; }}big\`
+        content: \`"$\{props => { return props.textSize; }}"\`
       });
     `);
 
-    expect(actual).toInclude('{font-size:var(--_1j0t240)}');
+    expect(actual).toInclude('{content:var(--_1j0t240)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--_1j0t240":"super"+(()=>{return textSize;})()+"big"');
+    expect(actual).toInclude('"--_1j0t240":"\\""+(()=>{return textSize;})()+"\\""');
   });
 
   it('should collect args as styles', () => {

--- a/packages/babel-plugin/src/styled/__tests__/string-literal.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/string-literal.test.tsx
@@ -152,12 +152,12 @@ describe('styled component string literal', () => {
         import { styled } from '@compiled/react';
 
         const ListItem = styled.div\`
-          color: very$\{props => { return props.color; }}dark;
+          content: "$\{props => { return props.color; }}";
         \`;
       `);
 
-    expect(actual).toInclude('{color:var(--_1poneq5)}');
-    expect(actual).toInclude('"--_1poneq5":"very"+(()=>{return props.color;})()+"dark"');
+    expect(actual).toInclude('{content:var(--_1poneq5)}');
+    expect(actual).toInclude('"--_1poneq5":"\\""+(()=>{return props.color;})()+"\\""');
   });
 
   it('should move suffix and prefix of a dynamic arrow function with a body into an IIFE by preventing passing down invalid html attributes to the node', () => {
@@ -165,13 +165,13 @@ describe('styled component string literal', () => {
         import { styled } from '@compiled/react';
 
         const ListItem = styled.div\`
-          font-size: super$\{props => { return props.textSize; }}big;
+          content: "$\{props => { return props.textSize; }}";
         \`;
       `);
 
-    expect(actual).toInclude('{font-size:var(--_1j0t240)}');
+    expect(actual).toInclude('{content:var(--_1j0t240)}');
     expect(actual).toInclude('({as:C="div",style,textSize,...props},ref)');
-    expect(actual).toInclude('"--_1j0t240":"super"+(()=>{return textSize;})()+"big"');
+    expect(actual).toInclude('"--_1j0t240":"\\""+(()=>{return textSize;})()+"\\""');
   });
 
   it('should transform template string literal with obj variable', () => {
@@ -313,11 +313,11 @@ describe('styled component string literal', () => {
         import { styled } from '@compiled/react';
 
         const ListItem = styled.div\`
-          font-size: super$\{props => props.color}big;
+          content: "$\{props => props.color}";
         \`;
       `);
 
-    expect(actual).toInclude('"--_1p69eoh":"super"+props.color+"big"');
+    expect(actual).toInclude('"--_1p69eoh":"\\""+props.color+"\\""');
   });
 
   it('should move any prefix of a dynamic arrow func property into the style property', () => {
@@ -325,11 +325,11 @@ describe('styled component string literal', () => {
         import { styled } from '@compiled/react';
 
         const ListItem = styled.div\`
-          font-size: super$\{props => props.color};
+          content: "$\{props => props.color}";
         \`;
       `);
 
-    expect(actual).toInclude('"--_1p69eoh":"super"+props.color');
+    expect(actual).toInclude('"--_1p69eoh":"\\""+props.color+"\\""');
   });
 
   it('should move any suffix of a dynamic arrow func property into the style property', () => {
@@ -337,11 +337,11 @@ describe('styled component string literal', () => {
         import { styled } from '@compiled/react';
 
         const ListItem = styled.div\`
-          font-size: $\{props => props.color}big;
+          font-size: $\{props => props.color}px;
         \`;
       `);
 
-    expect(actual).toInclude('"--_1p69eoh":props.color+"big"');
+    expect(actual).toInclude('"--_1p69eoh":props.color+"px"');
   });
 
   it('should move suffix and prefix of a dynamic property into the style property', () => {
@@ -352,13 +352,13 @@ describe('styled component string literal', () => {
         color = 'blue';
 
         const ListItem = styled.div\`
-          font-size: super$\{color}big;
+          content: "$\{color}";
           color: red;
         \`;
       `);
 
-    expect(actual).toInclude('{font-size:var(--_1ylxx6h)}');
-    expect(actual).toInclude('"--_1ylxx6h":"super"+color+"big"');
+    expect(actual).toInclude('{content:var(--_1ylxx6h)}');
+    expect(actual).toInclude('"--_1ylxx6h":"\\""+color+"\\""');
   });
 
   it('should do nothing with suffix/prefix when referencing constant literal', () => {
@@ -367,12 +367,12 @@ describe('styled component string literal', () => {
 
         const color = 'red';
         const ListItem = styled.div\`
-          font-size: super$\{color}big;
+          content: "$\{color}";
           color: red;
         \`;
       `);
 
-    expect(actual).toInclude('{font-size:superredbig}');
+    expect(actual).toInclude('{content:\\"red\\"}');
   });
 
   it('should transform template string with no argument function variable', () => {

--- a/packages/css/src/utils/__tests__/string-iterpolations.test.tsx
+++ b/packages/css/src/utils/__tests__/string-iterpolations.test.tsx
@@ -26,7 +26,7 @@ describe('template literal to css', () => {
       const extract = cssAfterInterpolation(simpleParts[1]);
 
       expect(extract.variableSuffix).toEqual('px');
-      expect(extract.css).toEqual('!important;');
+      expect(extract.css).toEqual(' !important;');
     });
 
     it('should ignore a space as prefix', () => {
@@ -221,23 +221,23 @@ describe('template literal to css', () => {
     });
 
     it('should move whole prefix out', () => {
-      const simpleParts = ['font-size: super', 'big;'];
+      const simpleParts = ['font-size: "', 'big;'];
 
       const extract = cssBeforeInterpolation(simpleParts[0]);
 
-      expect(extract.variablePrefix).toEqual('super');
+      expect(extract.variablePrefix).toEqual('"');
       expect(extract.css).toEqual('font-size: ');
     });
   });
 
   describe('interpolations without surrounding css', () => {
     it('should extract the suffix with not prefix', () => {
-      const simpleParts = ['px'];
+      const simpleParts = ['px;'];
 
       const extract = cssAfterInterpolation(simpleParts[0]);
 
       expect(extract.variableSuffix).toEqual('px');
-      expect(extract.css).toEqual('');
+      expect(extract.css).toEqual(';');
     });
 
     it('should extract the prefix of a simple template literal', () => {
@@ -250,20 +250,20 @@ describe('template literal to css', () => {
     });
 
     it('should extract the suffix of a simple template literal', () => {
-      const simpleParts = ['"', '"'];
+      const simpleParts = ['"', '";'];
 
       const extract = cssAfterInterpolation(simpleParts[1]);
 
       expect(extract.variableSuffix).toEqual('"');
-      expect(extract.css).toEqual('');
+      expect(extract.css).toEqual(';');
     });
 
     it('should move whole prefix out', () => {
-      const simpleParts = ['super', 'big;'];
+      const simpleParts = ['"', 'big;'];
 
       const extract = cssBeforeInterpolation(simpleParts[0]);
 
-      expect(extract.variablePrefix).toEqual('super');
+      expect(extract.variablePrefix).toEqual('"');
       expect(extract.css).toEqual('');
     });
 

--- a/packages/css/src/utils/css-property.tsx
+++ b/packages/css/src/utils/css-property.tsx
@@ -45,6 +45,62 @@ const unitless = {
   strokeWidth: true,
 };
 
+// https://www.w3.org/TR/css-values-4/
+export const units = [
+  // font relative lengths
+  'em',
+  'ex',
+  'cap',
+  'ch',
+  'ic',
+  'rem',
+  'lh',
+  'rlh',
+
+  // viewport percentage lengths
+  'vw',
+  'vh',
+  'vi',
+  'vb',
+  'vmin',
+  'vmax',
+
+  // absolute lengths
+  'cm',
+  'mm',
+  'Q',
+  'in',
+  'pc',
+  'pt',
+  'px',
+
+  // angle units
+  'deg',
+  'grad',
+  'rad',
+  'turn',
+
+  // duration units
+  's',
+  'ms',
+
+  // frequency units
+  'Hz',
+  'kHz',
+
+  // resolution units
+  'dpi',
+  'dpcm',
+  'dppx',
+  'x',
+
+  // https://www.w3.org/TR/css-grid-1/#fr-unit
+  'fr',
+
+  // percentages
+  '%',
+];
+
 const isUnitlessProperty = (propertyName: string): boolean => {
   return propertyName in unitless;
 };

--- a/packages/css/src/utils/string-interpolations.tsx
+++ b/packages/css/src/utils/string-interpolations.tsx
@@ -11,9 +11,13 @@ export interface BeforeInterpolation {
 }
 
 /**
- * Will remove any suffix out of the CSS and return them both.
+ * Will remove any valid suffix out of the CSS and return them both.
+ * Handles both terminated and un-terminated CSS.
  *
- * E.g. `'px;font-size: 20px;'` would return `"px"` as the suffix and `";font-size: 20px;"` as the CSS.
+ * Some examples:
+ * - `'px;font-size: 20px;'` would return `"px"` as the suffix and `";font-size: 20px;"` as the CSS.
+ * - `'"'` would return `'"'` as the suffix and `''` as the CSS.
+ * - `'notasuffix;'` would return `''` as the suffix and `'notasuffix;'` as the CSS.
  *
  * @param css all the CSS after the interpolation
  */
@@ -35,7 +39,13 @@ export const cssAfterInterpolation = (css: string): AfterInterpolation => {
 };
 
 /**
- * Will extract any prefix out of the CSS and return them both.
+ * Will extract any valid prefix out of the CSS and return them both.
+ * Handles both CSS with and without a property key.
+ *
+ * Some examples:
+ * - `'"'` would return `'"'` as the suffix and `''` as the CSS.
+ * - `'font-size: -` would return `'-'` as the suffix and `'font-size: '` as the CSS.
+ * - `'color: blue'` would return `''` as the suffix and `'color: blue'` as the CSS.
  *
  * @param css all the CSS before the interpolation
  */

--- a/packages/css/src/utils/string-interpolations.tsx
+++ b/packages/css/src/utils/string-interpolations.tsx
@@ -1,8 +1,4 @@
-/**
- * PLEASE WE SHOULD RE-WRITE THIS MODULE.
- * It's currently a bunch of string slicing, regex, and BS.
- * Potentially we can delete this whole module and extract the prefix/suffix in the CSS transform step instead.
- */
+import { units } from './css-property';
 
 export interface AfterInterpolation {
   css: string;
@@ -15,43 +11,25 @@ export interface BeforeInterpolation {
 }
 
 /**
- * Will return any suffix out of the CSS and return them both.
+ * Will remove any suffix out of the CSS and return them both.
  *
  * E.g. `'px;font-size: 20px;'` would return `"px"` as the suffix and `";font-size: 20px;"` as the CSS.
  *
  * @param css all the CSS after the interpolation
  */
 export const cssAfterInterpolation = (css: string): AfterInterpolation => {
-  let variableSuffix = '';
+  const regex = new RegExp(`^(${units.join('|')}|"|')(;|,|\n| |\\))?`);
+  const result = regex.exec(css);
 
-  if (css.includes('(') || css[0] === ' ' || css[0] === '\n' || css[0] === ';' || css[0] === ',') {
-    css = css;
-  } else {
-    let cssIndex;
-    // when calc property used, we get ')' along with unit in the 'literal' object
-    // Eg. `marginLeft: calc(100% - ${obj.key}rem)` will give ')rem' in the span literal
-    if (css.indexOf(')') !== -1) {
-      cssIndex = css.indexOf(')');
-    } else if (css.indexOf('!important') !== -1) {
-      cssIndex = css.indexOf('!important');
-    } else if (css.indexOf(';') !== -1) {
-      cssIndex = css.indexOf(';');
-    } else if (css.indexOf(',') !== -1) {
-      cssIndex = css.indexOf(',');
-    } else if (css.indexOf('\n') !== -1) {
-      cssIndex = css.indexOf('\n');
-    } else if (css.indexOf(' ') !== -1) {
-      cssIndex = css.indexOf(' ');
-    } else {
-      cssIndex = css.length;
-    }
-
-    variableSuffix = css.slice(0, cssIndex).trim();
-    css = css.slice(cssIndex);
+  if (result) {
+    return {
+      variableSuffix: result[1],
+      css: css.replace(result[1], ''),
+    };
   }
 
   return {
-    variableSuffix,
+    variableSuffix: '',
     css,
   };
 };
@@ -62,39 +40,17 @@ export const cssAfterInterpolation = (css: string): AfterInterpolation => {
  * @param css all the CSS before the interpolation
  */
 export const cssBeforeInterpolation = (css: string): BeforeInterpolation => {
-  const trimCss = css.trim();
-  if (
-    trimCss[trimCss.length - 1] === '(' ||
-    trimCss[0] === ',' ||
-    trimCss[trimCss.length - 1] === ',' ||
-    css[css.length - 1] === ' '
-  ) {
-    // We are inside a css like "translateX(".
-    // There is no prefix we need to extract here.
-    return {
-      css: css,
-      variablePrefix: '',
-    };
-  }
+  const lastCharacter = css[css.length - 1];
 
-  if (!css.match(/:|;/) && !css.includes('(') && !css.includes(' ')) {
+  if (['"', "'", '-'].includes(lastCharacter)) {
     return {
-      variablePrefix: css,
-      css: '',
+      variablePrefix: lastCharacter,
+      css: css.slice(0, -1),
     };
-  }
-
-  // Grab any prefix that is before the end of the string
-  // E.g. "margin: 0 -" will match " -".
-  let variablePrefix: string = css.match(/ +.$/)?.[0] || css.match(/:(.+$)/)?.[1] || '';
-  if (variablePrefix) {
-    variablePrefix = variablePrefix.trim();
-    const lastIndex = css.lastIndexOf(variablePrefix);
-    css = css.slice(0, lastIndex);
   }
 
   return {
+    variablePrefix: '',
     css,
-    variablePrefix,
   };
 };

--- a/packages/react/src/styled/index.tsx
+++ b/packages/react/src/styled/index.tsx
@@ -3,7 +3,7 @@ import { createSetupError } from '../utils/error';
 import { CssFunction, BasicTemplateInterpolations } from '../types';
 
 export interface FunctionIterpolation<TProps> {
-  (props: TProps): string | number;
+  (props: TProps): string | number | undefined;
 }
 
 /**

--- a/packages/react/src/types.tsx
+++ b/packages/react/src/types.tsx
@@ -18,4 +18,5 @@ export type CssFunction<TValue = void> =
   | CSSProps
   | AnyKeyCssProps<TValue>
   | TemplateStringsArray
-  | string;
+  | string
+  | undefined;


### PR DESCRIPTION
This PR simplifies the interpolation handling by making more assumptions, and handling only things that would actually happen. Obviously invalid suffix/prefixes and the like are now unsupported.

Closes https://github.com/atlassian-labs/compiled/issues/413 
Closes https://github.com/atlassian-labs/compiled/issues/345