### PR TITLE
feat(css function): add support of additional parameters

### DIFF
--- a/.changeset/red-kids-agree.md
+++ b/.changeset/red-kids-agree.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+add support of additional parameters to css function

--- a/packages/react/src/css/index.tsx
+++ b/packages/react/src/css/index.tsx
@@ -12,7 +12,8 @@ import type { CSSProps } from '../types';
  * https://compiledcssinjs.com/docs/api-css
  *
  * @param css
+ * @param values
  */
-export default function css(_css: TemplateStringsArray): CSSProps {
+export default function css(_css: TemplateStringsArray, ..._values:(string|number)[]): CSSProps {
   throw createSetupError();
 }


### PR DESCRIPTION
Add support of array additional parameters to css function.

The bug: 

```
 const colors = { blue: () => 'blue' };
  return (
    <div
      css={css`
      /*Expected 1 arguments, but got 2.*/
        background-color: ${colors.blue()};
        color: #00f;      `}>
      I&m blue
    </div>
  );
```
[Link](https://codesandbox.io/s/distracted-morning-ihd3h?file=/pages/index.tsx) to sandbox with the problem

[Proof to the solution on StackOverflow](https://stackoverflow.com/questions/49442210/template-interpolation-in-function-argument-results-in-ts2554expected-1-argumen)