### PR TITLE
Update package.json and tsconfig.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,44 +1,59 @@
 {
   "name": "compiled",
-  "private": true,
   "version": "0.0.0",
-  "author": "Michael Dougall",
+  "private": true,
   "license": "Apache-2.0",
+  "author": "Michael Dougall",
+  "workspaces": [
+    "packages/*",
+    "examples/packages/*"
+  ],
   "scripts": {
     "benchmark:all": "cd examples/packages/benchmarks && yarn all",
     "benchmark:ax": "cd examples/packages/benchmarks && yarn ax",
+    "benchmark:module-traversal": "cd packages/babel-plugin && yarn benchmark:module-traversal",
     "benchmark:ssr": "cd examples/packages/benchmarks && yarn ssr",
     "benchmark:stylesheet": "cd examples/packages/benchmarks && yarn stylesheet",
-    "benchmark:module-traversal": "cd packages/babel-plugin && yarn benchmark:module-traversal",
+    "build": "yarn build:esm && yarn build:cjs && yarn build:browser",
+    "build-ssr": "CI=false && yarn build && cd examples/packages/ssr && yarn build",
+    "build-storybook": "build-storybook",
+    "build:browser": "IS_NODE_EXPRESSION='false' ttsc --build packages/tsconfig.browser.json",
+    "build:cjs": "ttsc --build packages/tsconfig.cjs.json",
+    "build:esm": "ttsc --build packages/tsconfig.json && yarn build:examples-babel",
+    "build:examples-babel": "cd examples/packages/babel-component && yarn build",
+    "build:inspect": "node --inspect-brk node_modules/typescript/lib/tsc.js --build packages",
+    "build:parcel": "yarn build:browser && yarn build:esm && cd examples/packages/parcel && yarn build",
+    "build:webpack": "yarn build:browser && yarn build:esm && cd examples/packages/webpack && yarn build",
+    "build:webpack:extract": "yarn build:browser && yarn build:esm && cd examples/packages/webpack && EXTRACT_TO_CSS=true yarn build",
+    "bundlesize": "yarn build && size-limit",
     "clean": "rm -rf node_modules/.cache && rm -rf test/dead-code-elimination/dist && rm -f test/dead-code-elimination/tsconfig.tsbuildinfo && workspaces-run -- rm -rf dist -- rm -f tsconfig.tsbuildinfo -- rm -f tsconfig.browser.tsbuildinfo -- rm -rf build -- rm -rf tsconfig.cjs.tsbuildinfo -- rm -rf tsconfig.esm.tsbuildinfo",
+    "postinstall": "npx yarn-deduplicate && yarn --ignore-scripts",
+    "lint": "eslint --config .eslintrc.js --ext tsx,ts ./packages/**/src ./examples",
+    "lint:fix": "yarn lint -- --fix",
+    "prettier": "pretty-quick",
+    "release": "yarn clean && yarn build && yarn changeset publish",
     "start": "npx nodemon --exec \"yarn build:esm && start-storybook -p 6006 --ci\" --watch packages/babel-plugin/ -e tsx",
-    "start:ssr": "yarn build && cd examples/packages/ssr && yarn start",
-    "start:prod": "NODE_ENV=production yarn start",
-    "start:parcel": "yarn build:esm && cd examples/packages/parcel && yarn start",
     "start:cli": "cd packages/cli && yarn start",
     "start:inspect": "npx nodemon --exec \"node --inspect-brk node_modules/.bin/start-storybook -p 6006 --ci\" --watch packages/babel-plugin/ -e tsx",
+    "start:parcel": "yarn build:esm && cd examples/packages/parcel && yarn start",
+    "start:prod": "NODE_ENV=production yarn start",
+    "start:ssr": "yarn build && cd examples/packages/ssr && yarn start",
     "start:webpack": "yarn build:browser && yarn build:esm && cd examples/packages/webpack && yarn start",
     "start:webpack:extract": "yarn build:browser && yarn build:esm && cd examples/packages/webpack && EXTRACT_TO_CSS=true yarn start",
     "test": "yarn build:cjs && yarn build:esm && jest --no-cache",
-    "test:watch": "yarn build:esm && jest --no-cache --watch",
-    "test:imports": "node test/test-imports",
     "test:cover": "yarn test --collectCoverage",
-    "lint": "eslint --config .eslintrc.js --ext tsx,ts ./packages/**/src ./examples",
-    "lint:fix": "yarn lint -- --fix",
-    "build": "yarn build:esm && yarn build:cjs && yarn build:browser",
-    "build:esm": "ttsc --build packages/tsconfig.json && yarn build:examples-babel",
-    "build:cjs": "ttsc --build packages/tsconfig.cjs.json",
-    "build:examples-babel": "cd examples/packages/babel-component && yarn build",
-    "build:browser": "IS_NODE_EXPRESSION='false' ttsc --build packages/tsconfig.browser.json",
-    "build:inspect": "node --inspect-brk node_modules/typescript/lib/tsc.js --build packages",
-    "build:webpack": "yarn build:browser && yarn build:esm && cd examples/packages/webpack && yarn build",
-    "build:webpack:extract": "yarn build:browser && yarn build:esm && cd examples/packages/webpack && EXTRACT_TO_CSS=true yarn build",
-    "build:parcel": "yarn build:browser && yarn build:esm && cd examples/packages/parcel && yarn build",
-    "build-storybook": "build-storybook",
-    "build-ssr": "CI=false && yarn build && cd examples/packages/ssr && yarn build",
-    "bundlesize": "yarn build && size-limit",
-    "release": "yarn clean && yarn build && yarn changeset publish",
-    "postinstall": "npx yarn-deduplicate && yarn --ignore-scripts"
+    "test:imports": "node test/test-imports",
+    "test:watch": "yarn build:esm && jest --no-cache --watch"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": " yarn lint:fix && pretty-quick --staged"
+    }
+  },
+  "resolutions": {
+    "@babel/core": "^7.14.8",
+    "jest": "^26.6.3",
+    "typescript": "^4.2.4"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx-self": "^7.14.9",
@@ -80,20 +95,9 @@
     "typescript": "^4.2.4",
     "workspaces-run": "^1.0.1"
   },
