### PR TITLE
fix: style duplication issue #388

### DIFF
--- a/.changeset/rotten-zebras-film.md
+++ b/.changeset/rotten-zebras-film.md
@@ -1,0 +1,5 @@
+---
+"@compiled/react": patch
+---
+
+Styles that were SSR'd are no longer duplicated on the client

--- a/examples/packages/ssr/src/app.js
+++ b/examples/packages/ssr/src/app.js
@@ -11,6 +11,9 @@ const Header = () => (
       height: 56,
       display: 'flex',
       alignItems: 'center',
+      '@media only screen and (max-width:1100px)': {
+        background: 'green',
+      },
     }}>
     server side rendering
   </header>

--- a/examples/packages/ssr/src/app.js
+++ b/examples/packages/ssr/src/app.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import '@compiled/react';
+import { SSRCacheComponent } from '@compiled/react/runtime';
 
 const Footer = () => <footer css={{ background: 'purple', padding: 8 * 4 }}>footer</footer>;
 
@@ -19,16 +20,25 @@ const Header = () => (
   </header>
 );
 
+const Button = ({ count, setCount }) => (
+  <button css={{ background: 'white', borderRadius: 3 }} onClick={() => setCount((count += 1))}>
+    Count {count}
+  </button>
+);
+
 const Content = () => (
   <main css={{ padding: 8 * 4, height: '200vh', background: 'blue' }}>content</main>
 );
 
 export default function Home() {
+  const [count, setCount] = React.useState(0);
   return (
     <div css={{ fontSize: '100%' }}>
       <Header />
+      <Button count={count} setCount={setCount} />
       <Content />
       <Footer />
+      <SSRCacheComponent />
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime.js",
-      "limit": "445B",
+      "limit": "599B",
       "import": "{ CC, CS }",
       "ignore": [
         "react"

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime.js",
-      "limit": "585B",
+      "limit": "538B",
       "import": "{ CC, CS }",
       "ignore": [
         "react"

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime.js",
-      "limit": "599B",
+      "limit": "585B",
       "import": "{ CC, CS }",
       "ignore": [
         "react"

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime.js",
-      "limit": "538B",
+      "limit": "729B",
       "import": "{ CC, CS }",
       "ignore": [
         "react"

--- a/packages/react/src/__tests__/browser.test.tsx
+++ b/packages/react/src/__tests__/browser.test.tsx
@@ -42,7 +42,7 @@ describe('browser', () => {
     );
 
     expect(document.head.innerHTML).toMatchInlineSnapshot(
-      `"<style nonce=\\"k0Mp1lEd\\">._1wybdlk8{font-size:14px}</style>"`
+      `"<style data-cmpld=\\"h\\" nonce=\\"k0Mp1lEd\\">._1wybdlk8{font-size:14px}</style>"`
     );
   });
 
@@ -95,13 +95,13 @@ describe('browser', () => {
     render(<StyledLink href="https://atlassian.design">Atlassian Design System</StyledLink>);
 
     expect(document.head.innerHTML.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
-      "<style nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}._1wyb12am{font-size:50px}._syaz1cnh{color:purple}._v0vw1x77:focus-visible, ._ysv71x77:link{color:white}</style>
-      <style nonce=\\"k0Mp1lEd\\">._ysv75scu:link{color:red}</style>
-      <style nonce=\\"k0Mp1lEd\\">._105332ev:visited{color:pink}</style>
-      <style nonce=\\"k0Mp1lEd\\">._f8pjbf54:focus{color:green}</style>
-      <style nonce=\\"k0Mp1lEd\\">._30l31gy6:hover{color:yellow}</style>
-      <style nonce=\\"k0Mp1lEd\\">._9h8h13q2:active{color:blue}</style>
-      <style nonce=\\"k0Mp1lEd\\">@supports (display:grid){._1df61gy6:focus{color:yellow}._7okp11x8:active{color:black}}@media (max-width:800px){._1o8z1gy6:focus{color:yellow}._jbabtwqo:focus-visible, ._6146twqo:hover{color:grey}._1cld11x8:active{color:black}}</style>
+      "<style data-cmpld=\\"h\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}._1wyb12am{font-size:50px}._syaz1cnh{color:purple}._v0vw1x77:focus-visible, ._ysv71x77:link{color:white}</style>
+      <style data-cmpld=\\"h\\" nonce=\\"k0Mp1lEd\\">._ysv75scu:link{color:red}</style>
+      <style data-cmpld=\\"h\\" nonce=\\"k0Mp1lEd\\">._105332ev:visited{color:pink}</style>
+      <style data-cmpld=\\"h\\" nonce=\\"k0Mp1lEd\\">._f8pjbf54:focus{color:green}</style>
+      <style data-cmpld=\\"h\\" nonce=\\"k0Mp1lEd\\">._30l31gy6:hover{color:yellow}</style>
+      <style data-cmpld=\\"h\\" nonce=\\"k0Mp1lEd\\">._9h8h13q2:active{color:blue}</style>
+      <style data-cmpld=\\"h\\" nonce=\\"k0Mp1lEd\\">@supports (display:grid){._1df61gy6:focus{color:yellow}._7okp11x8:active{color:black}}@media (max-width:800px){._1o8z1gy6:focus{color:yellow}._jbabtwqo:focus-visible, ._6146twqo:hover{color:grey}._1cld11x8:active{color:black}}</style>
       "
     `);
   });

--- a/packages/react/src/__tests__/server-side-hydrate.test.tsx
+++ b/packages/react/src/__tests__/server-side-hydrate.test.tsx
@@ -29,7 +29,7 @@ describe('server side hydrate', () => {
     // It's notoriously hard to do both server and client rendering in this test.
     // Instead of doing the server flow we hardcode the result instead.
     const elem = appendHTML(
-      `<style data-cmpld="true">.foo{color:blue}</style><div class="foo">hello world</div>`
+      `<style data-cmpld="s">.foo{color:blue}</style><div class="foo">hello world</div>`
     );
 
     flushRuntimeModule();

--- a/packages/react/src/__tests__/ssr.test.tsx
+++ b/packages/react/src/__tests__/ssr.test.tsx
@@ -15,7 +15,7 @@ describe('SSR', () => {
     const result = renderToStaticMarkup(<StyledDiv>hello world</StyledDiv>);
 
     expect(result).toMatchInlineSnapshot(
-      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div>"`
+      `"<style data-cmpld=\\"s\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div>"`
     );
   });
 
@@ -42,7 +42,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div>"`
+      `"<style data-cmpld=\\"s\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div>"`
     );
   });
 
@@ -66,7 +66,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<div><div><div><style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div></div></div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
+      `"<div><div><div><style data-cmpld=\\"s\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div></div></div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
     );
   });
 
@@ -86,7 +86,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}</style><div class=\\"_1e0c1txw\\"><style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
+      `"<style data-cmpld=\\"s\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}</style><div class=\\"_1e0c1txw\\"><style data-cmpld=\\"s\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
     );
   });
 
