### PR TITLE
chore: bumps typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "@storybook/react": "^5.3.18",
     "@types/jest": "25.2.1",
     "@types/node": "13.11.1",
-    "@typescript-eslint/eslint-plugin": "^2.30.0",
-    "@typescript-eslint/parser": "^2.30.0",
+    "@typescript-eslint/eslint-plugin": "^4.11.0",
+    "@typescript-eslint/parser": "^4.11.0",
     "babel-loader": "^8.1.0",
     "chromatic": "^5.1.0",
     "eslint": "^6.8.0",
@@ -68,8 +68,11 @@
     "ts-node": "8.9.1",
     "ts-transform-define": "^0.1.3",
     "ttypescript": "^1.5.10",
-    "typescript": "^3.7.3",
+    "typescript": "^4.1.3",
     "workspaces-run": "^1.0.1"
+  },
+  "resolutions": {
+    "typescript": ">= 4.0.0"
   },
   "husky": {
     "hooks": {

--- a/packages/babel-plugin/src/utils/ast.tsx
+++ b/packages/babel-plugin/src/utils/ast.tsx
@@ -11,7 +11,7 @@ import { Metadata } from '../types';
  * @param node
  * @param parentPath
  */
-export const getPathOfNode = <TNode extends {}>(
+export const getPathOfNode = <TNode extends Record<string, unknown>>(
   node: TNode,
   parentPath: NodePath
 ): NodePath<TNode> => {

--- a/packages/babel-plugin/src/utils/ast.tsx
+++ b/packages/babel-plugin/src/utils/ast.tsx
@@ -11,7 +11,7 @@ import { Metadata } from '../types';
  * @param node
  * @param parentPath
  */
-export const getPathOfNode = <TNode extends Record<string, unknown>>(
+export const getPathOfNode = <TNode extends unknown>(
   node: TNode,
   parentPath: NodePath
 ): NodePath<TNode> => {

--- a/packages/cli/src/isRunningInTsNode.tsx
+++ b/packages/cli/src/isRunningInTsNode.tsx
@@ -6,7 +6,7 @@ const REGISTER_INSTANCE = Symbol.for('ts-node.register.instance');
 declare global {
   namespace NodeJS {
     interface Process {
-      [REGISTER_INSTANCE]?: object;
+      [REGISTER_INSTANCE]?: Record<string, unknown>;
     }
   }
 }

--- a/packages/jest/src/matchers.tsx
+++ b/packages/jest/src/matchers.tsx
@@ -112,6 +112,7 @@ export function toHaveCompiledCss(
     // This is a hack to get ahold of the styles.
     // Unfortunately JSDOM doesn't handle css variables properly
     // See: https://github.com/jsdom/jsdom/issues/1895
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const styles = element[Object.keys(element)[0]].memoizedProps.style;
 

--- a/packages/react/src/codemods/emotion-to-compiled/__tests__/emotion-to-compiled.test.tsx
+++ b/packages/react/src/codemods/emotion-to-compiled/__tests__/emotion-to-compiled.test.tsx
@@ -1,5 +1,6 @@
 jest.disableAutomock();
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const defineInlineTest = require('jscodeshift/dist/testUtils').defineInlineTest;
 
 import transformer from '../emotion-to-compiled';

--- a/packages/react/src/codemods/styled-components-to-compiled/__tests__/styled-components-to-compiled.test.tsx
+++ b/packages/react/src/codemods/styled-components-to-compiled/__tests__/styled-components-to-compiled.test.tsx
@@ -1,5 +1,6 @@
 jest.disableAutomock();
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const defineInlineTest = require('jscodeshift/dist/testUtils').defineInlineTest;
 
 import transformer from '../styled-components-to-compiled';

--- a/packages/react/src/styled/__tests__/index.test.tsx
+++ b/packages/react/src/styled/__tests__/index.test.tsx
@@ -198,7 +198,7 @@ describe('styled component', () => {
   });
 
   it('should compose a component using template literal', () => {
-    const Div = (props: {}) => <div {...props} />;
+    const Div = (props: Record<string, unknown>) => <div {...props} />;
     const StyledDiv = styled(Div)`
       font-size: 12px;
     `;
@@ -224,7 +224,7 @@ describe('styled component', () => {
   });
 
   it('should compose a component using object literal', () => {
-    const Div = (props: {}) => <div {...props} />;
+    const Div = (props: Record<string, unknown>) => <div {...props} />;
     const StyledDiv = styled(Div)({
       fontSize: 12,
     });

--- a/packages/react/src/styled/index.tsx
+++ b/packages/react/src/styled/index.tsx
@@ -18,7 +18,7 @@ export interface StyledProps {
   as?: keyof JSX.IntrinsicElements;
 }
 
-export type Interpolations<TProps extends {}> = (
+export type Interpolations<TProps extends Record<string, unknown>> = (
   | BasicTemplateInterpolations
   | FunctionIterpolation<TProps>
   | CssObject<TProps>
@@ -31,15 +31,15 @@ export type Interpolations<TProps extends {}> = (
  * props from `StyledProps`.
  */
 export interface StyledFunctionFromTag<TTag extends keyof JSX.IntrinsicElements> {
-  <TProps extends {}>(
+  <TProps extends Record<string, unknown>>(
     // Allows either string or object (`` or ({}))
     css: CssObject<TProps> | CssObject<TProps>[],
     ...interpoltations: Interpolations<TProps>
   ): React.ComponentType<TProps & JSX.IntrinsicElements[TTag] & StyledProps>;
 }
 
-export interface StyledFunctionFromComponent<TInheritedProps extends {}> {
-  <TProps extends {}>(
+export interface StyledFunctionFromComponent<TInheritedProps extends Record<string, unknown>> {
+  <TProps extends Record<string, unknown>>(
     // Allows either string or object (`` or ({}))
     css: CssObject<TProps> | TemplateStringsArray,
     ...interpoltations: Interpolations<TProps>
@@ -55,7 +55,7 @@ export interface StyledComponentInstantiator extends StyledComponentMap {
   /**
    * Typing to enable consumers to compose components, e.g: `styled(Component)`
    */
-  <TInheritedProps extends {}>(
+  <TInheritedProps extends Record<string, unknown>>(
     Component: ComponentType<TInheritedProps>
   ): StyledFunctionFromComponent<TInheritedProps>;
 }

--- a/packages/utils/src/array.tsx
+++ b/packages/utils/src/array.tsx
@@ -5,7 +5,7 @@
  * @param arr
  * @param getId
  */
-export const unique = <TArrItem extends {}>(
+export const unique = <TArrItem extends Record<string, unknown>>(
   arr: TArrItem[],
   getId: (item: TArrItem) => any = (item) => item
 ): TArrItem[] => {
@@ -25,6 +25,6 @@ export const unique = <TArrItem extends {}>(
  *
  * @param arrays
  */
-export const flatten = <TArr extends {}>(...arrays: TArr[][]): TArr[] => {
+export const flatten = <TArr extends Record<string, unknown>>(...arrays: TArr[][]): TArr[] => {
   return arrays.reduce((acc, arr) => acc.concat(arr), []);
 };

--- a/packages/utils/src/array.tsx
+++ b/packages/utils/src/array.tsx
@@ -5,7 +5,7 @@
  * @param arr
  * @param getId
  */
-export const unique = <TArrItem extends Record<string, unknown>>(
+export const unique = <TArrItem extends unknown>(
   arr: TArrItem[],
   getId: (item: TArrItem) => any = (item) => item
 ): TArrItem[] => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2273,11 +2273,6 @@
   dependencies:
     postcss "5 - 7"
 
-"@types/eslint-visitor-keys@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
-  integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
-
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -2519,48 +2514,75 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^2.30.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz#6f8ce8a46c7dea4a6f1d171d2bb8fbae6dac2be9"
-  integrity sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==
+"@typescript-eslint/eslint-plugin@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.11.0.tgz#bc6c1e4175c0cf42083da4314f7931ad12f731cc"
+  integrity sha512-x4arJMXBxyD6aBXLm3W7mSDZRiABzy+2PCLJbL7OPqlp53VXhaA1HKK7R2rTee5OlRhnUgnp8lZyVIqjnyPT6g==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.34.0"
+    "@typescript-eslint/experimental-utils" "4.11.0"
+    "@typescript-eslint/scope-manager" "4.11.0"
+    debug "^4.1.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
+    semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz#d3524b644cdb40eebceca67f8cf3e4cc9c8f980f"
-  integrity sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==
+"@typescript-eslint/experimental-utils@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.11.0.tgz#d1a47cc6cfe1c080ce4ead79267574b9881a1565"
+  integrity sha512-1VC6mSbYwl1FguKt8OgPs8xxaJgtqFpjY/UzUYDBKq4pfQ5lBvN2WVeqYkzf7evW42axUHYl2jm9tNyFsb8oLg==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.34.0"
+    "@typescript-eslint/scope-manager" "4.11.0"
+    "@typescript-eslint/types" "4.11.0"
+    "@typescript-eslint/typescript-estree" "4.11.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^2.30.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.34.0.tgz#50252630ca319685420e9a39ca05fe185a256bc8"
-  integrity sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==
+"@typescript-eslint/parser@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.11.0.tgz#1dd3d7e42708c10ce9f3aa64c63c0ab99868b4e2"
+  integrity sha512-NBTtKCC7ZtuxEV5CrHUO4Pg2s784pvavc3cnz6V+oJvVbK4tH9135f/RBP6eUA2KHiFKAollSrgSctQGmHbqJQ==
   dependencies:
-    "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.34.0"
-    "@typescript-eslint/typescript-estree" "2.34.0"
-    eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.34.0":
-  version "2.34.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz#14aeb6353b39ef0732cc7f1b8285294937cf37d5"
-  integrity sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==
-  dependencies:
+    "@typescript-eslint/scope-manager" "4.11.0"
+    "@typescript-eslint/types" "4.11.0"
+    "@typescript-eslint/typescript-estree" "4.11.0"
     debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
+
+"@typescript-eslint/scope-manager@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.11.0.tgz#2d906537db8a3a946721699e4fc0833810490254"
+  integrity sha512-6VSTm/4vC2dHM3ySDW9Kl48en+yLNfVV6LECU8jodBHQOhO8adAVizaZ1fV0QGZnLQjQ/y0aBj5/KXPp2hBTjA==
+  dependencies:
+    "@typescript-eslint/types" "4.11.0"
+    "@typescript-eslint/visitor-keys" "4.11.0"
+
+"@typescript-eslint/types@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.11.0.tgz#86cf95e7eac4ccfd183f9fcf1480cece7caf4ca4"
+  integrity sha512-XXOdt/NPX++txOQHM1kUMgJUS43KSlXGdR/aDyEwuAEETwuPt02Nc7v+s57PzuSqMbNLclblQdv3YcWOdXhQ7g==
+
+"@typescript-eslint/typescript-estree@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.0.tgz#1144d145841e5987d61c4c845442a24b24165a4b"
+  integrity sha512-eA6sT5dE5RHAFhtcC+b5WDlUIGwnO9b0yrfGa1mIOIAjqwSQCpXbLiFmKTdRbQN/xH2EZkGqqLDrKUuYOZ0+Hg==
+  dependencies:
+    "@typescript-eslint/types" "4.11.0"
+    "@typescript-eslint/visitor-keys" "4.11.0"
+    debug "^4.1.1"
+    globby "^11.0.1"
     is-glob "^4.0.1"
     lodash "^4.17.15"
     semver "^7.3.2"
     tsutils "^3.17.1"
+
+"@typescript-eslint/visitor-keys@4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.0.tgz#906669a50f06aa744378bb84c7d5c4fdbc5b7d51"
+  integrity sha512-tRYKyY0i7cMk6v4UIOCjl1LhuepC/pc6adQqJk4Is3YcC6k46HvsV9Wl7vQoLbm9qADgeujiT7KdLrylvFIQ+A==
+  dependencies:
+    "@typescript-eslint/types" "4.11.0"
+    eslint-visitor-keys "^2.0.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -5906,6 +5928,11 @@ eslint-visitor-keys@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^6.8.0:
   version "6.8.0"
@@ -14122,10 +14149,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.0, typescript@^3.7.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+"typescript@>= 4.0.0", typescript@^3.7.0, typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
 
 unfetch@^4.1.0:
   version "4.2.0"


### PR DESCRIPTION
When we did #349 we didn't upgrade typescript - so the examples were type erroring (but didn't break builds because it didn't typecheck during storybook build).

This upgrades TS to 4.1 to add in the new jsx behaviour.