### PR TITLE
Parcel extraction

### DIFF
--- a/examples/packages/parcel/.compiledcssrc
+++ b/examples/packages/parcel/.compiledcssrc
@@ -1,3 +1,4 @@
 {
-  "importReact": false
+  "importReact": false,
+  "extract": true
 }

--- a/examples/packages/parcel/.parcelrc
+++ b/examples/packages/parcel/.parcelrc
@@ -1,10 +1,15 @@
 {
-  "extends": "@parcel/config-default",
+  "extends": ["@parcel/config-default"],
+  "resolvers": ["@parcel/resolver-default", "..."],
   "transformers": {
     "*.{js,jsx,ts,tsx}": [
       "@compiled/parcel-transformer",
-      "@parcel/transformer-babel",
-      "@parcel/transformer-js"
-    ]
+      "..."
+    ],
+    "css:*": [
+      "@compiled/parcel-transformer-css",
+      "@parcel/transformer-postcss",
+      "@parcel/transformer-css"
+    ],
   }
 }

--- a/examples/packages/parcel/.parcelrc
+++ b/examples/packages/parcel/.parcelrc
@@ -11,5 +11,8 @@
       "@parcel/transformer-postcss",
       "@parcel/transformer-css"
     ],
+  },
+  "optimizers": {
+    "css:*.css": ["@compiled/parcel-optimizer", "..."]
   }
 }

--- a/examples/packages/parcel/.parcelrc
+++ b/examples/packages/parcel/.parcelrc
@@ -1,18 +1,3 @@
 {
-  "extends": ["@parcel/config-default"],
-  "resolvers": ["@parcel/resolver-default", "..."],
-  "transformers": {
-    "*.{js,jsx,ts,tsx}": [
-      "@compiled/parcel-transformer",
-      "..."
-    ],
-    "css:*": [
-      "@compiled/parcel-transformer-css",
-      "@parcel/transformer-postcss",
-      "@parcel/transformer-css"
-    ],
-  },
-  "optimizers": {
-    "css:*.css": ["@compiled/parcel-optimizer", "..."]
-  }
+  "extends": ["@parcel/config-default", "@compiled/parcel-config"]
 }

--- a/examples/packages/parcel/package.json
+++ b/examples/packages/parcel/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@compiled/parcel-transformer": "*",
+    "@compiled/parcel-transformer-css": "*",
     "@parcel/transformer-html": "^2.0.0-nightly.632",
     "@parcel/transformer-posthtml": "^2.0.0-nightly.632",
     "@parcel/optimizer-htmlnano": "^2.0.0-nightly.632",

--- a/examples/packages/parcel/package.json
+++ b/examples/packages/parcel/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@compiled/react": "*",
+    "@private/babel-component": "*",
     "react": "17.0.1",
     "react-dom": "17.0.1"
   },