@@ -133,7 +133,7 @@ describe('SSR', () => {
     );
 
     expect(result.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
-      "<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}._1wyb12am{font-size:50px}._syaz1cnh{color:purple}._ysv75scu:link{color:red}._105332ev:visited{color:pink}._f8pjbf54:focus{color:green}._30l31gy6:hover{color:yellow}._9h8h13q2:active{color:blue}@supports (display:grid){._1df61gy6:focus{color:yellow}._7okp11x8:active{color:black}}@media (max-width:800px){._1o8z1gy6:focus{color:yellow}._1cld11x8:active{color:black}}</style>
+      "<style data-cmpld=\\"s\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}._1wyb12am{font-size:50px}._syaz1cnh{color:purple}._ysv75scu:link{color:red}._105332ev:visited{color:pink}._f8pjbf54:focus{color:green}._30l31gy6:hover{color:yellow}._9h8h13q2:active{color:blue}@supports (display:grid){._1df61gy6:focus{color:yellow}._7okp11x8:active{color:black}}@media (max-width:800px){._1o8z1gy6:focus{color:yellow}._1cld11x8:active{color:black}}</style>
       <a href=\\"https://atlassian.design\\" class=\\"_1e0c1txw _1wyb12am _syaz1cnh _30l31gy6 _9h8h13q2 _ysv75scu _7okp11x8 _1df61gy6 _f8pjbf54 _105332ev _1cld11x8 _1o8z1gy6\\">Atlassian Design System</a>"
     `);
   });

--- a/packages/react/src/__tests__/ssr.test.tsx
+++ b/packages/react/src/__tests__/ssr.test.tsx
@@ -15,7 +15,7 @@ describe('SSR', () => {
     const result = renderToStaticMarkup(<StyledDiv>hello world</StyledDiv>);
 
     expect(result).toMatchInlineSnapshot(
-      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><script data-cmpld-cache=\\"true\\">{\\"._1wyb1fwx{font-size:12px}\\":true}</script><div class=\\"_1wyb1fwx\\">hello world</div>"`
+      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div>"`
     );
   });
 
