### PR TITLE
Make strip plugin work with esbuild/rollup bundled code

### DIFF
--- a/packages/babel-plugin-strip-runtime/src/__tests__/first-party-strip.test.tsx
+++ b/packages/babel-plugin-strip-runtime/src/__tests__/first-party-strip.test.tsx
@@ -115,7 +115,7 @@ describe('first party strip runtime', () => {
 
         const Component = () => <div css={{ fontSize: 12, color: 'blue' }}>hello world</div>
       `;
-      console.log(baked);
+
       const actual = transform({ runtime: 'classic', run: 'extract' })(baked);
 
       expect(actual).toMatchInlineSnapshot(`

--- a/packages/babel-plugin-strip-runtime/src/__tests__/first-party-strip.test.tsx
+++ b/packages/babel-plugin-strip-runtime/src/__tests__/first-party-strip.test.tsx
@@ -193,7 +193,7 @@ describe('first party strip runtime', () => {
         });
       `;
 
-      const actual = transform({ runtime: 'classic', run: 'extract' })(baked);
+      const actual = transform({ runtime: 'automatic', run: 'extract' })(baked);
 
       expect(actual).toMatchInlineSnapshot(`
         "import { ax as ax2, ix as ix2 } from \\"@compiled/react/runtime\\";

--- a/packages/babel-plugin-strip-runtime/src/__tests__/first-party-strip.test.tsx
+++ b/packages/babel-plugin-strip-runtime/src/__tests__/first-party-strip.test.tsx
@@ -152,7 +152,7 @@ describe('first party strip runtime', () => {
       `);
     });
 
-    it('should remove CSS prop runtime when js is bundled by other tools (eg. esbuild/rollup)', () => {
+    it('should remove CSS prop runtime when js is bundled by other tools (eg. esbuild/rollup) classic', () => {
       const baked = `
         import React4 from "react";
         import { ax as ax2, ix as ix2, CC as CC2, CS as CS2 } from "@compiled/react/runtime";
@@ -172,6 +172,38 @@ describe('first party strip runtime', () => {
         const Component = () => /*#__PURE__*/React4.createElement(\\"div\\", {
           className: ax2([\\"_1wyb1fwx _syaz13q2\\"])
         }, \\"hello world\\");"
+      `);
+    });
+
+    it('should remove CSS prop runtime when js is bundled by other tools (eg. esbuild/rollup) automatic', () => {
+      const baked = `
+        import { ax as ax2, ix as ix2, CC as CC2, CS as CS2 } from "@compiled/react/runtime";
+        import { jsxs as _jsxs2 } from "react/jsx-runtime";
+        import { jsx as _jsx2 } from "react/jsx-runtime";
+        const _2 = "._syaz13q2{color:blue}";
+        const _ = "._1wyb1fwx{font-size:12px}";
+
+        const Component = () => /*#__PURE__*/_jsxs2(CC, {
+          children: [/*#__PURE__*/_jsx2(CS2, {
+            children: [_, _2]
+          }), /*#__PURE__*/_jsx2("div", {
+            className: ax2(["_1wyb1fwx _syaz13q2"]),
+            children: "hello world"
+          })]
+        });
+      `;
+
+      const actual = transform({ runtime: 'classic', run: 'extract' })(baked);
+
+      expect(actual).toMatchInlineSnapshot(`
+        "import { ax as ax2, ix as ix2 } from \\"@compiled/react/runtime\\";
+        import { jsxs as _jsxs2 } from \\"react/jsx-runtime\\";
+        import { jsx as _jsx2 } from \\"react/jsx-runtime\\";
+
+        const Component = () => _jsx2(\\"div\\", {
+          className: ax2([\\"_1wyb1fwx _syaz13q2\\"]),
+          children: \\"hello world\\"
+        });"
       `);
     });
 

--- a/packages/babel-plugin-strip-runtime/src/__tests__/first-party-strip.test.tsx
+++ b/packages/babel-plugin-strip-runtime/src/__tests__/first-party-strip.test.tsx
@@ -115,7 +115,7 @@ describe('first party strip runtime', () => {
 
         const Component = () => <div css={{ fontSize: 12, color: 'blue' }}>hello world</div>
       `;
-
+      console.log(baked);
       const actual = transform({ runtime: 'classic', run: 'extract' })(baked);
 
       expect(actual).toMatchInlineSnapshot(`
@@ -149,6 +149,29 @@ describe('first party strip runtime', () => {
           className: ax([\\"_1wyb1fwx _syaz13q2\\"]),
           children: \\"hello world\\"
         });"
+      `);
+    });
+
+    it('should remove CSS prop runtime when js is bundled by other tools (eg. esbuild/rollup)', () => {
+      const baked = `
+        import React4 from "react";
+        import { ax as ax2, ix as ix2, CC as CC2, CS as CS2 } from "@compiled/react/runtime";
+        const _2 = "._syaz13q2{color:blue";
+        const _ = "._1wyb1fwx{font-size:12px";
+
+        const Component = () => /*#__PURE__*/React4.createElement(CC2, null, /*#__PURE__*/React4.createElement(CS2, null, [_, _2]), /*#__PURE__*/React4.createElement("div", {
+          className: ax2(["_1wyb1fwx _syaz13q2"])
+        }, "hello world"));`;
+
+      const actual = transform({ runtime: 'classic', run: 'extract' })(baked);
+
+      expect(actual).toMatchInlineSnapshot(`
+        "import React4 from \\"react\\";
+        import { ax as ax2, ix as ix2 } from \\"@compiled/react/runtime\\";
+
+        const Component = () => /*#__PURE__*/React4.createElement(\\"div\\", {
+          className: ax2([\\"_1wyb1fwx _syaz13q2\\"])
+        }, \\"hello world\\");"
       `);
     });
 

--- a/packages/babel-plugin-strip-runtime/src/index.tsx
+++ b/packages/babel-plugin-strip-runtime/src/index.tsx
@@ -65,8 +65,7 @@ export default declare<PluginPass>((api) => {
           // We've found something that looks like React.createElement(...)
           // Now we want to check if it's from the Compiled Runtime and if it is - replace with its children.
           const component = path.node.arguments[0];
-          // @ts-ignore
-          if (!isCCComponent(component) && !this.removed.has(component.name)) {
+          if (!isCCComponent(component, this.removed)) {
             return;
           }
 
@@ -86,8 +85,7 @@ export default declare<PluginPass>((api) => {
           // We've found something that looks like _jsxs(...)
           // Now we want to check if it's from the Compiled Runtime and if it is - replace with its children.
           const component = path.node.arguments[0];
-          // @ts-ignore
-          if (!isCCComponent(component) && !this.removed.has(component.name)) {
+          if (!isCCComponent(component, this.removed)) {
             return;
           }
 

--- a/packages/babel-plugin-strip-runtime/src/index.tsx
+++ b/packages/babel-plugin-strip-runtime/src/index.tsx
@@ -16,6 +16,7 @@ export default declare<PluginPass>((api) => {
     name: '@compiled/babel-plugin-strip-runtime',
     pre() {
       this.styleRules = [];
+      this.removed = new Set();
     },
     visitor: {
       Program: {
@@ -27,6 +28,7 @@ export default declare<PluginPass>((api) => {
       },
       ImportSpecifier(path) {
         if (t.isIdentifier(path.node.imported) && ['CC', 'CS'].includes(path.node.imported.name)) {
+          this.removed.add(path.node.local.name);
           path.remove();
         }
       },
@@ -63,7 +65,8 @@ export default declare<PluginPass>((api) => {
           // We've found something that looks like React.createElement(...)
           // Now we want to check if it's from the Compiled Runtime and if it is - replace with its children.
           const component = path.node.arguments[0];
-          if (!isCCComponent(component)) {
+          // @ts-ignore
+          if (!isCCComponent(component) && !this.removed.has(component.name)) {
             return;
           }
 
@@ -83,7 +86,8 @@ export default declare<PluginPass>((api) => {
           // We've found something that looks like _jsxs(...)
           // Now we want to check if it's from the Compiled Runtime and if it is - replace with its children.
           const component = path.node.arguments[0];
-          if (!isCCComponent(component)) {
+          // @ts-ignore
+          if (!isCCComponent(component) && !this.removed.has(component.name)) {
             return;
           }
 

--- a/packages/babel-plugin-strip-runtime/src/types.tsx
+++ b/packages/babel-plugin-strip-runtime/src/types.tsx
@@ -10,4 +10,8 @@ export interface PluginPass {
    * Stores all found style rules during the file pass.
    */
   styleRules: string[];
+  /**
+   * Stores all removed node (local) names during the file pass.
+   */
+  removed: Set<string>;
 }

--- a/packages/babel-plugin-strip-runtime/src/utils/ast.tsx
+++ b/packages/babel-plugin-strip-runtime/src/utils/ast.tsx
@@ -13,7 +13,7 @@ export const isCreateElement = (node: t.Node): node is t.CallExpression => {
   return (
     t.isMemberExpression(node) &&
     t.isIdentifier(node.object) &&
-    node.object.name === 'React' &&
+    node.object.name.startsWith('React') &&
     t.isIdentifier(node.property) &&
     node.property.name === 'createElement'
   );

--- a/packages/babel-plugin-strip-runtime/src/utils/ast.tsx
+++ b/packages/babel-plugin-strip-runtime/src/utils/ast.tsx
@@ -32,7 +32,8 @@ export const isAutomaticRuntime = (
   func: 'jsx' | 'jsxs'
 ): node is t.CallExpression => {
   if (t.isCallExpression(node)) {
-    if (t.isIdentifier(node.callee) && node.callee.name === `_${func}`) {
+    // Different bundlers (eg esbuild/rollup) may append affix to func name
+    if (t.isIdentifier(node.callee) && node.callee.name.startsWith(`_${func}`)) {
       return true;
     }
 
@@ -40,7 +41,8 @@ export const isAutomaticRuntime = (
       t.isSequenceExpression(node.callee) &&
       t.isMemberExpression(node.callee.expressions[1]) &&
       t.isIdentifier(node.callee.expressions[1].property) &&
-      node.callee.expressions[1].property.name === func
+      // Different bundlers (eg esbuild/rollup) may append affix to func name
+      node.callee.expressions[1].property.name.startsWith(func)
     ) {
       return true;
     }


### PR DESCRIPTION
Currently the strip plugin checks for exact matches of React/CC/CS to replace/remove. Tools like rollup and esbuild often rename imports by adding a number (eg `import React from 'react'` becomes `import React2 from 'react'`). This makes it that the plugin does not work with input from these tools.

Example input:
```js
import React4 from "react";
import { ax as ax2, ix as ix2, CC as CC2, CS as CS2 } from "@compiled/react/runtime";
const _2 = "._syaz13q2{color:blue";
const _ = "._1wyb1fwx{font-size:12px";

const Component = () => /*#__PURE__*/React4.createElement(CC2, null, /*#__PURE__*/React4.createElement(CS2, null, [_, _2]), /*#__PURE__*/React4.createElement("div", {
  className: ax2(["_1wyb1fwx _syaz13q2"])
}, "hello world"));
```

This PR makes the `isComponent` check less strict by checking if a node name starts with `"React"` vs checking if it equals `"React"`. It also now stores the imports that it removed and will remove any calls that match one of those imports.

This makes the plugin fully functional in the cases that I have tested (stripping runtime from code bundled with esbuild)