--- a/examples/packages/parcel/package.json
+++ b/examples/packages/parcel/package.json
@@ -13,8 +13,7 @@
     "react-dom": "17.0.1"
   },
   "devDependencies": {
-    "@compiled/parcel-transformer": "*",
-    "@compiled/parcel-transformer-css": "*",
+    "@compiled/parcel-config": "*",
     "@parcel/transformer-html": "^2.0.0-nightly.632",
     "@parcel/transformer-posthtml": "^2.0.0-nightly.632",
     "@parcel/optimizer-htmlnano": "^2.0.0-nightly.632",

--- a/examples/packages/parcel/src/app.js
+++ b/examples/packages/parcel/src/app.js
@@ -1,13 +1,20 @@
-import * as React from 'react';
+import { Suspense, lazy } from 'react';
 import '@compiled/react';
+import BabelComponent from '@private/babel-component';
 import { primary } from './module';
-import TypeScriptComponent from './ts';
+import HelloWorld from './component';
+
+const AsyncComponent = lazy(() => import('./async'));
 
 export default function Home() {
   return (
     <>
-      <div css={{ fontSize: 50, color: primary }}>hello from parcel 2</div>
-      <TypeScriptComponent color="blue" />
+      <div css={{ fontSize: 50, color: primary }}>hello from webpack</div>
+      <HelloWorld>TypeScript component</HelloWorld>
+      <BabelComponent>Component from NPM</BabelComponent>
+      <Suspense fallback="Loading...">
+        <AsyncComponent>I was loaded async</AsyncComponent>
+      </Suspense>
     </>
   );
 }

--- a/examples/packages/parcel/src/async.js
+++ b/examples/packages/parcel/src/async.js
@@ -1,0 +1,22 @@
+import { styled } from '@compiled/react';
+
+const LoadedAsync = styled.button`
+  font-weight: 700;
+  color: purple;
+  border: 2px solid pink;
+  background-color: transparent;
+
+  :focus {
+    color: blue;
+  }
+
+  :hover {
+    color: red;
+  }
+
+  @media (min-width: 500px) {
+    border: 2px solid red;
+  }
+`;
+
+export default LoadedAsync;

--- a/examples/packages/parcel/src/component.tsx
+++ b/examples/packages/parcel/src/component.tsx
@@ -1,0 +1,51 @@
+import { styled } from '@compiled/react';
+import { primary } from './module';
+
+const HelloWorld = styled.div`
+  color: ${primary};
+  font-weight: 500;
+
+  :hover {
+    color: red;
+  }
+
+  :focus {
+    color: blue;
+  }
+`;
+
+const MediaComponent = styled.div`
+  border: 10px dotted purple;
+  :before {
+    content: 'small screen';
+  }
+
+  @media (min-width: 500px) {
+    border: 2px solid red;
+
+    :before {
+      content: 'large screen';
+    }
+  }
+`;
+
+export default function TSComponent(props: { children: string }): JSX.Element {
+  return (
+    <HelloWorld tabIndex={0}>
+      {props.children}
+      <MediaComponent />
+
+      <div
+        css={{
+          span: {
+            color: '#ccc',
+            ':hover': {
+              color: 'red',
+            },
+          },
+        }}>
+        <span>nested span</span>
+      </div>
+    </HelloWorld>
+  );
+}

--- a/examples/packages/parcel/src/extra.css
+++ b/examples/packages/parcel/src/extra.css
@@ -1,0 +1,4 @@
+body::before {
+  display: block;
+  content: 'CSS FROM A FILE OUTSIDE OF COMPILED';
+}

--- a/examples/packages/parcel/src/index.js
+++ b/examples/packages/parcel/src/index.js
@@ -1,5 +1,17 @@
-import React from 'react';
 import { render } from 'react-dom';
+import './extra.css';
 import App from './app';
 
-render(<App />, document.getElementById('root'));
+function createRoot() {
+  const element = document.createElement('div');
+  element.id = 'root';
+  document.body.appendChild(element);
+  return element;
+}
+
+const element = document.getElementById('root') || createRoot();
+render(<App />, element);
+
+if (module.hot) {
+  module.hot.accept();
+}

--- a/examples/packages/parcel/src/module.js
+++ b/examples/packages/parcel/src/module.js
@@ -1,1 +1,1 @@
-export const primary = 'red';
+export const primary = 'pink';

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "npx nodemon --exec \"yarn build:esm && start-storybook -p 6006 --ci\" --watch packages/babel-plugin/ -e tsx",
     "start:ssr": "yarn build && cd examples/packages/ssr && yarn start",
     "start:prod": "NODE_ENV=production yarn start",
-    "start:parcel": "yarn build:esm && cd examples/packages/parcel && yarn start",
+    "start:parcel": "yarn build:browser && yarn build:esm && cd examples/packages/parcel && yarn start",
     "start:cli": "cd packages/cli && yarn start",
     "start:inspect": "npx nodemon --exec \"node --inspect-brk node_modules/.bin/start-storybook -p 6006 --ci\" --watch packages/babel-plugin/ -e tsx",
     "start:webpack": "yarn build:browser && yarn build:esm && cd examples/packages/webpack && yarn start",

--- a/packages/parcel-config/config.json
+++ b/packages/parcel-config/config.json
@@ -1,0 +1,13 @@
+{
+  "transformers": {
+    "*.{js,jsx,ts,tsx}": ["@compiled/parcel-transformer", "..."],
+    "css:*": [
+      "@compiled/parcel-transformer-css",
+      "@parcel/transformer-postcss",
+      "@parcel/transformer-css"
+    ]
+  },
+  "optimizers": {
+    "css:*.css": ["@compiled/parcel-optimizer", "..."]
+  }
+}

--- a/packages/parcel-config/config.json
+++ b/packages/parcel-config/config.json
@@ -1,13 +1,10 @@
 {
   "transformers": {
     "*.{js,jsx,ts,tsx}": ["@compiled/parcel-transformer", "..."],
-    "css:*": [
-      "@compiled/parcel-transformer-css",
-      "@parcel/transformer-postcss",
-      "@parcel/transformer-css"
-    ]
+    "css:*": ["@compiled/parcel-transformer-css", "..."]
   },
   "optimizers": {
-    "css:*.css": ["@compiled/parcel-optimizer", "..."]
+    "*.css": ["@compiled/parcel-optimizer", "..."],
+    "css:*": ["@compiled/parcel-optimizer", "..."]
   }
 }

--- a/packages/parcel-config/package.json
+++ b/packages/parcel-config/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@compiled/parcel-config",
+  "version": "0.1.0",
+  "description": "Build time CSS-in-JS for React. Baked and ready to serve.",
+  "author": "Michael Dougall",
+  "license": "Apache-2.0",
+  "homepage": "https://compiledcssinjs.com",
+  "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atlassian-labs/compiled.git",
+    "directory": "packages/parcel-transformer"
+  },
+  "main": "config.json",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "dependencies": {
+    "@compiled/parcel-optimizer": "^0.1.0",
+    "@compiled/parcel-transformer": "^0.6.11",
+    "@compiled/parcel-transformer-css": "^0.1.0"
+  },
+  "engines": {
+    "parcel": "^2.0.0 || ^2.0.0-beta.1"
+  }
+}