@@ -42,7 +42,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><script data-cmpld-cache=\\"true\\">{\\"._1wyb1fwx{font-size:12px}\\":true}</script><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div>"`
+      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div>"`
     );
   });
 
@@ -66,7 +66,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<div><div><div><style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><script data-cmpld-cache=\\"true\\">{\\"._1wyb1fwx{font-size:12px}\\":true}</script><div class=\\"_1wyb1fwx\\">hello world</div></div></div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
+      `"<div><div><div><style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div></div></div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
     );
   });
 
@@ -86,7 +86,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}</style><script data-cmpld-cache=\\"true\\">{\\"._1e0c1txw{display:flex}\\":true}</script><div class=\\"_1e0c1txw\\"><style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><script data-cmpld-cache=\\"true\\">{\\"._1e0c1txw{display:flex}\\":true,\\"._1wyb1fwx{font-size:12px}\\":true}</script><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
+      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}</style><div class=\\"_1e0c1txw\\"><style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
     );
   });
 
@@ -134,7 +134,7 @@ describe('SSR', () => {
 
     expect(result.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
       "<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}._1wyb12am{font-size:50px}._syaz1cnh{color:purple}._ysv75scu:link{color:red}._105332ev:visited{color:pink}._f8pjbf54:focus{color:green}._30l31gy6:hover{color:yellow}._9h8h13q2:active{color:blue}@supports (display:grid){._1df61gy6:focus{color:yellow}._7okp11x8:active{color:black}}@media (max-width:800px){._1o8z1gy6:focus{color:yellow}._1cld11x8:active{color:black}}</style>
-      <script data-cmpld-cache=\\"true\\">{\\"._1e0c1txw{display:flex}\\":true,\\"._1wyb12am{font-size:50px}\\":true,\\"._syaz1cnh{color:purple}\\":true,\\"._30l31gy6:hover{color:yellow}\\":true,\\"._9h8h13q2:active{color:blue}\\":true,\\"._ysv75scu:link{color:red}\\":true,\\"@supports (display:grid){._1df61gy6:focus{color:yellow}._7okp11x8:active{color:black}}\\":true,\\"._f8pjbf54:focus{color:green}\\":true,\\"._105332ev:visited{color:pink}\\":true,\\"@media (max-width:800px){._1o8z1gy6:focus{color:yellow}._1cld11x8:active{color:black}}\\":true}</script><a href=\\"https://atlassian.design\\" class=\\"_1e0c1txw _1wyb12am _syaz1cnh _30l31gy6 _9h8h13q2 _ysv75scu _7okp11x8 _1df61gy6 _f8pjbf54 _105332ev _1cld11x8 _1o8z1gy6\\">Atlassian Design System</a>"
+      <a href=\\"https://atlassian.design\\" class=\\"_1e0c1txw _1wyb12am _syaz1cnh _30l31gy6 _9h8h13q2 _ysv75scu _7okp11x8 _1df61gy6 _f8pjbf54 _105332ev _1cld11x8 _1o8z1gy6\\">Atlassian Design System</a>"
     `);
   });
 });

--- a/packages/react/src/__tests__/ssr.test.tsx
+++ b/packages/react/src/__tests__/ssr.test.tsx
@@ -15,7 +15,7 @@ describe('SSR', () => {
     const result = renderToStaticMarkup(<StyledDiv>hello world</StyledDiv>);
 
     expect(result).toMatchInlineSnapshot(
-      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div>"`
+      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><script data-cmpld-cache=\\"true\\">{\\"._1wyb1fwx{font-size:12px}\\":true}</script><div class=\\"_1wyb1fwx\\">hello world</div>"`
     );
   });
 
@@ -42,7 +42,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div>"`
+      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><script data-cmpld-cache=\\"true\\">{\\"._1wyb1fwx{font-size:12px}\\":true}</script><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div>"`
     );
   });
 
