### PR TITLE
Fix missing key prop on generated React elements

### DIFF
--- a/.changeset/long-chefs-matter.md
+++ b/.changeset/long-chefs-matter.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Fix missing key prop on generated React elements

--- a/examples/stories/css-prop-static-object.tsx
+++ b/examples/stories/css-prop-static-object.tsx
@@ -72,3 +72,13 @@ export const ObjectLiteralImportedObj = (): JSX.Element => {
     </div>
   );
 };
+
+export const ObjectLiteralMapWithKeys = (): JSX.Element => (
+  <div>
+    {['foo', 'bar'].map((string) => (
+      <div key={string} css={{ backgroundColor: 'blue' }}>
+        {string}
+      </div>
+    ))}
+  </div>
+);

--- a/examples/stories/styled-static-object.tsx
+++ b/examples/stories/styled-static-object.tsx
@@ -13,6 +13,18 @@ const Box = styled.div({ fontSize: 20 }, `color: blue;`, [{ padding: 20 }], {
   backgroundColor: 'red',
 });
 
+const Background = styled.div({
+  backgroundColor: 'blue',
+});
+
 export const ObjectLiteral = (): JSX.Element => <Thing>hello world</Thing>;
 
 export const StyledArgs = (): JSX.Element => <Box>HELLO WORLD</Box>;
+
+export const ObjectLiteralMapWithKeys = (): JSX.Element => (
+  <div>
+    {['foo', 'bar'].map((string) => (
+      <Background key={string}>{string}</Background>
+    ))}
+  </div>
+);

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
@@ -615,4 +615,19 @@ describe('css prop behaviour', () => {
 
     expect(actual).toInclude('ax([isPrimary&&"_syaz13q2 _1wybgktf"])');
   });
+
+  it('should retain keys for mapped react components', () => {
+    const actual = transform(`
+      import '@compiled/react';
+      import React from 'react';
+
+      ['foo', 'bar'].map((str) => (
+        <div key={str} css={{ backgroundColor: 'blue' }}>
+          {str}
+        </div>
+      ));
+    `);
+
+    expect(actual).toInclude('<CC key={str}>');
+  });
 });

--- a/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
@@ -729,4 +729,20 @@ describe('css prop object literal', () => {
 
     expect(actual).toInclude('{color:red}');
   });
+
+  it('should retain keys for mapped react components', () => {
+    const actual = transform(`
+        import '@compiled/react';
+
+        ['foo', 'bar'].map((str) => (
+          <div key={str} css={{ backgroundColor: 'blue' }}>
+            {str}
+          </div>
+        ));
+      `);
+
+    console.log(actual);
+    expect(actual).toMatch(/<CC key={.+}>/);
+    expect(actual).toMatch(/<CS key={.+}>/);
+  });
 });

--- a/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
@@ -729,18 +729,4 @@ describe('css prop object literal', () => {
 
     expect(actual).toInclude('{color:red}');
   });
-
-  it('should retain keys for mapped react components', () => {
-    const actual = transform(`
-        import '@compiled/react';
-
-        ['foo', 'bar'].map((str) => (
-          <div key={str} css={{ backgroundColor: 'blue' }}>
-            {str}
-          </div>
-        ));
-      `);
-
-    expect(actual).toInclude('<CC key={str}>');
-  });
 });

--- a/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/object-literal.test.tsx
@@ -741,8 +741,6 @@ describe('css prop object literal', () => {
         ));
       `);
 
-    console.log(actual);
-    expect(actual).toMatch(/<CC key={.+}>/);
-    expect(actual).toMatch(/<CS key={.+}>/);
+    expect(actual).toInclude('<CC key={str}>');
   });
 });


### PR DESCRIPTION
Fixes #802 

Simple change to add a key prop to generated React elements. This will suppress the React warning and remove the performance bug where React will always trigger re-rendering for children components ([per react docs](https://reactjs.org/docs/lists-and-keys.html)).