### PR TITLE
BREAKING CHANGE: removes babel plugin from react pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ const StyledButton = styled.button`
 Install the React package:
 
 ```bash
-npm install @compiled/react
+npm install @compiled/react @compiled/babel-plugin
 ```
 
 Configure [Babel](https://babeljs.io/docs/en/config-files):
 
 ```json
 {
-  "plugins": ["@compiled/react/babel-plugin"]
+  "plugins": ["@compiled/babel-plugin"]
 }
 ```
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: [['@compiled/react/babel-plugin', { nonce: '"k0Mp1lEd"', importReact: false }]],
+  plugins: [['@compiled/babel-plugin', { nonce: '"k0Mp1lEd"', importReact: false }]],
   presets: [
     ['@babel/preset-env', { targets: { node: 'current' } }],
     '@babel/preset-typescript',

--- a/examples/ssr/.babelrc
+++ b/examples/ssr/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["razzle/babel"],
-  "plugins": ["@compiled/react/babel-plugin"]
+  "plugins": ["@compiled/babel-plugin"]
 }

--- a/packages/react/babel-plugin/README.md
+++ b/packages/react/babel-plugin/README.md
@@ -1,5 +1,0 @@
-# @compiled/react/babel-plugin
-
-This folder and `package.json` exists to add another entry point to `@compiled/react`.
-When the `exports` property is more widely used we can remove this (we've currently defined it in `package.json`,
-but it won't do much on node versions that don't support it).

--- a/packages/react/babel-plugin/package.json
+++ b/packages/react/babel-plugin/package.json
@@ -1,5 +1,0 @@
-{
-  "main": "../dist/cjs/babel-plugin.js",
-  "module": "../dist/esm/babel-plugin.js",
-  "types": "../dist/esm/babel-plugin.d.ts"
-}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -45,7 +45,6 @@
     "README.md"
   ],
   "dependencies": {
-    "@compiled/babel-plugin": "0.5.3",
     "csstype": "^3.0.6"
   },
   "peerDependencies": {

--- a/packages/react/src/babel-plugin.tsx
+++ b/packages/react/src/babel-plugin.tsx
@@ -1,1 +1,0 @@
-module.exports = require('@compiled/babel-plugin');

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -17,5 +17,5 @@
     ],
     "tsBuildInfoFile": "tsconfig.esm.tsbuildinfo"
   },
-  "references": [{ "path": "../babel-plugin" }]
+  "references": []
 }

--- a/test/test-imports.js
+++ b/test/test-imports.js
@@ -1,3 +1,3 @@
 require('@compiled/react');
 require('@compiled/react/runtime');
-require('@compiled/react/babel-plugin');
+require('@compiled/babel-plugin');


### PR DESCRIPTION
**BREAKING CHANGE**

Removes babel plugin entrypoint from the react package. This will be a minor version bump (in our case, breaking because we are `v0.x.x`.

Closes #493 
Closes #484

**TODO**

- [ ] Update website with new consumption info