@@ -66,7 +66,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<div><div><div><style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div></div></div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
+      `"<div><div><div><style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><script data-cmpld-cache=\\"true\\">{\\"._1wyb1fwx{font-size:12px}\\":true}</script><div class=\\"_1wyb1fwx\\">hello world</div></div></div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
     );
   });
 
@@ -86,7 +86,7 @@ describe('SSR', () => {
     );
 
     expect(result).toMatchInlineSnapshot(
-      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}</style><div class=\\"_1e0c1txw\\"><style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
+      `"<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}</style><script data-cmpld-cache=\\"true\\">{\\"._1e0c1txw{display:flex}\\":true}</script><div class=\\"_1e0c1txw\\"><style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1wyb1fwx{font-size:12px}</style><script data-cmpld-cache=\\"true\\">{\\"._1e0c1txw{display:flex}\\":true,\\"._1wyb1fwx{font-size:12px}\\":true}</script><div class=\\"_1wyb1fwx\\">hello world</div><div class=\\"_1wyb1fwx\\">hello world</div></div>"`
     );
   });
 
@@ -134,7 +134,7 @@ describe('SSR', () => {
 
     expect(result.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
       "<style data-cmpld=\\"true\\" nonce=\\"k0Mp1lEd\\">._1e0c1txw{display:flex}._1wyb12am{font-size:50px}._syaz1cnh{color:purple}._ysv75scu:link{color:red}._105332ev:visited{color:pink}._f8pjbf54:focus{color:green}._30l31gy6:hover{color:yellow}._9h8h13q2:active{color:blue}@supports (display:grid){._1df61gy6:focus{color:yellow}._7okp11x8:active{color:black}}@media (max-width:800px){._1o8z1gy6:focus{color:yellow}._1cld11x8:active{color:black}}</style>
-      <a href=\\"https://atlassian.design\\" class=\\"_1e0c1txw _1wyb12am _syaz1cnh _30l31gy6 _9h8h13q2 _ysv75scu _7okp11x8 _1df61gy6 _f8pjbf54 _105332ev _1cld11x8 _1o8z1gy6\\">Atlassian Design System</a>"
+      <script data-cmpld-cache=\\"true\\">{\\"._1e0c1txw{display:flex}\\":true,\\"._1wyb12am{font-size:50px}\\":true,\\"._syaz1cnh{color:purple}\\":true,\\"._30l31gy6:hover{color:yellow}\\":true,\\"._9h8h13q2:active{color:blue}\\":true,\\"._ysv75scu:link{color:red}\\":true,\\"@supports (display:grid){._1df61gy6:focus{color:yellow}._7okp11x8:active{color:black}}\\":true,\\"._f8pjbf54:focus{color:green}\\":true,\\"._105332ev:visited{color:pink}\\":true,\\"@media (max-width:800px){._1o8z1gy6:focus{color:yellow}._1cld11x8:active{color:black}}\\":true}</script><a href=\\"https://atlassian.design\\" class=\\"_1e0c1txw _1wyb12am _syaz1cnh _30l31gy6 _9h8h13q2 _ysv75scu _7okp11x8 _1df61gy6 _f8pjbf54 _105332ev _1cld11x8 _1o8z1gy6\\">Atlassian Design System</a>"
     `);
   });
 });

--- a/packages/react/src/runtime.tsx
+++ b/packages/react/src/runtime.tsx
@@ -1,1 +1,1 @@
-export { CC, CS, ax, ix } from './runtime/index';
+export { CC, CS, ax, ix, SSRCacheComponent } from './runtime/index';

