### PR TITLE
Code split CSS chunks

### DIFF
--- a/.changeset/fresh-tools-refuse.md
+++ b/.changeset/fresh-tools-refuse.md
@@ -1,0 +1,5 @@
+---
+'@compiled/webpack-loader': minor
+---
+
+**BREAKING** Compiled now takes control of the entire CSS pipeline. This means any CSS declared inside or outside of Compiled will be sorted and potentially hoisted if unsafe.

--- a/.changeset/large-pans-retire.md
+++ b/.changeset/large-pans-retire.md
@@ -1,0 +1,5 @@
+---
+'@compiled/css': patch
+---
+
+Sort now can remove unstable atomic rules with the `removeUnstableRules` option set to `true`.

--- a/.changeset/silent-planets-invent.md
+++ b/.changeset/silent-planets-invent.md
@@ -1,0 +1,5 @@
+---
+'@compiled/webpack-loader': patch
+---
+
+Compiled now supports async chunked CSS. When components are code split and have unique styles only used in that chunk, its styles will be in their own style sheet.

--- a/.changeset/tame-trains-draw.md
+++ b/.changeset/tame-trains-draw.md
@@ -1,0 +1,5 @@
+---
+'@compiled/css': minor
+---
+
+**BREAKING** Sort now returns an object with `css` and any found `unstableRules` when the `removeUnstableRules` option is `true`.

--- a/packages/css/src/plugins/remove-unstable-rules.tsx
+++ b/packages/css/src/plugins/remove-unstable-rules.tsx
@@ -1,0 +1,24 @@
+import { plugin } from 'postcss';
+
+/**
+ * Removes unstable atomic rules from the style sheet.
+ */
+export const removeUnstableRules = plugin<{ callback: (sheet: string) => void }>(
+  'remove-unstable-rules',
+  (opts) => {
+    return (root) => {
+      root.each((node) => {
+        switch (node.type) {
+          case 'rule':
+            if (node.selector.includes(':')) {
+              opts?.callback(node.toString());
+              node.remove();
+            }
+
+          default:
+            break;
+        }
+      });
+    };
+  }
+);

--- a/packages/webpack-loader/src/__tests__/extract-plugin.test.tsx
+++ b/packages/webpack-loader/src/__tests__/extract-plugin.test.tsx
@@ -63,17 +63,13 @@ describe('CompiledExtractPlugin', () => {
 
     expect(getCSSAssets(actual)).toMatchInlineSnapshot(`
       Object {
-        "static/569.css": "
-      ._syaz5scu{color:red}
+        "static/569.css": "._syaz5scu{color:red}
       ._19itgh5a{border:2px solid orange}
-      ._syazruxl{color:orange}._f8pjruxl:focus{color:orange}
-      ._f8pj1cnh:focus{color:purple}
-      ._30l31gy6:hover{color:yellow}
-      ._30l313q2:hover{color:blue}
+      ._syazruxl{color:orange}
       @media screen{._43475scu{color:red}}
       ",
         "static/main.css": "._syazmu8g{color:blueviolet}
-      ",
+      ._f8pjruxl:focus{color:orange}._f8pj1cnh:focus{color:purple}._30l31gy6:hover{color:yellow}._30l313q2:hover{color:blue}",
       }
     `);
   });

--- a/packages/webpack-loader/src/__tests__/extract-plugin.test.tsx
+++ b/packages/webpack-loader/src/__tests__/extract-plugin.test.tsx
@@ -49,7 +49,7 @@ describe('CompiledExtractPlugin', () => {
     // Extract the styles into said bundle
     expect(getCSSAssets(actual)).toMatchInlineSnapshot(`
       Object {
-        "static/298.css": "._19itgh5a{border:2px solid orange}
+        "static/696.css": "._19itgh5a{border:2px solid orange}
       ._syazruxl{color:orange}
       ",
         "static/main.css": "._syazmu8g{color:blueviolet}
@@ -58,12 +58,12 @@ describe('CompiledExtractPlugin', () => {
     `);
   });
 