-  "resolutions": {
-    "@babel/core": "^7.14.8",
-    "jest": "^26.6.3",
-    "typescript": "^4.2.4"
+  "engines": {
+    "node": "^v14.16.1"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": " yarn lint:fix && pretty-quick --staged"
-    }
-  },
-  "workspaces": [
-    "packages/*",
-    "examples/packages/*"
-  ],
   "size-limit": [
     {
       "path": "./packages/react/dist/browser/runtime.js",
@@ -119,8 +123,5 @@
         "react"
       ]
     }
-  ],
-  "engines": {
-    "node": "^v14.16.1"
-  }
+  ]
 }

--- a/packages/babel-plugin-strip-runtime/package.json
+++ b/packages/babel-plugin-strip-runtime/package.json
@@ -2,8 +2,6 @@
   "name": "@compiled/babel-plugin-strip-runtime",
   "version": "0.6.13",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "author": "Michael Dougall",
-  "license": "Apache-2.0",
   "homepage": "https://compiledcssinjs.com",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
@@ -11,6 +9,8 @@
     "url": "https://github.com/atlassian-labs/compiled.git",
     "directory": "packages/babel-plugin-strip-runtime"
   },
+  "license": "Apache-2.0",
+  "author": "Michael Dougall",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -22,8 +22,8 @@
   "dependencies": {
     "@babel/core": "^7.14.8",
     "@babel/helper-plugin-utils": "^7.14.5",
-    "@babel/types": "^7.14.9",
-    "@babel/traverse": "^7.14.9"
+    "@babel/traverse": "^7.14.9",
+    "@babel/types": "^7.14.9"
   },
   "devDependencies": {
     "@compiled/babel-plugin": "*",

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -2,8 +2,6 @@
   "name": "@compiled/babel-plugin",
   "version": "0.6.14",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "author": "Michael Dougall",
-  "license": "Apache-2.0",
   "homepage": "https://compiledcssinjs.com",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
@@ -11,6 +9,8 @@
     "url": "https://github.com/atlassian-labs/compiled.git",
     "directory": "packages/babel-plugin"
   },