--- a/packages/react/src/runtime/__tests__/style-cache-ssr.test.tsx
+++ b/packages/react/src/runtime/__tests__/style-cache-ssr.test.tsx
@@ -1,0 +1,56 @@
+jest.mock('../is-node', () => ({
+  isNodeEnvironment: () => false,
+}));
+
+afterEach(() => {
+  document.head.innerHTML = '';
+  document.body.innerHTML = '';
+  jest.resetModules();
+});
+
+describe('style-cache', () => {
+  it('should collect all SSR style tags and move them to the head', () => {
+    document.body.innerHTML = '<style data-cmpld="s">.a { display: block; }</style>';
+
+    require('../style-cache');
+
+    expect(document.body.innerHTML).toBe('');
+    expect(document.head.innerHTML).toInclude(
+      '<style data-cmpld="s">.a { display: block; }</style>'
+    );
+  });
+
+  it('should consolidate all style tags in head', () => {
+    jest.useFakeTimers();
+
+    const styles = [
+      '<style data-cmpld="s">.a { display: block; }</style>',
+      '<style data-cmpld="s">.b { color: red; }</style>',
+      '<style data-cmpld="s">.c { width: 100%; }</style>',
+    ].join('');
+
+    document.body.innerHTML = styles;
+
+    require('../style-cache');
+
+    expect(document.body.innerHTML).toBe('');
+    // all style tags should have been moved to head
+    expect(document.head.innerHTML).toInclude(styles);
+
+    jest.runAllTimers();
+
+    // all style tags should now be consolidated
+    expect(document.head.innerHTML).toInclude(
+      '<style data-cmpld="h">.a { display: block; }.b { color: red; }.c { width: 100%; }</style>'
+    );
+  });
+
+  it('should create client cache from SSR cache', () => {
+    document.body.innerHTML = '<script data-cmpld="c">{".b { display: block; }": true}</script>';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { useCache } = require('../style-cache');
+
+    expect(useCache()).toEqual({ ['.b { display: block; }']: true });
+  });
+});

