### PR TITLE
Catch unhandled exception on inserting rules with prefixed selectors

### DIFF
--- a/.changeset/stale-badgers-exercise.md
+++ b/.changeset/stale-badgers-exercise.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Catch unhandled exception on inserting rules with prefixed selectors.

--- a/packages/react/src/runtime/sheet.tsx
+++ b/packages/react/src/runtime/sheet.tsx
@@ -135,7 +135,11 @@ export default function insertRule(css: string, opts: StyleSheetOpts): void {
 
   if (process.env.NODE_ENV === 'production') {
     const sheet = style.sheet as CSSStyleSheet;
-    sheet.insertRule(css, sheet.cssRules.length);
+
+    // Used to avoid unhandled exceptions across browsers with prefixed selectors such as -moz-placeholder.
+    try {
+      sheet.insertRule(css, sheet.cssRules.length);
+    } catch {}
   } else {
     style.appendChild(document.createTextNode(css));
   }


### PR DESCRIPTION
Usage of `::placeholder` pseudo element throws the error in production when it gets prefixed:

```
DOMException: Failed to execute 'insertRule' on 'CSSStyleSheet': Failed to parse the rule '._1idr12ax::-moz-placeholder{color:red}'.
```

After some research I found that Chrome specifically throws an exception on `insertRule` with prefixed pseudo elements. The easiest way to fix is to add try/catch block. For example, [Emotion](https://github.com/emotion-js/emotion/blob/f3c51e8aca287170e43110bee2e4527eacfcada4/packages/sheet/src/index.js#L137) handles the exception similarly. They even have a comment for `::placeholder` pseudo element and `:read-write` selector.

Reproduction: [Codesandbox](https://codesandbox.io/s/competent-bush-dcnoi?file=/pages/index.js) (development).
Demo: https://csb-dcnoi-ei3wqlflp-georgiyridgebox.vercel.app/ (production env where `insertRule` is used).

One thing that I can't figure out is how to make a test🙂 It requires a browser environment.
