### PR TITLE
fix: fixes transform parsing not using local config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Run import test
         run: yarn test:imports
 
+      - name: Build webpack example
+        run: yarn build:webpack-example
+
       - name: Bundle size
         run: |
           GITHUB_RUN_NUMBER_TMP=GITHUB_RUN_NUMBER && export GITHUB_RUN_NUMBER=1;

--- a/examples/packages/webpack/src/app.js
+++ b/examples/packages/webpack/src/app.js
@@ -1,7 +1,12 @@
-import * as React from 'react';
 import '@compiled/react';
 import { primary } from './module';
+import HelloWorld from './component';
 
 export default function Home() {
-  return <div css={{ fontSize: 50, color: primary }}>hello from webpack</div>;
+  return (
+    <>
+      <div css={{ fontSize: 50, color: primary }}>hello from webpack</div>
+      <HelloWorld>TypeScript component</HelloWorld>
+    </>
+  );
 }

--- a/examples/packages/webpack/src/component.tsx
+++ b/examples/packages/webpack/src/component.tsx
@@ -1,0 +1,11 @@
+import { styled } from '@compiled/react';
+import { primary } from './module';
+
+const HelloWorld = styled.div`
+  color: ${primary};
+  font-weight: 500;
+`;
+
+export default function TSComponent(props: { children: string }) {
+  return <HelloWorld>{props.children}</HelloWorld>;
+}

--- a/examples/packages/webpack/src/index.js
+++ b/examples/packages/webpack/src/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { hydrate } from 'react-dom';
 import App from './app';
 

--- a/examples/packages/webpack/webpack.config.js
+++ b/examples/packages/webpack/webpack.config.js
@@ -10,24 +10,23 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js',
   },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.json', '.js'],
+  },
   module: {
     rules: [
       {
-        test: /\.js$/,
+        test: /\.(js|ts|tsx)$/,
         exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader',
-        },
-      },
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: {
-          loader: '@compiled/webpack-loader',
-          options: {
-            importReact: false,
+        use: [
+          { loader: 'babel-loader' },
+          {
+            loader: '@compiled/webpack-loader',
+            options: {
+              importReact: false,
+            },
           },
-        },
+        ],
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:browser": "IS_NODE_EXPRESSION='false' ttsc --build packages/tsconfig.browser.json",
     "build:dead-code-elimination": "cd test/dead-code-elimination && ttsc",
     "build:inspect": "node --inspect-brk node_modules/typescript/lib/tsc.js --build packages",
+    "build:webpack-example": "yarn build:browser && yarn build:esm && cd examples/packages/webpack && yarn build",
     "build-storybook": "build-storybook",
     "build-ssr": "CI=false && yarn build && cd examples/packages/ssr && yarn build",
     "preversion": "git-branch-is master && yarn clean && yarn build && yarn test",

--- a/packages/babel-plugin/src/transform.tsx
+++ b/packages/babel-plugin/src/transform.tsx
@@ -1,4 +1,4 @@
-import { transformAsync as babelTransformAsync } from '@babel/core';
+import { transformFromAstAsync, parseAsync } from '@babel/core';
 import { unique } from '@compiled/utils';
 import babelPlugin from './babel-plugin';
 import type { TransformResult, PluginOptions } from './types';
@@ -17,7 +17,14 @@ interface TransformOpts {
 export async function transformAsync(code: string, opts: TransformOpts): Promise<TransformResult> {
   const includedFiles: string[] = [];
 
-  const result = await babelTransformAsync(code, {
+  // Transform to an AST using the local babel config.
+  const ast = await parseAsync(code, {
+    filename: opts.filename,
+    caller: { name: 'compiled' },
+  });
+
+  // Transform using the Compiled Babel Plugin - we deliberately turn off using the local config.
+  const result = await transformFromAstAsync(ast!, code, {
     babelrc: false,
     configFile: false,
     filename: opts.filename,


### PR DESCRIPTION
This ensures when parsing code it will use the local babel config - meaning TypeScript and Flow work.