--- a/packages/react/src/runtime/__tests__/style-ssr.test.tsx
+++ b/packages/react/src/runtime/__tests__/style-ssr.test.tsx
@@ -6,15 +6,13 @@ describe('<Style />', () => {
   it('should render style as children on the server', () => {
     const result = renderToStaticMarkup(<Style>{[`.a { display: block; }`]}</Style>);
 
-    expect(result).toInclude('<style data-cmpld="true">.a { display: block; }</style>');
+    expect(result).toInclude('<style data-cmpld="s">.a { display: block; }</style>');
   });
 
   it('should render style as children on the server with nonce', () => {
     const result = renderToStaticMarkup(<Style nonce="1234">{[`.a { display: block; }`]}</Style>);
 
-    expect(result).toInclude(
-      '<style data-cmpld="true" nonce="1234">.a { display: block; }</style>'
-    );
+    expect(result).toInclude('<style data-cmpld="s" nonce="1234">.a { display: block; }</style>');
   });
 
   it('should not output html comments', () => {
@@ -43,7 +41,7 @@ describe('<Style />', () => {
     );
 
     expect(result.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
-      "<style data-cmpld=\\"true\\">._c1234567{ display: block; }._d1234567:link{ color: green; }._g1234567:visited{ color: grey; }._i1234567:focus-within{ color: black; }._f1234567:focus{ color: pink; }._h1234567:focus-visible{ color: white; }._a1234567:hover{ color: red; }._b1234567:active{ color: blue; }@media (max-width: 800px){ ._e1234567{ color: yellow; } }</style>
+      "<style data-cmpld=\\"s\\">._c1234567{ display: block; }._d1234567:link{ color: green; }._g1234567:visited{ color: grey; }._i1234567:focus-within{ color: black; }._f1234567:focus{ color: pink; }._h1234567:focus-visible{ color: white; }._a1234567:hover{ color: red; }._b1234567:active{ color: blue; }@media (max-width: 800px){ ._e1234567{ color: yellow; } }</style>
       "
     `);
   });

--- a/packages/react/src/runtime/__tests__/style-ssr.test.tsx
+++ b/packages/react/src/runtime/__tests__/style-ssr.test.tsx
@@ -44,7 +44,7 @@ describe('<Style />', () => {
 
     expect(result.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
       "<style data-cmpld=\\"true\\">._c1234567{ display: block; }._d1234567:link{ color: green; }._g1234567:visited{ color: grey; }._i1234567:focus-within{ color: black; }._f1234567:focus{ color: pink; }._h1234567:focus-visible{ color: white; }._a1234567:hover{ color: red; }._b1234567:active{ color: blue; }@media (max-width: 800px){ ._e1234567{ color: yellow; } }</style>
-      <script data-cmpld-cache=\\"true\\">{\\"._a1234567:hover{ color: red; }\\":true,\\"._b1234567:active{ color: blue; }\\":true,\\"._c1234567{ display: block; }\\":true,\\"._d1234567:link{ color: green; }\\":true,\\"@media (max-width: 800px){ ._e1234567{ color: yellow; } }\\":true,\\"._f1234567:focus{ color: pink; }\\":true,\\"._g1234567:visited{ color: grey; }\\":true,\\"._h1234567:focus-visible{ color: white; }\\":true,\\"._i1234567:focus-within{ color: black; }\\":true}</script>"
+      "
     `);
   });
 });

--- a/packages/react/src/runtime/__tests__/style-ssr.test.tsx
+++ b/packages/react/src/runtime/__tests__/style-ssr.test.tsx
@@ -44,7 +44,7 @@ describe('<Style />', () => {
 
     expect(result.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
       "<style data-cmpld=\\"true\\">._c1234567{ display: block; }._d1234567:link{ color: green; }._g1234567:visited{ color: grey; }._i1234567:focus-within{ color: black; }._f1234567:focus{ color: pink; }._h1234567:focus-visible{ color: white; }._a1234567:hover{ color: red; }._b1234567:active{ color: blue; }@media (max-width: 800px){ ._e1234567{ color: yellow; } }</style>
-      "
+      <script data-cmpld-cache=\\"true\\">{\\"._a1234567:hover{ color: red; }\\":true,\\"._b1234567:active{ color: blue; }\\":true,\\"._c1234567{ display: block; }\\":true,\\"._d1234567:link{ color: green; }\\":true,\\"@media (max-width: 800px){ ._e1234567{ color: yellow; } }\\":true,\\"._f1234567:focus{ color: pink; }\\":true,\\"._g1234567:visited{ color: grey; }\\":true,\\"._h1234567:focus-visible{ color: white; }\\":true,\\"._i1234567:focus-within{ color: black; }\\":true}</script>"
     `);
   });
 });

--- a/packages/react/src/runtime/__tests__/style.test.tsx
+++ b/packages/react/src/runtime/__tests__/style.test.tsx
@@ -24,14 +24,19 @@ describe('<Style />', () => {
   it('should add style to the head on the client', () => {
     render(<Style>{[`.b { display: block; }`]}</Style>);
 
-    expect(document.head.innerHTML).toInclude('<style>.b { display: block; }</style>');
+    expect(document.head.innerHTML).toInclude(
+      '<style data-cmpld="h">.b { display: block; }</style>'
+    );
   });
 
   it('should only add one style if it was already added', () => {
     render(<Style>{[`.c { display: block; }`]}</Style>);
     render(<Style>{[`.c { display: block; }`]}</Style>);
 
-    expect(document.head.innerHTML).toIncludeRepeated('<style>.c { display: block; }</style>', 1);
+    expect(document.head.innerHTML).toIncludeRepeated(
+      '<style data-cmpld="h">.c { display: block; }</style>',
+      1
+    );
   });
 
   it('should noop in prod', () => {
@@ -80,15 +85,15 @@ describe('<Style />', () => {
     );
 
     expect(document.head.innerHTML.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
-      "<style>._d1234567{ display: block; }</style>
-      <style>._c1234567:link{ color: green; }</style>
-      <style>._g1234567:visited{ color: grey; }</style>
-      <style>._i1234567:focus-within{ color: black; }</style>
-      <style>._f1234567:focus{ color: pink; }</style>
-      <style>._h1234567:focus-visible{ color: white; }</style>
-      <style>._a1234567:hover{ color: red; }</style>
-      <style>._b1234567:active{ color: blue; }</style>
-      <style>@media (max-width: 800px){ ._e1234567{ color: yellow; } }</style>
+      "<style data-cmpld=\\"h\\">._d1234567{ display: block; }</style>
+      <style data-cmpld=\\"h\\">._c1234567:link{ color: green; }</style>
+      <style data-cmpld=\\"h\\">._g1234567:visited{ color: grey; }</style>
+      <style data-cmpld=\\"h\\">._i1234567:focus-within{ color: black; }</style>
+      <style data-cmpld=\\"h\\">._f1234567:focus{ color: pink; }</style>
+      <style data-cmpld=\\"h\\">._h1234567:focus-visible{ color: white; }</style>
+      <style data-cmpld=\\"h\\">._a1234567:hover{ color: red; }</style>
+      <style data-cmpld=\\"h\\">._b1234567:active{ color: blue; }</style>
+      <style data-cmpld=\\"h\\">@media (max-width: 800px){ ._e1234567{ color: yellow; } }</style>
       "
     `);
   });

--- a/packages/react/src/runtime/index.tsx
+++ b/packages/react/src/runtime/index.tsx
@@ -1,4 +1,4 @@
 export { default as CS } from './style';
-export { default as CC } from './style-cache';
+export { default as CC, SSRCacheComponent } from './style-cache';
 export { default as ax } from './ax';
 export { default as ix } from './css-custom-property';

--- a/packages/react/src/runtime/sheet.tsx
+++ b/packages/react/src/runtime/sheet.tsx
@@ -75,6 +75,8 @@ function lazyAddStyleBucketToHead(bucketName: Bucket, opts: StyleSheetOpts): HTM
     }
 
     const tag = document.createElement('style');
