### PR TITLE
eslint consistent type imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,12 @@ module.exports = {
         argsIgnorePattern: '^_',
       },
     ],
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        prefer: 'type-imports',
+      },
+    ],
   },
   settings: {
     react: {

--- a/examples/packages/benchmarks/src/ax/benchmark.tsx
+++ b/examples/packages/benchmarks/src/ax/benchmark.tsx
@@ -1,5 +1,6 @@
 import { ax } from '@compiled/react/runtime';
-import Benchmark, { Event as BenchmarkEvent } from 'benchmark';
+import type { Event as BenchmarkEvent } from 'benchmark';
+import Benchmark from 'benchmark';
 import { newAx } from './playground';
 
 console.log('Start ax benchmarking');

--- a/examples/packages/benchmarks/src/ssr/benchmark.tsx
+++ b/examples/packages/benchmarks/src/ssr/benchmark.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
-import Benchmark, { Event as BenchmarkEvent } from 'benchmark';
+import type { Event as BenchmarkEvent } from 'benchmark';
+import Benchmark from 'benchmark';
 import { CC, CS } from '@compiled/react/runtime';
 import { CompiledComponent, StyleArr, StyleStr } from './playground';
 

--- a/examples/packages/benchmarks/src/stylesheet/benchmark.tsx
+++ b/examples/packages/benchmarks/src/stylesheet/benchmark.tsx
@@ -1,6 +1,7 @@
 import { createStyleSheet as css } from './playground';
 import createStyleSheet from '@compiled/react/dist/runtime/sheet';
-import Benchmark, { Event as BenchmarkEvent } from 'benchmark';
+import type { Event as BenchmarkEvent } from 'benchmark';
+import Benchmark from 'benchmark';
 
 console.log('Start stylesheet benchmarking');
 console.log();

--- a/packages/babel-plugin/src/__perf__/module-traversal-caching.tsx
+++ b/packages/babel-plugin/src/__perf__/module-traversal-caching.tsx
@@ -1,4 +1,5 @@
-import Benchmark, { Event as BenchmarkEvent } from 'benchmark';
+import type { Event as BenchmarkEvent } from 'benchmark';
+import Benchmark from 'benchmark';
 import { transformSync } from '@babel/core';
 
 import babelPlugin from '../index';

--- a/packages/babel-plugin/src/__tests__/index.test.tsx
+++ b/packages/babel-plugin/src/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
-import { transformSync, TransformOptions } from '@babel/core';
+import type { TransformOptions } from '@babel/core';
+import { transformSync } from '@babel/core';
 import babelNext from '../index';
 
 const babelOpts: TransformOptions = {

--- a/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
+++ b/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
@@ -1,6 +1,6 @@
 import { transformSync } from '@babel/core';
 import babelPlugin from '../index';
-import { PluginOptions } from '../types';
+import type { PluginOptions } from '../types';
 
 jest.mock('../utils/cache');
 

--- a/packages/babel-plugin/src/babel-plugin.tsx
+++ b/packages/babel-plugin/src/babel-plugin.tsx
@@ -2,7 +2,7 @@ import { declare } from '@babel/helper-plugin-utils';
 import template from '@babel/template';
 import * as t from '@babel/types';
 import jsxSyntax from '@babel/plugin-syntax-jsx';
-import { NodePath } from '@babel/traverse';
+import type { NodePath } from '@babel/traverse';
 import { unique } from '@compiled/utils';
 import * as path from 'path';
 import { importSpecifier } from './utils/ast-builders';
@@ -10,7 +10,7 @@ import { Cache } from './utils/cache';
 import { visitCssPropPath } from './css-prop';
 import { visitStyledPath } from './styled';
 import { visitClassNamesPath } from './class-names';
-import { State } from './types';
+import type { State } from './types';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkgJson = require('../package.json');

--- a/packages/babel-plugin/src/class-names/index.tsx
+++ b/packages/babel-plugin/src/class-names/index.tsx
@@ -1,5 +1,5 @@
 import * as t from '@babel/types';
-import { NodePath } from '@babel/core';
+import type { NodePath } from '@babel/core';
 import { transformCss } from '@compiled/css';
 import {
   pickFunctionBody,
@@ -8,8 +8,8 @@ import {
 } from '../utils/ast';
 import { compiledTemplate, buildCssVariablesProp } from '../utils/ast-builders';
 import { buildCss, getItemCss } from '../utils/css-builders';
-import { Metadata } from '../types';
-import { CSSOutput } from '../utils/types';
+import type { Metadata } from '../types';
+import type { CSSOutput } from '../utils/types';
 
 /**
  * Handles style prop value. If variables are present it will replace its value with it

--- a/packages/babel-plugin/src/css-prop/index.tsx
+++ b/packages/babel-plugin/src/css-prop/index.tsx
@@ -1,8 +1,8 @@
 import * as t from '@babel/types';
-import { NodePath } from '@babel/core';
+import type { NodePath } from '@babel/core';
 import { buildCompiledComponent } from '../utils/ast-builders';
 import { buildCss } from '../utils/css-builders';
-import { Metadata } from '../types';
+import type { Metadata } from '../types';
 
 const getJsxAttributeExpression = (node: t.JSXAttribute) => {
   if (t.isStringLiteral(node.value)) {

--- a/packages/babel-plugin/src/styled/index.tsx
+++ b/packages/babel-plugin/src/styled/index.tsx
@@ -1,9 +1,9 @@
 import * as t from '@babel/types';
-import { NodePath } from '@babel/core';
+import type { NodePath } from '@babel/core';
 import { buildCodeFrameError } from '../utils/ast';
 import { buildStyledComponent, buildDisplayName } from '../utils/ast-builders';
 import { buildCss } from '../utils/css-builders';
-import { Metadata, Tag } from '../types';
+import type { Metadata, Tag } from '../types';
 
 interface StyledData {
   tag: Tag;

--- a/packages/babel-plugin/src/types.tsx
+++ b/packages/babel-plugin/src/types.tsx
@@ -1,4 +1,4 @@
-import * as t from '@babel/types';
+import type * as t from '@babel/types';
 import type { NodePath } from '@babel/traverse';
 import type { PluginPass } from '@babel/core';
 import type { Cache } from './utils/cache';

--- a/packages/babel-plugin/src/utils/__tests__/cache.test.tsx
+++ b/packages/babel-plugin/src/utils/__tests__/cache.test.tsx
@@ -1,4 +1,5 @@
-import { Cache, CacheOptions } from '../cache';
+import type { CacheOptions } from '../cache';
+import { Cache } from '../cache';
 
 jest.mock('../cache');
 

--- a/packages/babel-plugin/src/utils/ast-builders.tsx
+++ b/packages/babel-plugin/src/utils/ast-builders.tsx
@@ -1,15 +1,16 @@
 import generate from '@babel/generator';
 import template from '@babel/template';
 import * as t from '@babel/types';
-import traverse, { NodePath, Visitor } from '@babel/traverse';
+import type { NodePath, Visitor } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { unique } from '@compiled/utils';
 import { transformCss } from '@compiled/css';
 import isPropValid from '@emotion/is-prop-valid';
-import { Tag } from '../types';
+import type { Tag } from '../types';
 import { getItemCss } from './css-builders';
 import { pickFunctionBody, resolveIdentifierComingFromDestructuring } from './ast';
-import { Metadata } from '../types';
-import { CSSOutput, CssItem } from '../utils/types';
+import type { Metadata } from '../types';
+import type { CSSOutput, CssItem } from '../utils/types';
 import { PROPS_IDENTIFIER_NAME } from '../constants';
 
 export interface StyledTemplateOpts {

--- a/packages/babel-plugin/src/utils/ast.tsx
+++ b/packages/babel-plugin/src/utils/ast.tsx
@@ -1,5 +1,6 @@
 import * as t from '@babel/types';
-import traverse, { NodePath } from '@babel/traverse';
+import type { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
 import { parse } from '@babel/parser';
 import fs from 'fs';
 import path from 'path';

--- a/packages/babel-plugin/src/utils/cache.tsx
+++ b/packages/babel-plugin/src/utils/cache.tsx
@@ -1,6 +1,6 @@
 import { hash } from '@compiled/utils';
 
-import { PluginOptions } from '../types';
+import type { PluginOptions } from '../types';
 
 export interface CacheOptions extends PluginOptions {
   cache?: boolean;

--- a/packages/babel-plugin/src/utils/css-builders.tsx
+++ b/packages/babel-plugin/src/utils/css-builders.tsx
@@ -2,7 +2,7 @@ import * as t from '@babel/types';
 import generate from '@babel/generator';
 import { addUnitIfNeeded, cssAfterInterpolation, cssBeforeInterpolation } from '@compiled/css';
 import { kebabCase, hash } from '@compiled/utils';
-import { Metadata } from '../types';
+import type { Metadata } from '../types';
 import {
   getKey,
   resolveBindingNode,
@@ -12,7 +12,7 @@ import {
   isCompiledKeyframesCallExpression,
 } from './ast';
 import { evaluateExpression } from './evaluate-expression';
-import { CSSOutput, CssItem, LogicalCssItem, SheetCssItem } from './types';
+import type { CSSOutput, CssItem, LogicalCssItem, SheetCssItem } from './types';
 
 /**
  * Will normalize the value of a `content` CSS property to ensure it has quotations around it.

--- a/packages/babel-plugin/src/utils/evaluate-expression.tsx
+++ b/packages/babel-plugin/src/utils/evaluate-expression.tsx
@@ -1,7 +1,7 @@
 import * as t from '@babel/types';
 import traverse from '@babel/traverse';
 
-import { Metadata } from '../types';
+import type { Metadata } from '../types';
 
 import {
   babelEvaluateExpression,

--- a/packages/babel-plugin/src/utils/types.tsx
+++ b/packages/babel-plugin/src/utils/types.tsx
@@ -1,4 +1,4 @@
-import * as t from '@babel/types';
+import type * as t from '@babel/types';
 import type { NodePath } from '@babel/traverse';
 import type { Metadata } from '../types';
 

--- a/packages/css/src/plugins/atomicify-rules.tsx
+++ b/packages/css/src/plugins/atomicify-rules.tsx
@@ -1,4 +1,5 @@
-import { plugin, Node, Declaration, decl, Container, rule, Rule, AtRule } from 'postcss';
+import type { Node, Declaration, Container, Rule, AtRule } from 'postcss';
+import { plugin, decl, rule } from 'postcss';
 import { hash } from '@compiled/utils';
 
 interface PluginOpts {

--- a/packages/css/src/plugins/discard-duplicates.tsx
+++ b/packages/css/src/plugins/discard-duplicates.tsx
@@ -1,4 +1,5 @@
-import { plugin, Declaration } from 'postcss';
+import type { Declaration } from 'postcss';
+import { plugin } from 'postcss';
 
 /**
  * Discards top level duplicate declarations.

--- a/packages/css/src/plugins/expand-shorthands/background.tsx
+++ b/packages/css/src/plugins/expand-shorthands/background.tsx
@@ -1,4 +1,4 @@
-import { ConversionFunction } from './types';
+import type { ConversionFunction } from './types';
 import { isColor } from './utils';
 
 /**

--- a/packages/css/src/plugins/expand-shorthands/flex-flow.tsx
+++ b/packages/css/src/plugins/expand-shorthands/flex-flow.tsx
@@ -1,5 +1,5 @@
-import { Node } from 'postcss-values-parser';
-import { ConversionFunction } from './types';
+import type { Node } from 'postcss-values-parser';
+import type { ConversionFunction } from './types';
 import { globalValues } from './utils';
 
 /**

--- a/packages/css/src/plugins/expand-shorthands/flex.tsx
+++ b/packages/css/src/plugins/expand-shorthands/flex.tsx
@@ -1,4 +1,4 @@
-import { ConversionFunction } from './types';
+import type { ConversionFunction } from './types';
 import { isWidth, getWidth } from './utils';
 
 /**

--- a/packages/css/src/plugins/expand-shorthands/index.tsx
+++ b/packages/css/src/plugins/expand-shorthands/index.tsx
@@ -1,6 +1,6 @@
 import { plugin } from 'postcss';
 import { parse } from 'postcss-values-parser';
-import { ConversionFunction } from './types';
+import type { ConversionFunction } from './types';
 import { margin } from './margin';
 import { padding } from './padding';
 import { placeContent } from './place-content';

--- a/packages/css/src/plugins/expand-shorthands/margin.tsx
+++ b/packages/css/src/plugins/expand-shorthands/margin.tsx
@@ -1,4 +1,4 @@
-import { ConversionFunction } from './types';
+import type { ConversionFunction } from './types';
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/CSS/margin

--- a/packages/css/src/plugins/expand-shorthands/outline.tsx
+++ b/packages/css/src/plugins/expand-shorthands/outline.tsx
@@ -1,5 +1,5 @@
-import { Node } from 'postcss-values-parser';
-import { ConversionFunction } from './types';
+import type { Node } from 'postcss-values-parser';
+import type { ConversionFunction } from './types';
 import { globalValues, isColor } from './utils';
 
 /**

--- a/packages/css/src/plugins/expand-shorthands/overflow.tsx
+++ b/packages/css/src/plugins/expand-shorthands/overflow.tsx
@@ -1,4 +1,4 @@
-import { ConversionFunction } from './types';
+import type { ConversionFunction } from './types';
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/CSS/overflow

--- a/packages/css/src/plugins/expand-shorthands/padding.tsx
+++ b/packages/css/src/plugins/expand-shorthands/padding.tsx
@@ -1,4 +1,4 @@
-import { ConversionFunction } from './types';
+import type { ConversionFunction } from './types';
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/CSS/padding

--- a/packages/css/src/plugins/expand-shorthands/place-content.tsx
+++ b/packages/css/src/plugins/expand-shorthands/place-content.tsx
@@ -1,4 +1,4 @@
-import { ConversionFunction } from './types';
+import type { ConversionFunction } from './types';
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/CSS/place-content

--- a/packages/css/src/plugins/expand-shorthands/place-items.tsx
+++ b/packages/css/src/plugins/expand-shorthands/place-items.tsx
@@ -1,4 +1,4 @@
-import { ConversionFunction } from './types';
+import type { ConversionFunction } from './types';
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/CSS/place-items

--- a/packages/css/src/plugins/expand-shorthands/place-self.tsx
+++ b/packages/css/src/plugins/expand-shorthands/place-self.tsx
@@ -1,4 +1,4 @@
-import { ConversionFunction } from './types';
+import type { ConversionFunction } from './types';
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/CSS/place-self

--- a/packages/css/src/plugins/expand-shorthands/text-decoration.tsx
+++ b/packages/css/src/plugins/expand-shorthands/text-decoration.tsx
@@ -1,5 +1,5 @@
-import { Node } from 'postcss-values-parser';
-import { ConversionFunction } from './types';
+import type { Node } from 'postcss-values-parser';
+import type { ConversionFunction } from './types';
 import { globalValues, isColor } from './utils';
 
 /**

--- a/packages/css/src/plugins/expand-shorthands/types.tsx
+++ b/packages/css/src/plugins/expand-shorthands/types.tsx
@@ -1,4 +1,4 @@
-import { Root as ValuesRoot } from 'postcss-values-parser';
+import type { Root as ValuesRoot } from 'postcss-values-parser';
 
 export type ConversionFunction = (
   value: ValuesRoot

--- a/packages/css/src/plugins/expand-shorthands/utils.tsx
+++ b/packages/css/src/plugins/expand-shorthands/utils.tsx
@@ -1,4 +1,4 @@
-import { Node } from 'postcss-values-parser';
+import type { Node } from 'postcss-values-parser';
 
 /**
  * Common global values

--- a/packages/css/src/plugins/normalize-css.tsx
+++ b/packages/css/src/plugins/normalize-css.tsx
@@ -1,5 +1,5 @@
 import cssnano from 'cssnano-preset-default';
-import { Plugin } from 'postcss';
+import type { Plugin } from 'postcss';
 import { normalizeCurrentColor } from './normalize-current-color';
 
 /**

--- a/packages/css/src/plugins/sort-at-rule-pseudos.tsx
+++ b/packages/css/src/plugins/sort-at-rule-pseudos.tsx
@@ -1,4 +1,5 @@
-import { plugin, Rule, AtRule } from 'postcss';
+import type { Rule, AtRule } from 'postcss';
+import { plugin } from 'postcss';
 import { styleOrder } from '../utils/style-ordering';
 
 const getPseudoClassScore = (selector: string) => {

--- a/packages/jest/src/index.tsx
+++ b/packages/jest/src/index.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { MatchFilter } from './types';
+import type { MatchFilter } from './types';
 
 declare global {
   namespace jest {

--- a/packages/jest/src/matchers.tsx
+++ b/packages/jest/src/matchers.tsx
@@ -1,5 +1,6 @@
-import CSS, { StyleRules, Media } from 'css';
-import { MatchFilter } from './types';
+import type { StyleRules, Media } from 'css';
+import CSS from 'css';
+import type { MatchFilter } from './types';
 
 type Arg = [{ [key: string]: string }, MatchFilter?];
 

--- a/packages/jest/src/types.tsx
+++ b/packages/jest/src/types.tsx
@@ -1,4 +1,4 @@
-import { Pseudos } from 'csstype';
+import type { Pseudos } from 'csstype';
 
 /**
  * {} is used to enabled the compiler to not reduce Target down to a string.

--- a/packages/react/src/class-names/index.tsx
+++ b/packages/react/src/class-names/index.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { createSetupError } from '../utils/error';
-import { CssFunction, BasicTemplateInterpolations } from '../types';
+import type { CssFunction, BasicTemplateInterpolations } from '../types';
 
 export type Interpolations = (BasicTemplateInterpolations | CssFunction | CssFunction[])[];
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -3,7 +3,7 @@ export { styled } from './styled';
 export { ClassNames } from './class-names';
 export { default as css } from './css';
 
-import { CssFunction } from './types';
+import type { CssFunction } from './types';
 
 declare module 'react' {
   // We must match the same type signature so the generic needs to stay.

--- a/packages/react/src/runtime/sheet.tsx
+++ b/packages/react/src/runtime/sheet.tsx
@@ -1,4 +1,4 @@
-import { StyleSheetOpts, Bucket } from './types';
+import type { StyleSheetOpts, Bucket } from './types';
 
 /**
  * Ordered style buckets using their short psuedo name.

--- a/packages/react/src/runtime/style-cache.tsx
+++ b/packages/react/src/runtime/style-cache.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createContext, useContext } from 'react';
 import { isNodeEnvironment } from './is-node';
-import { ProviderComponent, UseCacheHook } from './types';
+import type { ProviderComponent, UseCacheHook } from './types';
 
 /**
  * Cache to hold already used styles.

--- a/packages/react/src/runtime/style.tsx
+++ b/packages/react/src/runtime/style.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import insertRule, { getStyleBucketName, styleBucketOrdering } from './sheet';
 import { analyzeCssInDev } from './dev-warnings';
-import { StyleSheetOpts, Bucket } from './types';
+import type { StyleSheetOpts, Bucket } from './types';
 import { useCache } from './style-cache';
 import { isNodeEnvironment } from './is-node';
 

--- a/packages/react/src/styled/index.tsx
+++ b/packages/react/src/styled/index.tsx
@@ -1,6 +1,6 @@
-import { ComponentType } from 'react';
+import type { ComponentType } from 'react';
 import { createSetupError } from '../utils/error';
-import { BasicTemplateInterpolations, CssFunction, CSSProps } from '../types';
+import type { BasicTemplateInterpolations, CssFunction, CSSProps } from '../types';
 
 export interface FunctionIterpolation<TProps> {
   (props: TProps): CSSProps | string | number | boolean | undefined;

--- a/packages/react/src/types.tsx
+++ b/packages/react/src/types.tsx
@@ -1,4 +1,4 @@
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
 
 /**
  * Typing for the interpolations.

--- a/packages/webpack-loader/src/types.tsx
+++ b/packages/webpack-loader/src/types.tsx
@@ -1,5 +1,5 @@
 import type { RuleSetCondition } from 'webpack';
-import { pluginName } from './extract-plugin';
+import type { pluginName } from './extract-plugin';
 
 export interface CompiledLoaderOptions {
   /**


### PR DESCRIPTION
Introducing new rule [consistent-type-imports](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md).

As discussed in https://github.com/atlassian-labs/compiled/pull/790#discussion_r686423869