+  "license": "Apache-2.0",
+  "author": "Michael Dougall",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,8 +2,6 @@
   "name": "@compiled/cli",
   "version": "0.6.9",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "author": "Michael Dougall",
-  "license": "Apache-2.0",
   "homepage": "https://compiledcssinjs.com",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
@@ -11,12 +9,11 @@
     "url": "https://github.com/atlassian-labs/compiled.git",
     "directory": "packages/cli"
   },
+  "license": "Apache-2.0",
+  "author": "Michael Dougall",
   "main": "./dist/main.js",
   "module": "./dist/main.js",
   "types": "./dist/main.d.ts",
-  "scripts": {
-    "start": "ts-node --files src/index.tsx"
-  },
   "bin": {
     "compiled-cli": "./dist/index.js"
   },
@@ -24,8 +21,8 @@
     "dist",
     "src"
   ],
-  "peerDependencies": {
-    "@compiled/react": ">=0.6.10"
+  "scripts": {
+    "start": "ts-node --files src/index.tsx"
   },
   "dependencies": {
     "app-root-path": "^3.0.0",
@@ -39,5 +36,8 @@
   },
   "devDependencies": {
     "@types/app-root-path": "^1.2.4"
+  },
+  "peerDependencies": {
+    "@compiled/react": ">=0.6.10"
   }
 }

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -2,8 +2,6 @@
   "name": "@compiled/css",
   "version": "0.6.11",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "author": "Michael Dougall",
-  "license": "Apache-2.0",
   "homepage": "https://compiledcssinjs.com",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
@@ -11,6 +9,8 @@
     "url": "https://github.com/atlassian-labs/compiled.git",
     "directory": "packages/css"
   },
+  "license": "Apache-2.0",
+  "author": "Michael Dougall",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -2,8 +2,6 @@
   "name": "@compiled/jest",
   "version": "0.6.9",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "author": "Michael Dougall",
-  "license": "Apache-2.0",
   "homepage": "https://compiledcssinjs.com",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
@@ -11,10 +9,12 @@
     "url": "https://github.com/atlassian-labs/compiled.git",
     "directory": "packages/jest"
   },
+  "license": "Apache-2.0",
+  "author": "Michael Dougall",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "sideEffects": false,
   "files": [
     "dist",
     "src",

--- a/packages/parcel-transformer/package.json
+++ b/packages/parcel-transformer/package.json
@@ -2,8 +2,6 @@
   "name": "@compiled/parcel-transformer",
   "version": "0.6.12",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "author": "Michael Dougall",
-  "license": "Apache-2.0",
   "homepage": "https://compiledcssinjs.com",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
@@ -11,10 +9,12 @@
     "url": "https://github.com/atlassian-labs/compiled.git",
     "directory": "packages/parcel-transformer"
   },
+  "license": "Apache-2.0",
+  "author": "Michael Dougall",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "sideEffects": false,
   "files": [
     "dist",
     "src",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,20 +2,6 @@
   "name": "@compiled/react",
   "version": "0.6.13",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "author": "Michael Dougall",
-  "license": "Apache-2.0",
-  "homepage": "https://compiledcssinjs.com",
-  "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/atlassian-labs/compiled.git",
-    "directory": "packages/react"
-  },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "browser": "./dist/browser/index.js",
-  "types": "./dist/esm/index.d.ts",
-  "sideEffects": false,
   "keywords": [
     "compiled",
     "css-in-js",
@@ -23,6 +9,16 @@
     "emotion-js",
     "typescript"
   ],
