### PR TITLE
Override the default storybook babel configuration

### DIFF
--- a/.storybook/.babelrc.json
+++ b/.storybook/.babelrc.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [["@compiled/babel-plugin", { "importReact": false }]],
+  "presets": ["@babel/preset-typescript", ["@babel/preset-react", { "runtime": "automatic" }]]
+}

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,7 +1,7 @@
 module.exports = {
   addons: ['storybook-addon-performance/register', 'storybook-addon-pseudo-states'],
-  stories: ['../examples/stories/*.tsx'],
   core: {
     builder: 'webpack5',
   },
+  stories: ['../examples/stories/*.tsx'],
 };

--- a/examples/stories/css-prop-string.tsx
+++ b/examples/stories/css-prop-string.tsx
@@ -10,7 +10,7 @@ export const TemplateLiteral = (): JSX.Element => {
     <div
       css={`
         display: flex;
-        font-size: 50px;
+        font-size: 30px;
         color: blue;
       `}>
       blue text
@@ -18,7 +18,7 @@ export const TemplateLiteral = (): JSX.Element => {
   );
 };
 
-export const TemplateLiteralCSS = (): JSX.Element => {
+export const InlineCssTaggedTemplateExpression = (): JSX.Element => {
   return (
     <div
       css={css`
@@ -29,6 +29,16 @@ export const TemplateLiteralCSS = (): JSX.Element => {
       red text
     </div>
   );
+};
+
+const taggedTemplateExpressionCss = css`
+  display: flex;
+  font-size: 30px;
+  color: green;
+`;
+
+export const CssTaggedTemplateExpression = (): JSX.Element => {
+  return <div css={taggedTemplateExpressionCss}>green text</div>;
 };
 
 export const UsingMixinImportSpread = (): JSX.Element => {


### PR DESCRIPTION
## Background
Currently, storybook does not allow a `css` style to be defined as a variable:

```tsx
import { css } from '@compiled/react';

export default {
  title: 'test',
};

const foo = css`
  color: blue;
`;

export const Foo = (): JSX.Element => (
  <div css={foo}>hello world</div>
);
```

```sh
SyntaxError: /compiled/examples/stories/foo.tsx: CallExpression isn't a supported CSS type - try using an object or string. (This is an error on an internal node. Probably an internal error. Location has been estimated.)
   5 | };
   6 |
>  7 | const foo = css`
     |             ^^^
   8 |   color: blue;
   9 | `;
  10 |
```

This seems to occur because the css tagged template expression is transpiled into a call expression, and this syntax is not supported. Instead, the babel plugin should run on the source code.

## Changes
* Add a `.babelrc.json` file to `.storybook`, which runs `@compiled/babel-plugin` first
* Add a new story for a tagged template defined by a variable 