-  it('should sort chunk style declaration', async () => {
+  it('should hoist and sort chunked style declaration', async () => {
     const actual = await bundle(require.resolve('./fixtures/async-sort.js'));
 
     expect(getCSSAssets(actual)).toMatchInlineSnapshot(`
       Object {
-        "static/354.css": "
+        "static/569.css": "
       ._syaz5scu{color:red}
       ._19itgh5a{border:2px solid orange}
       ._syazruxl{color:orange}._f8pjruxl:focus{color:orange}

--- a/packages/webpack-loader/src/__tests__/extract-plugin.test.tsx
+++ b/packages/webpack-loader/src/__tests__/extract-plugin.test.tsx
@@ -1,22 +1,35 @@
 import { bundle } from './utils/webpack';
 
 describe('CompiledExtractPlugin', () => {
-  const assetName = 'static/compiled-css.css';
+  const getCSSAssets = (assets: Record<string, string>) => {
+    return Object.keys(assets)
+      .filter((name) => name.endsWith('.css'))
+      .reduce(
+        (acc, name) =>
+          Object.assign(acc, {
+            [name]: assets[name],
+          }),
+        {}
+      );
+  };
 
   it('should extract styles from a single file into a style sheet', async () => {
     const actual = await bundle(require.resolve('./fixtures/single.js'));
 
-    expect(actual[assetName]).toMatchInlineSnapshot(`
-      "._1wyb1fwx{font-size:12px}
-      "
+    expect(getCSSAssets(actual)).toMatchInlineSnapshot(`
+      Object {
+        "static/main.css": "._1wyb1fwx{font-size:12px}
+      ",
+      }
     `);
   });
 
   it('should extract styles from multiple files into a style sheet', async () => {
     const actual = await bundle(require.resolve('./fixtures/multiple.js'));
 
-    expect(actual[assetName]).toMatchInlineSnapshot(`
-      "
+    expect(getCSSAssets(actual)).toMatchInlineSnapshot(`
+      Object {
+        "static/main.css": "
       ._syaz5scu{color:red}
       ._syazmu8g{color:blueviolet}
       ._19itgh5a{border:2px solid orange}
@@ -24,27 +37,23 @@ describe('CompiledExtractPlugin', () => {
       ._f8pjruxl:focus{color:orange}
       ._f8pj1cnh:focus{color:purple}._30l31gy6:hover{color:yellow}
       ._30l313q2:hover{color:blue}
-      "
+      ",
+      }
     `);
   });
 
-  it('should extract styles from an async chunk', async () => {
+  it('should chunk safe style declarations', async () => {
     const actual = await bundle(require.resolve('./fixtures/async.js'));
 
-    // Only generate one CSS bundle
-    expect(Object.keys(actual)).toMatchInlineSnapshot(`
-      Array [
-        "bundle.js",
-        "298.bundle.js",
-        "static/compiled-css.css",
-        "298.bundle.js.LICENSE.txt",
-      ]
-    `);
     // Extract the styles into said bundle
-    expect(actual[assetName]).toMatchInlineSnapshot(`
-      "._19itgh5a{border:2px solid orange}
+    expect(getCSSAssets(actual)).toMatchInlineSnapshot(`
+      Object {
+        "static/298.css": "._19itgh5a{border:2px solid orange}
       ._syazruxl{color:orange}
-      "
+      ",
+        "static/main.css": "._1wyb1fwx{font-size:12px}
+      ",
+      }
     `);
   });
 
@@ -61,8 +70,9 @@ describe('CompiledExtractPlugin', () => {
   it('should extract from a pre-built babel files', async () => {
     const actual = await bundle(require.resolve('./fixtures/babel.js'));
 
-    expect(actual[assetName]).toMatchInlineSnapshot(`
-      "._19pk1ul9{margin-top:30px}
+    expect(getCSSAssets(actual)).toMatchInlineSnapshot(`
+      Object {
+        "static/main.css": "._19pk1ul9{margin-top:30px}
       ._19bvftgi{padding-left:8px}
       ._n3tdftgi{padding-bottom:8px}
       ._u5f3ftgi{padding-right:8px}
@@ -70,15 +80,17 @@ describe('CompiledExtractPlugin', () => {
       ._19itlf8h{border:2px solid blue}
       ._1wyb1ul9{font-size:30px}
       ._syaz13q2{color:blue}
-      "
+      ",
+      }
     `);
   });
 
   it('should find bindings', async () => {
     const actual = await bundle(require.resolve('./fixtures/binding-not-found.tsx'));
 
-    expect(actual[assetName]).toMatchInlineSnapshot(`
-      "._syaz1r31{color:currentColor}
+    expect(getCSSAssets(actual)).toMatchInlineSnapshot(`
+      Object {
+        "static/main.css": "._syaz1r31{color:currentColor}
       ._ajmmnqa1{-webkit-text-decoration-style:solid;text-decoration-style:solid}
       ._1hmsglyw{-webkit-text-decoration-line:none;text-decoration-line:none}
       ._4bfu1r31{-webkit-text-decoration-color:currentColor;text-decoration-color:currentColor}
@@ -101,17 +113,20 @@ describe('CompiledExtractPlugin', () => {
       ._4cvr1h6o{align-items:center}
       ._1e0c1txw{display:flex}
       ._4t3i1jdh{height:9rem}
-      "
+      ",
+      }
     `);
   });
 
   it('should extract important', async () => {
     const actual = await bundle(require.resolve('./fixtures/important-styles.js'));
 
-    expect(actual[assetName]).toMatchInlineSnapshot(`
-      "._syaz13q2{color:blue}
+    expect(getCSSAssets(actual)).toMatchInlineSnapshot(`
+      Object {
+        "static/main.css": "._syaz13q2{color:blue}
       ._1wybc038{font-size:12!important}
-      "
+      ",
+      }
     `);
   });
 });

--- a/packages/webpack-loader/src/__tests__/extract-plugin.test.tsx
+++ b/packages/webpack-loader/src/__tests__/extract-plugin.test.tsx
@@ -33,10 +33,11 @@ describe('CompiledExtractPlugin', () => {
       ._syaz5scu{color:red}
       ._syazmu8g{color:blueviolet}
       ._19itgh5a{border:2px solid orange}
-      ._syazruxl{color:orange}
-      ._f8pjruxl:focus{color:orange}
-      ._f8pj1cnh:focus{color:purple}._30l31gy6:hover{color:yellow}
+      ._syazruxl{color:orange}._f8pjruxl:focus{color:orange}
+      ._f8pj1cnh:focus{color:purple}
+      ._30l31gy6:hover{color:yellow}
       ._30l313q2:hover{color:blue}
+      @media screen{._43475scu{color:red}}
       ",
       }
     `);
@@ -52,6 +53,25 @@ describe('CompiledExtractPlugin', () => {
       ._syazruxl{color:orange}
       ",
         "static/main.css": "._1wyb1fwx{font-size:12px}
+      ",
+      }
+    `);
+  });
+
+  it('should sort chunk style declaration', async () => {
+    const actual = await bundle(require.resolve('./fixtures/async-sort.js'));
+
+    expect(getCSSAssets(actual)).toMatchInlineSnapshot(`
+      Object {
+        "static/354.css": "
+      ._syaz5scu{color:red}
+      ._syazmu8g{color:blueviolet}
+      ._19itgh5a{border:2px solid orange}
+      ._syazruxl{color:orange}._f8pjruxl:focus{color:orange}
+      ._f8pj1cnh:focus{color:purple}
+      ._30l31gy6:hover{color:yellow}
+      ._30l313q2:hover{color:blue}
+      @media screen{._43475scu{color:red}}
       ",
       }
     `);

--- a/packages/webpack-loader/src/__tests__/extract-plugin.test.tsx
+++ b/packages/webpack-loader/src/__tests__/extract-plugin.test.tsx
@@ -52,7 +52,7 @@ describe('CompiledExtractPlugin', () => {
         "static/298.css": "._19itgh5a{border:2px solid orange}
       ._syazruxl{color:orange}
       ",
-        "static/main.css": "._1wyb1fwx{font-size:12px}
+        "static/main.css": "._syazmu8g{color:blueviolet}
       ",
       }
     `);
@@ -65,13 +65,14 @@ describe('CompiledExtractPlugin', () => {
       Object {
         "static/354.css": "
       ._syaz5scu{color:red}
-      ._syazmu8g{color:blueviolet}
       ._19itgh5a{border:2px solid orange}
       ._syazruxl{color:orange}._f8pjruxl:focus{color:orange}
       ._f8pj1cnh:focus{color:purple}
       ._30l31gy6:hover{color:yellow}
       ._30l313q2:hover{color:blue}
       @media screen{._43475scu{color:red}}
+      ",
+        "static/main.css": "._syazmu8g{color:blueviolet}
       ",
       }
     `);

--- a/packages/webpack-loader/src/__tests__/fixtures/async-sort.js
+++ b/packages/webpack-loader/src/__tests__/fixtures/async-sort.js
@@ -1,0 +1,1 @@
+import('./multiple');

--- a/packages/webpack-loader/src/__tests__/fixtures/async-sort.js
+++ b/packages/webpack-loader/src/__tests__/fixtures/async-sort.js
@@ -1,1 +1,8 @@
+import '@compiled/react';
+import { blueviolet } from './imports/colors';
+
 import('./multiple');
+
+const Component = () => <div css={{ color: blueviolet }} />;
+
+export default Component;

--- a/packages/webpack-loader/src/__tests__/fixtures/async.js
+++ b/packages/webpack-loader/src/__tests__/fixtures/async.js
@@ -1,6 +1,7 @@
 import '@compiled/react';
+import { blueviolet } from './imports/colors';
 
-const Component = () => <div css={{ fontSize: 12 }} />;
+const Component = () => <div css={{ color: blueviolet }} />;
 
 import('./imports/css-prop');
 

--- a/packages/webpack-loader/src/__tests__/fixtures/async.js
+++ b/packages/webpack-loader/src/__tests__/fixtures/async.js
@@ -1,1 +1,7 @@
+import '@compiled/react';
+
+const Component = () => <div css={{ fontSize: 12 }} />;
+
 import('./imports/css-prop');
+
+export default Component;

--- a/packages/webpack-loader/src/__tests__/fixtures/multiple.js
+++ b/packages/webpack-loader/src/__tests__/fixtures/multiple.js
@@ -4,6 +4,10 @@ import { blueviolet, blue, orange, purple, red, yellow } from './imports/colors'
 import { Orange } from './imports/css-prop';
 
 export const Blue = styled.span`
+  @media screen {
+    color: red;
+  }
+
   color: ${blueviolet};
 
   :focus {
@@ -18,11 +22,11 @@ export const Blue = styled.span`
 export const Red = styled.span`
   color: ${red};
 
-  :focus {
-    color: ${orange};
-  }
-
   :hover {
     color: ${yellow};
+  }
+
+  :focus {
+    color: ${orange};
   }
 `;

--- a/packages/webpack-loader/src/__tests__/utils/webpack.tsx
+++ b/packages/webpack-loader/src/__tests__/utils/webpack.tsx
@@ -37,7 +37,7 @@ export function bundle(
               },
             },
             {
-              loader: '@compiled/webpack-loader',
+              loader: require.resolve('../../compiled-loader'),
               options: {
                 importReact: false,
                 extract,

--- a/packages/webpack-loader/src/extract-plugin.tsx
+++ b/packages/webpack-loader/src/extract-plugin.tsx
@@ -1,7 +1,7 @@
 import { sort } from '@compiled/css';
 import { toBoolean, createError } from '@compiled/utils';
 import type { Compiler, Compilation } from 'webpack';
-import type { CompiledExtractPluginOptions } from './types';
+import type { CompiledExtractPluginOptions, LoaderOpts } from './types';
 import {
   getAssetSourceContents,
   getNormalModuleHook,
@@ -72,10 +72,10 @@ export class CompiledExtractPlugin {
     pushNodeModulesExtractLoader(compiler, this.#options);
 
     compiler.hooks.compilation.tap(pluginName, (compilation) => {
-      getNormalModuleHook(compiler, compilation).tap(pluginName, (loaderContext) => {
+      getNormalModuleHook(compiler, compilation).tap(pluginName, (loaderContext: LoaderOpts) => {
         // We add some information here to tell loaders that the plugin has been configured.
         // Bundling will throw if this is missing (i.e. consumers did not setup correctly).
-        (loaderContext as any)[pluginName] = true;
+        loaderContext[pluginName] = true;
       });
 
       getOptimizeAssetsHook(compiler, compilation).tap(pluginName, (assets) => {

--- a/packages/webpack-loader/src/extract-plugin.tsx
+++ b/packages/webpack-loader/src/extract-plugin.tsx
@@ -7,6 +7,7 @@ import {
   getNormalModuleHook,
   getOptimizeAssetsHook,
   getSources,
+  getMergeAssetsHook,
 } from './utils/webpack';
 
 export const pluginName = 'CompiledExtractPlugin';
@@ -79,16 +80,24 @@ export class CompiledExtractPlugin {
       });
 
       getOptimizeAssetsHook(compiler, compilation).tap(pluginName, (assets) => {
-        const cssAssets = getCSSAssets(assets);
-        if (cssAssets.length === 0) {
+        const CSSAssets = getCSSAssets(assets);
+        if (CSSAssets.length === 0) {
           return;
         }
 
-        const [asset] = cssAssets;
-        const contents = getAssetSourceContents(asset.source);
-        const newSource = new RawSource(sort(contents));
+        CSSAssets.forEach((asset) => {
+          const contents = getAssetSourceContents(asset.source);
+          const newSource = new RawSource(sort(contents));
 
-        compilation.updateAsset(asset.name, newSource, asset.info);
+          compilation.updateAsset(asset.name, newSource, asset.info);
+        });
+      });
+
+      getMergeAssetsHook(compiler, compilation).tap(pluginName, (assets) => {
+        const CSSAssets = getCSSAssets(assets);
+        if (CSSAssets.length === 0) {
+          return;
+        }
       });
     });
   }

--- a/packages/webpack-loader/src/extract-plugin.tsx
+++ b/packages/webpack-loader/src/extract-plugin.tsx
@@ -13,54 +13,16 @@ export const pluginName = 'CompiledExtractPlugin';
 export const styleSheetName = 'compiled-css';
 
 /**
- * Returns CSS Assets that we're interested in.
+ * Returns CSS Assets from the current compilation.
  *
- * @param options
  * @param assets
- * @returns
  */
 const getCSSAssets = (assets: Compilation['assets']) => {
   return Object.keys(assets)
     .filter((assetName) => {
-      return assetName.endsWith(`${styleSheetName}.css`);
+      return assetName.endsWith('.css');
     })
     .map((assetName) => ({ name: assetName, source: assets[assetName], info: {} }));
-};
-
-/**
- * Set a cache group to force all CompiledCSS found to be in a single style sheet.
- * We do this to simplify the sorting story for now. Later on we can investigate
- * hoisting only unstable styles into the parent style sheet from async chunks.
- *
- * @param compiler
- */
-const forceCSSIntoOneStyleSheet = (compiler: Compiler) => {
-  const cacheGroup = {
-    compiledCSS: {
-      name: styleSheetName,
-      type: 'css/mini-extract',
-      chunks: 'all',
-      // We merge only CSS from Compiled.
-      test: /css-loader\/extract\.css$/,
-      enforce: true,
-    },
-  };
-
-  if (!compiler.options.optimization) {
-    compiler.options.optimization = {};
-  }
-
-  if (!compiler.options.optimization.splitChunks) {
-    compiler.options.optimization.splitChunks = {
-      cacheGroups: {},
-    };
-  }
-
-  if (!compiler.options.optimization.splitChunks.cacheGroups) {
-    compiler.options.optimization.splitChunks.cacheGroups = {};
-  }
-
-  Object.assign(compiler.options.optimization.splitChunks.cacheGroups, cacheGroup);
 };
 
 /**
@@ -108,7 +70,6 @@ export class CompiledExtractPlugin {
     const { RawSource } = getSources(compiler);
 
     pushNodeModulesExtractLoader(compiler, this.#options);
-    forceCSSIntoOneStyleSheet(compiler);
 
     compiler.hooks.compilation.tap(pluginName, (compilation) => {
       getNormalModuleHook(compiler, compilation).tap(pluginName, (loaderContext) => {

--- a/packages/webpack-loader/src/types.tsx
+++ b/packages/webpack-loader/src/types.tsx
@@ -27,7 +27,14 @@ export interface CompiledLoaderOptions {
   nonce?: string;
 }
 
-export interface LoaderThis<TOptions = unknown> {
+export interface LoaderOpts {
+  /**
+   * When set confirms that the extract plugin has been configured.
+   */
+  [pluginName]?: true;
+}
+
+export interface LoaderThis<TOptions = unknown> extends LoaderOpts {
   /**
    * Query param passed to the loader.
    *
@@ -81,11 +88,6 @@ export interface LoaderThis<TOptions = unknown> {
    * @param error
    */
   emitError(error: Error): void;
-
-  /**
-   * When set confirms that the extract plugin has been configured.
-   */
-  [pluginName]?: true;
 }
 
 export interface CompiledExtractPluginOptions {

--- a/packages/webpack-loader/src/utils/webpack.tsx
+++ b/packages/webpack-loader/src/utils/webpack.tsx
@@ -78,32 +78,6 @@ export const getOptimizeAssetsHook = (
 };
 
 /**
- * Returns webpack 4 & 5 compatible merge assets hook.
- * @param compiler
- * @param compilation
- * @returns
- */
-export const getMergeAssetsHook = (
-  compiler: Compiler,
-  compilation: CompilationType
-): { tap: CompilationType['hooks']['processAssets']['tap'] } => {
-  const { Compilation } = compiler.webpack;
-  const processAssets = compilation.hooks.processAssets;
-
-  return {
-    tap: (pluginName: string, callback: (assets: CompilationType['assets']) => void) => {
-      processAssets.tap(
-        {
-          name: pluginName,
-          stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_COUNT,
-        },
-        callback
-      );
-    },
-  };
-};
-
-/**
  * Returns webpack 4 & 5 compatible sources.
  * @returns
  */

--- a/packages/webpack-loader/src/utils/webpack.tsx
+++ b/packages/webpack-loader/src/utils/webpack.tsx
@@ -78,6 +78,32 @@ export const getOptimizeAssetsHook = (
 };
 
 /**
+ * Returns webpack 4 & 5 compatible merge assets hook.
+ * @param compiler
+ * @param compilation
+ * @returns
+ */
+export const getMergeAssetsHook = (
+  compiler: Compiler,
+  compilation: CompilationType
+): { tap: CompilationType['hooks']['processAssets']['tap'] } => {
+  const { Compilation } = compiler.webpack;
+  const processAssets = compilation.hooks.processAssets;
+
+  return {
+    tap: (pluginName: string, callback: (assets: CompilationType['assets']) => void) => {
+      processAssets.tap(
+        {
+          name: pluginName,
+          stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_COUNT,
+        },
+        callback
+      );
+    },
+  };
+};
+
+/**
  * Returns webpack 4 & 5 compatible sources.
  * @returns
  */


### PR DESCRIPTION
Closes #722

Seems to work, need to think about edge cases. As well as what happens with multiple entry points. This might also closes #669 as we remove the need for placing everything into a single style sheet via cache groups.

@jantimon how's this look?

**Changes**

- Compiled now supports async CSS chunks
- To enable this Compiled now takes control over the entire CSS pipeline
- Any CSS declared inside or outside of Compiled will be sorted and potentially hoisted if unsafe for atomic styles

**TODO**

- [x] Investigate potential edge cases & side effects
- [ ] Update docs to talk through how Compiled will take control of the entire CSS pipeline