+  "homepage": "https://compiledcssinjs.com",
+  "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atlassian-labs/compiled.git",
+    "directory": "packages/react"
+  },
+  "license": "Apache-2.0",
+  "author": "Michael Dougall",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -37,6 +33,10 @@
       "require": "./dist/cjs/runtime.js"
     }
   },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "browser": "./dist/browser/index.js",
+  "types": "./dist/esm/index.d.ts",
   "files": [
     "dist",
     "src",
@@ -47,14 +47,14 @@
   "dependencies": {
     "csstype": "^3.0.8"
   },
-  "peerDependencies": {
-    "react": ">= 16.12.0"
-  },
   "devDependencies": {
     "@testing-library/react": "^11.2.7",
     "@types/jscodeshift": "^0.11.2",
     "jscodeshift": "^0.12.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
+  },
+  "peerDependencies": {
+    "react": ">= 16.12.0"
   }
 }

--- a/packages/tsconfig.options.json
+++ b/packages/tsconfig.options.json
@@ -1,23 +1,22 @@
 {
   "compilerOptions": {
-    "forceConsistentCasingInFileNames": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
-    "noImplicitAny": true,
-    "strict": true,
-    "noUnusedLocals": true,
+    "allowJs": true,
+    "composite": true,
+    "declaration": true,
     "esModuleInterop": true,
-    "noUnusedParameters": true,
+    "forceConsistentCasingInFileNames": true,
     "jsx": "react",
-    "resolveJsonModule": true,
+    "lib": ["dom", "es2016", "es2017.object"],
     "module": "es6",
     "moduleResolution": "node",
-    "composite": true,
-    "target": "es5",
-    "lib": ["dom", "es2016", "es2017.object"],
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
-    "declaration": true,
-    "allowJs": true
+    "strict": true,
+    "target": "es5"
   },
   "exclude": ["**/**.test.tsx", "**/dist", "**/__perf__/**"]
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,8 +2,6 @@
   "name": "@compiled/utils",
   "version": "0.6.11",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "author": "Michael Dougall",
-  "license": "Apache-2.0",
   "homepage": "https://compiledcssinjs.com",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
@@ -11,6 +9,8 @@
     "url": "https://github.com/atlassian-labs/compiled.git",
     "directory": "packages/utils"
   },
+  "license": "Apache-2.0",
+  "author": "Michael Dougall",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -2,8 +2,6 @@
   "name": "@compiled/webpack-loader",
   "version": "0.6.15",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "author": "Michael Dougall",
-  "license": "Apache-2.0",
   "homepage": "https://compiledcssinjs.com",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
@@ -11,6 +9,8 @@
     "url": "https://github.com/atlassian-labs/compiled.git",
     "directory": "packages/webpack-loader"
   },
+  "license": "Apache-2.0",
+  "author": "Michael Dougall",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -29,14 +29,14 @@
     "loader-utils": "^2.0.0",
     "webpack-sources": "^1.4.3"
   },
-  "peerDependencies": {
-    "webpack": ">= 4.46.0"
-  },
   "devDependencies": {
     "babel-loader": "^8.2.2",
     "css-loader": "^5.2.7",
     "memfs": "^3.2.2",
     "mini-css-extract-plugin": "^1.5.0",
     "webpack": "^5.46.0"
+  },
+  "peerDependencies": {
+    "webpack": ">= 4.46.0"
   }
 }


### PR DESCRIPTION
## Background
The `package.json` files and `tsconfig.json` files are hard to scan when they are not sorted alphabetically. This set of changes sorts both sets of files, removes a redundant tsconfig option (`noImplicitAny`), and adds in a `prettier` script so that prettier can be run directly outside of commits and IDE setups.

## Changes
* Sort package.json with sort-package-json
* Sort tsconfig.json alphabetically
* Add prettier script
* Remove noImplicitAny in favour of strict