### PR TITLE
Eval a computed object property in object styles

### DIFF
--- a/.changeset/chatty-yaks-act.md
+++ b/.changeset/chatty-yaks-act.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Adds a support of computed properties static evaluation in object styles.

--- a/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
+++ b/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
@@ -305,4 +305,24 @@ describe('import specifiers', () => {
     `);
     }).not.toThrow();
   });
+
+  it('handles the computed object property with static evaluation of variable', () => {
+    const actual = transform(`
+      import { styled } from '@compiled/react';
+      import React from 'react';
+
+      const media = '@media screen'
+      const obj = { [media]: { color: 'blue' } };
+
+      const Span = styled.span(obj);
+
+      function Component() {
+        return (
+          <Span />
+        );
+      };
+    `);
+
+    expect(actual).toInclude('"@media screen{._434713q2{color:blue}}');
+  });
 });

--- a/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
+++ b/packages/babel-plugin/src/__tests__/expression-evaluation.test.tsx
@@ -323,6 +323,6 @@ describe('import specifiers', () => {
       };
     `);
 
-    expect(actual).toInclude('"@media screen{._434713q2{color:blue}}');
+    expect(actual).toInclude('@media screen{._434713q2{color:blue}}');
   });
 });

--- a/packages/babel-plugin/src/utils/css-builders.tsx
+++ b/packages/babel-plugin/src/utils/css-builders.tsx
@@ -178,7 +178,7 @@ const extractObjectExpression = (node: t.ObjectExpression, meta: Metadata): CSSO
 
       callbackIfFileIncluded(meta, updatedMeta);
 
-      const key = getKey(prop.key);
+      const key = getKey(prop.computed ? evaluateExpression(prop.key, meta).value : prop.key);
       let value = '';
 
       if (t.isStringLiteral(propValue)) {


### PR DESCRIPTION
This PR adds a support of computed properties static evaluation in object styles. Consider following example:
```javascript
import { styled } from '@compiled/react';
import React from 'react';

const media = '@media screen'
const obj = { [media]: { color: 'blue' } };

const Span = styled.span(obj);

function Component() {
  return (
    <Span />
  );
};
```
Current implementation transpiles to something like this:
```javascript
import { forwardRef } from "react";
import { ax, ix, CC, CS } from "@compiled/react/runtime";
import React from "react";
const _ = "._40rh13q2 media{color:blue}";
const media = "@media screen";
const obj = { [media]: { color: "blue" } };
const Span = forwardRef(({ as: C = "span", style, ...props }, ref) => (
  <CC>
    <CS>{[_]}</CS>
    <C
      {...props}
      style={style}
      ref={ref}
      className={ax(["_40rh13q2", props.className])}
    />
  </CC>
));
if (process.env.NODE_ENV !== "production") {
  Span.displayName = "Span";
}
function Component() {
  return <Span />;
}
```
As it shows, the selector generates incorrectly and takes the identifier name `media` as a selector.

**Fix**: I slightly changed the object property key extraction to support computed props. So it transpiles to this code:
```javascript
import { forwardRef } from "react";
import { ax, ix, CC, CS } from "@compiled/react/runtime";
import React from "react";
const _ = "@media screen{._434713q2{color:blue}}";
const media = "@media screen";
const obj = { [media]: { color: "blue" } };
const Span = forwardRef(({ as: C = "span", style, ...props }, ref) => (
  <CC>
    <CS>{[_]}</CS>
    <C
      {...props}
      style={style}
      ref={ref}
      className={ax(["_434713q2", props.className])}
    />
  </CC>
));
if (process.env.NODE_ENV !== "production") {
  Span.displayName = "Span";
}
function Component() {
  return <Span />;
}
```
Thanks folks for awesome work!