+    // set data-cmpld attribute to "h" for hydrated
+    tag.setAttribute('data-cmpld', 'h');
     opts.nonce && tag.setAttribute('nonce', opts.nonce);
     tag.appendChild(document.createTextNode(''));
     styleBucketsInHead[bucketName] = tag;

--- a/packages/react/src/runtime/style.tsx
+++ b/packages/react/src/runtime/style.tsx
@@ -43,19 +43,23 @@ export default function Style(props: StyleProps): JSX.Element | null {
       }
 
       return (
-        <style data-cmpld nonce={props.nonce}>
-          {styleBucketOrdering.map((bucket) => bucketedSheets[bucket]).join('')}
-        </style>
+        <>
+          <style data-cmpld nonce={props.nonce}>
+            {styleBucketOrdering.map((bucket) => bucketedSheets[bucket]).join('')}
+          </style>
+          <script
+            data-cmpld-cache
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(inserted) }}></script>
+        </>
       );
     } else {
       for (let i = 0; i < props.children.length; i++) {
         const sheet = props.children[i];
-        if (inserted[sheet]) {
-          continue;
-        }
 
-        inserted[sheet] = true;
-        insertRule(sheet, props);
+        if (!inserted[sheet]) {
+          inserted[sheet] = true;
+          insertRule(sheet, props);
+        }
       }
     }
   }

--- a/packages/react/src/runtime/style.tsx
+++ b/packages/react/src/runtime/style.tsx
@@ -43,18 +43,20 @@ export default function Style(props: StyleProps): JSX.Element | null {
       }
 
       return (
-        <style data-cmpld nonce={props.nonce}>
+        // set data-cmpld attribute to "s" for SSR
+        <style data-cmpld="s" nonce={props.nonce}>
           {styleBucketOrdering.map((bucket) => bucketedSheets[bucket]).join('')}
         </style>
       );
     } else {
       for (let i = 0; i < props.children.length; i++) {
         const sheet = props.children[i];
-
-        if (!inserted[sheet]) {
-          inserted[sheet] = true;
-          insertRule(sheet, props);
+        if (inserted[sheet]) {
+          continue;
         }
+
+        inserted[sheet] = true;
+        insertRule(sheet, props);
       }
     }
   }

--- a/packages/react/src/runtime/style.tsx
+++ b/packages/react/src/runtime/style.tsx
@@ -43,14 +43,9 @@ export default function Style(props: StyleProps): JSX.Element | null {
       }
 
       return (
-        <>
-          <style data-cmpld nonce={props.nonce}>
-            {styleBucketOrdering.map((bucket) => bucketedSheets[bucket]).join('')}
-          </style>
-          <script
-            data-cmpld-cache
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(inserted) }}></script>
-        </>
+        <style data-cmpld nonce={props.nonce}>
+          {styleBucketOrdering.map((bucket) => bucketedSheets[bucket]).join('')}
+        </style>
       );
     } else {
       for (let i = 0; i < props.children.length; i++) {


### PR DESCRIPTION
To solve the issue I have added a script tag as a sibling to the style tag when SSR'd. The script tag contains the stringifyed inserted cache data and is added to the client cache object when the bundle is executed.

This solution does have a few downsides: 
1) Adding an extra DOM node next to the style tag with the inserted classnames cache effectively doubles the DOM nodes needed to operate.
2) When the size of the application grows and there are a large number of SSR'd components there is potential that the parsing of both the style and script tags will block execution long enough to be noticeable. It might be prudent to add a batching function. e.g. raf or settimeout.