--- a/packages/parcel-optimizer/index.js
+++ b/packages/parcel-optimizer/index.js
@@ -1,0 +1,8 @@
+const { Optimizer } = require('@parcel/plugin');
+const { sort } = require('@compiled/css');
+
+module.exports = new Optimizer({
+  async optimize({ contents, map }) {
+    return { contents: sort(contents), map };
+  },
+});

--- a/packages/parcel-optimizer/package.json
+++ b/packages/parcel-optimizer/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@compiled/parcel-optimizer",
+  "version": "0.1.0",
+  "description": "Build time CSS-in-JS for React. Baked and ready to serve.",
+  "author": "Michael Dougall",
+  "license": "Apache-2.0",
+  "homepage": "https://compiledcssinjs.com",
+  "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atlassian-labs/compiled.git",
+    "directory": "packages/parcel-resolver"
+  },
+  "module": "./index.js",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "dependencies": {
+    "@compiled/css": "0.6.10",
+    "@parcel/plugin": "^2.0.0-nightly.632"
+  },
+  "engines": {
+    "parcel": "^2.0.0 || ^2.0.0-beta.1"
+  }
+}

--- a/packages/parcel-transformer-css/index.js
+++ b/packages/parcel-transformer-css/index.js
@@ -3,6 +3,7 @@ const { Transformer } = require('@parcel/plugin');
 module.exports = new Transformer({
   async transform({ asset }) {
     asset.setCode(asset.query.style || '');
+    asset.isSplittable = false;
     return [asset];
   },
 

--- a/packages/parcel-transformer-css/index.js
+++ b/packages/parcel-transformer-css/index.js
@@ -1,0 +1,12 @@
+const { Transformer } = require('@parcel/plugin');
+
+module.exports = new Transformer({
+  async transform({ asset }) {
+    asset.setCode(asset.query.style || '');
+    return [asset];
+  },
+
+  async generate({ asset }) {
+    return { content: asset.getCode() };
+  },
+});

--- a/packages/parcel-transformer-css/package.json
+++ b/packages/parcel-transformer-css/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@compiled/parcel-transformer",
-  "version": "0.6.11",
+  "name": "@compiled/parcel-transformer-css",
+  "version": "0.1.0",
   "description": "Build time CSS-in-JS for React. Baked and ready to serve.",
   "author": "Michael Dougall",
   "license": "Apache-2.0",
@@ -9,11 +9,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/atlassian-labs/compiled.git",
-    "directory": "packages/parcel-transformer"
+    "directory": "packages/parcel-resolver"
   },
-  "main": "./dist/index.js",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "./index.js",
   "sideEffects": false,
   "files": [
     "dist",
@@ -21,15 +19,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@babel/core": "^7.13.10",
-    "@babel/generator": "^7.13.9",
-    "@compiled/babel-plugin": "^0.6.10",
-    "@compiled/babel-plugin-strip-runtime": "^0.6.11",
-    "@compiled/utils": "^0.6.10",
     "@parcel/plugin": "^2.0.0-nightly.632"
-  },
-  "devDependencies": {
-    "@types/babel__core": "^7.1.14"
   },
   "engines": {
     "parcel": "^2.0.0 || ^2.0.0-beta.1"

--- a/packages/parcel-transformer/src/transformer.tsx
+++ b/packages/parcel-transformer/src/transformer.tsx
@@ -1,9 +1,8 @@
 import { Transformer } from '@parcel/plugin';
-import type { PluginOptions } from '@compiled/babel-plugin';
 import { parseAsync, transformFromAstAsync } from '@babel/core';
 import generate from '@babel/generator';
-
-type UserlandOpts = Omit<PluginOptions, 'cache' | 'onIncludedFiles'>;
+import type { ParcelTransformerOpts } from './types';
+import { toBoolean } from '@compiled/utils';
 
 const configFiles = [
   '.compiledcssrc',
@@ -15,13 +14,16 @@ const configFiles = [
 /**
  * Compiled parcel transformer.
  */
-export default new Transformer<UserlandOpts>({
+export default new Transformer<ParcelTransformerOpts>({
   async loadConfig({ config }) {
     const conf = await config.getConfig(configFiles, {
       packageKey: '@compiled/parcel-transformer',
     });
 
-    const contents: UserlandOpts = {};
+    const contents: ParcelTransformerOpts = {
+      extract: false,
+      importReact: true,
+    };
 
     if (conf) {
       config.shouldInvalidateOnStartup();
@@ -67,11 +69,12 @@ export default new Transformer<UserlandOpts>({
     }
 
     const includedFiles: string[] = [];
+    const foundCSSRules: string[] = [];
     const code = asset.isASTDirty() ? undefined : await asset.getCode();
 
     const result = await transformFromAstAsync(ast.program, code, {
-      code: false,
-      ast: true,
+      code: true,
+      ast: false,
       filename: asset.filePath,
       babelrc: false,
       configFile: false,
@@ -85,11 +88,19 @@ export default new Transformer<UserlandOpts>({
             cache: 'single-pass',
           },
         ],
-      ],
+        config.extract && [
+          '@compiled/babel-plugin-strip-runtime',
+          {
+            onFoundStyleRules: (styles: string[]) => foundCSSRules.push(...styles),
+          },
+        ],
+      ].filter(toBoolean),
       caller: {
         name: 'compiled',
       },
     });
+
+    let output = result?.code || '';
 
     includedFiles.forEach((file) => {
       // Included files are those which have been statically evaluated into this asset.
@@ -98,15 +109,16 @@ export default new Transformer<UserlandOpts>({
       asset.addIncludedFile(file);
     });
 
-    if (result?.ast) {
-      asset.setAST({
-        // TODO: Currently if we set this as `'babel'` the babel transformer blows up.
-        // Let's figure out what we can do to reuse it.
-        type: 'compiled',
-        version: '0.0.0',
-        program: result.ast,
+    if (config.extract && foundCSSRules.length) {
+      foundCSSRules.forEach((rule) => {
+        const params = encodeURIComponent(rule);
+        output = `
+import "css:@compiled/parcel-transformer-css/extract.css?style=${params}";
+${output}`;
       });
     }
+
+    asset.setCode(output);
 
     return [asset];
   },

--- a/packages/parcel-transformer/src/transformer.tsx
+++ b/packages/parcel-transformer/src/transformer.tsx
@@ -39,8 +39,8 @@ export default new Transformer<ParcelTransformerOpts>({
     return false;
   },
 
-  async parse({ asset }) {
-    if (!asset.isSource) {
+  async parse({ asset, config }) {
+    if (!asset.isSource && !config.extract) {
       return undefined;
     }
 
@@ -62,7 +62,7 @@ export default new Transformer<ParcelTransformerOpts>({
 
   async transform({ asset, config }) {
     const ast = await asset.getAST();
-    if (!asset.isSource || !ast) {
+    if (!ast) {
       // We will only recieve ASTs for assets we're interested in.
       // Since this is undefined (or in node modules) we aren't interested in it.
       return [asset];
@@ -80,7 +80,7 @@ export default new Transformer<ParcelTransformerOpts>({
       configFile: false,
       sourceMaps: true,
       plugins: [
-        [
+        asset.isSource && [
           '@compiled/babel-plugin',
           {
             ...config,

--- a/packages/parcel-transformer/src/types.tsx
+++ b/packages/parcel-transformer/src/types.tsx
@@ -1,0 +1,9 @@
+export interface ParcelTransformerOpts {
+  /**
+   * Will import the React namespace if it is missing.
+   * When using the `'automatic'` jsx runtime set this to `false`.
+   */
+  importReact?: boolean;
+
+  extract?: boolean;
+}

--- a/packages/parcel-transformer/tsconfig.json
+++ b/packages/parcel-transformer/tsconfig.json
@@ -6,5 +6,9 @@
     "module": "commonjs",
     "target": "es2017"
   },
-  "references": [{ "path": "../babel-plugin" }, { "path": "../utils" }]
+  "references": [
+    { "path": "../babel-plugin" },
+    { "path": "../babel-plugin-strip-runtime" },
+    { "path": "../utils" }
+  ]
 }

--- a/packages/parcel-transformer/types/parcel__plugin.d.ts
+++ b/packages/parcel-transformer/types/parcel__plugin.d.ts
@@ -6,6 +6,7 @@ declare module '@parcel/plugin' {
     addIncludedFile(file: string): void;
     getCode(): Promise<string>;
     getAST(): Promise<any>;
+    setCode(code: string): void;
     setAST(opts: { type: string; version: string; program: any }): void;
   }
 


### PR DESCRIPTION
**Local playground**

```bash
yarn
yarn start:parcel
```

Example in `examples/packages/parcel`

**New packages**

- `parcel-transformer-css` - converts `css:xyz?style={rule}` import query params into CSS content, equivalent to the css loader we wrote for webpack
- `parcel-optimizer` - sorts a CSS bundle
- `parcel-config` - holds all config for compiled as a single entrypoint, convince wrapper

**`parcel-transformer` changes**

- Add extract option
- Extract from node modules
- Add `css:` import to file pass for every style declaration found

**Questions**

- Should we add the imports via the AST?
- How can we share the AST with the babel transformer? It throws an error
- How can we move styles from one bundle to another? (E.g. hoisting unstable CSS to the primary CSS bundle)
- Else - Is it possible to disable code splitting CSS? `asset.isSplittable = false` doesn't work
- Is it possible to "delete" the `css:xyz` imports after transformation?