### PR TITLE
Update codemod plugin API

### DIFF
--- a/.changeset/real-suits-film.md
+++ b/.changeset/real-suits-film.md
@@ -1,0 +1,5 @@
+---
+'@compiled/codemods': minor
+---
+
+Update codemod plugin API to include all parameters from jscodeshift

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -12,23 +12,28 @@
 Codemods support a simple plugin system where supported implementations can be overridden. The `CodemodPlugin` interface
 lists all the supported methods to be re-implemented. See the following example:
 
-```javascript
-import { JSCodeshift, Collection, ImportDeclaration } from 'jscodeshift';
-import { CodemodPlugin } from '@compiled/codemods';
-
-const insertBeforeImport = ({
-  j,
-}: {
-  j: JSCodeshift,
-  newImport: Collection<ImportDeclaration>,
-}): ImportDeclaration =>
-  j.importDeclaration(
-    [j.importSpecifier(j.identifier('getFeatureFlag'))],
-    j.literal('./feature-flag')
-  );
+```ts
+import type { API, FileInfo, Options } from 'jscodeshift';
+import type { CodemodPlugin } from '@compiled/codemods';
 
 const ExampleCodemodPlugin: CodemodPlugin = {
-  migrationTransform: { insertBeforeImport },
+  name: 'example-codemod-plugin',
+  create: (fileInfo: FileInfo, { jscodeshift: j }: API, options: Options) => ({
+    visitor: {
+      program({ program }) {
+        j(program)
+          .find(j.ImportDeclaration)
+          .at(-1)
+          .get()
+          .insertAfter(
+            j.importDeclaration(
+              [j.importSpecifier(j.identifier('getFeatureFlag'))],
+              j.literal('./feature-flags')
+            )
+          );
+      },
+    },
+  }),
 };
 
 export default ExampleCodemodPlugin;

--- a/packages/codemods/src/index.ts
+++ b/packages/codemods/src/index.ts
@@ -1,4 +1,11 @@
-export type { MigrationTransformer, CodemodPlugin } from './plugins/types';
+export type {
+  BuildImportContext,
+  CodemodPlugin,
+  CodemodPluginInstance,
+  ProgramVisitorContext,
+  Transform,
+  Visitor,
+} from './plugins/types';
 
-export { default as EmotionToCompiled } from './transforms/emotion-to-compiled';
-export { default as StyledComponentsToCompiled } from './transforms/styled-components-to-compiled';
+export { default as emotionToCompiled } from './transforms/emotion-to-compiled';
+export { default as styledComponentsToCompiled } from './transforms/styled-components-to-compiled';

--- a/packages/codemods/src/plugins/default.ts
+++ b/packages/codemods/src/plugins/default.ts
@@ -1,39 +1,22 @@
-import type { ImportDeclaration, JSCodeshift } from 'jscodeshift';
-import type { PluginMetadata, MigrationTransformer, CodemodPlugin } from './types';
+import type { CodemodPlugin } from './types';
 
-const buildImport = ({
-  j,
-  currentNode,
-  defaultSpecifierName,
-  namedImport,
-  compiledImportPath,
-}: {
-  processedPlugins: Array<PluginMetadata>;
-  j: JSCodeshift;
-  originalNode: ImportDeclaration;
-  currentNode: ImportDeclaration;
-  defaultSpecifierName: string;
-  namedImport: string;
-  compiledImportPath: string;
-}): ImportDeclaration => {
-  const newImport = j.importDeclaration(
-    [j.importSpecifier(j.identifier(namedImport), j.identifier(defaultSpecifierName))],
-    j.literal(compiledImportPath)
-  );
+const defaultCodemodPlugin: CodemodPlugin = {
+  name: 'default-plugin',
+  create: (_, { jscodeshift: j }) => ({
+    transform: {
+      buildImport({ compiledImportPath, currentNode, defaultSpecifierName, namedImport }) {
+        const newImport = j.importDeclaration(
+          [j.importSpecifier(j.identifier(namedImport), j.identifier(defaultSpecifierName))],
+          j.literal(compiledImportPath)
+        );
 
-  // Copy the comments from the previous import to the new one
-  newImport.comments = currentNode.comments;
+        // Copy the comments from the previous import to the new one
+        newImport.comments = currentNode.comments;
 
-  return newImport;
+        return newImport;
+      },
+    },
+  }),
 };
 
-export const migrationTransform: MigrationTransformer = {
-  buildImport,
-};
-
-const DefaultCodemodPlugin: CodemodPlugin = {
-  metadata: { name: 'default' },
-  migrationTransform,
-};
-
-export default DefaultCodemodPlugin;
+export default defaultCodemodPlugin;

--- a/packages/codemods/src/plugins/types.ts
+++ b/packages/codemods/src/plugins/types.ts
@@ -1,4 +1,4 @@
-import type { ImportDeclaration, JSCodeshift, Program } from 'jscodeshift';
+import type { API, FileInfo, ImportDeclaration, Options, Program } from 'jscodeshift';
 
 // We want to ensure the config contract is correct so devs can get type safety
 type ValidateConfig<T, Struct> = T extends Struct
@@ -7,71 +7,58 @@ type ValidateConfig<T, Struct> = T extends Struct
     : never
   : never;
 
-export interface PluginMetadata {
-  name: string;
+export type BuildImportContext<T> = ValidateConfig<
+  T,
+  {
+    // The original import node in the source code
+    originalNode: ImportDeclaration;
+    // The existing import node that will be replaced
+    currentNode: ImportDeclaration;
+    // The import name
+    defaultSpecifierName: string;
+    // The export from Compiled to be imported
+    namedImport: string;
+    // The import path for Compiled
+    compiledImportPath: string;
+  }
+>;
+
+/**
+ * Interface for codemods that handle migration from CSS-in-JS libraries to Compiled
+ */
+export interface Transform {
+  /**
+   * Build the compiled import replacing the existing import
+   *
+   * @param context {BuildImportContext} The context applied to the build import
+   * @returns {ImportDeclaration} The import to replace config.currentNode
+   */
+  buildImport?<T>(context: BuildImportContext<T>): ImportDeclaration;
 }
 
-type BaseConfig = {
-  processedPlugins: Array<PluginMetadata>;
-  j: JSCodeshift;
-};
+export type ProgramVisitorContext<T> = ValidateConfig<
+  T,
+  {
+    // The initial state of the program (before any processing)
+    originalProgram: Program;
+    // The current state of the program
+    program: Program;
+  }
+>;
 
 /**
  * Visitor interface for interacting with the AST
  */
 export interface Visitor {
-  /**
-   * Program visitor
-   *
-   * @param config The configuration object
-   * @param config.processedPlugins The plugins processed so far
-   * @param config.j The JSCodeshift object
-   * @param config.originalProgram The initial state of the program (before any processing)
-   * @param config.program The current state of the program
-   */
-  program?<T>(
-    config: ValidateConfig<
-      T,
-      BaseConfig & {
-        originalProgram: Program;
-        program: Program;
-      }
-    >
-  ): void;
+  program?<T>(context: ProgramVisitorContext<T>): void;
 }
 
-/**
- * Interface for codemods that handle migration from CSS-in-JS libraries to Compiled
- */
-export interface MigrationTransformer {
-  /**
-   * Build the compiled import replacing the existing import
-   *
-   * @param config The configuration object
-   * @param config.j The JSCodeshift object
-   * @param config.currentNode The existing import node that will be replaced
-   * @param config.defaultSpecifierName The import name
-   * @param config.namedImport The export from Compiled to be imported
-   * @param config.compiledImportPath The import path for Compiled
-   *
-   * @returns The import to replace config.currentNode
-   */
-  buildImport?<T>(
-    config: ValidateConfig<
-      T,
-      BaseConfig & {
-        originalNode: ImportDeclaration;
-        currentNode: ImportDeclaration;
-        defaultSpecifierName: string;
-        namedImport: string;
-        compiledImportPath: string;
-      }
-    >
-  ): ImportDeclaration;
+export interface CodemodPluginInstance {
+  transform?: Transform;
+  visitor?: Visitor;
 }
 
 export interface CodemodPlugin {
-  metadata: PluginMetadata;
-  visitor?: Visitor;
-  migrationTransform?: MigrationTransformer;
+  name: string;
+  create(file: FileInfo, api: API, options: Options): CodemodPluginInstance;
 }

--- a/packages/codemods/src/transforms/emotion-to-compiled/__tests__/emotion-to-compiled.test.tsx
+++ b/packages/codemods/src/transforms/emotion-to-compiled/__tests__/emotion-to-compiled.test.tsx
@@ -1,15 +1,17 @@
+import type { API, FileInfo } from 'jscodeshift';
+
+import type { ProgramVisitorContext } from '../../../plugins/types';
+import transformer from '../emotion-to-compiled';
+
 jest.disableAutomock();
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const defineInlineTest = require('jscodeshift/dist/testUtils').defineInlineTest;
 
-import type { JSCodeshift, Program } from 'jscodeshift';
-import { transformer } from '../emotion-to-compiled';
-
 describe('emotion-to-compiled transformer', () => {
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     "import styled from '@emotion/styled';",
     "import { styled } from '@compiled/react';",
     'it transforms default @emotion/styled imports'
@@ -17,7 +19,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     "import sc from '@emotion/styled';",
     "import { styled as sc } from '@compiled/react';",
     'it transforms default with different name than "styled" @emotion/styled imports'
@@ -25,7 +27,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     import { ClassNames } from '@emotion/core';
     `,
@@ -37,7 +39,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css, jsx, ClassNames } from '@emotion/core';
@@ -51,7 +53,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css as c, jsx, ClassNames as CN } from '@emotion/core';
@@ -65,7 +67,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css, jsx, ClassNames } from '@emotion/core';
@@ -80,7 +82,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css as c, jsx, ClassNames as CN } from '@emotion/core';
@@ -95,7 +97,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css, jsx } from '@emotion/core';
@@ -109,7 +111,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css, jsx } from '@emotion/core';
@@ -148,7 +150,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css as c, jsx } from '@emotion/core';
@@ -187,7 +189,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { jsx } from '@emotion/core';
@@ -220,7 +222,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { jsx } from '@emotion/core';
@@ -253,7 +255,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import _ from 'lodash';
@@ -269,7 +271,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import styled from '@emotion/styled';
@@ -284,7 +286,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css, jsx } from '@emotion/core';
@@ -301,7 +303,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css, jsx } from '@emotion/core';
@@ -319,7 +321,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css, jsx } from '@emotion/core';
@@ -337,7 +339,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { css, jsx } from '@emotion/core';
@@ -355,7 +357,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { ClassNames, CSSObject, css as c, jsx } from '@emotion/core';
@@ -413,7 +415,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     // @top-level comment
 
@@ -436,7 +438,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     // @top-level comment
 
@@ -459,7 +461,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     `
     /** @jsx jsx */
     import { ClassNames as CN, css as c, jsx } from '@emotion/core';
@@ -519,7 +521,7 @@ describe('emotion-to-compiled transformer', () => {
 
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
-    { pluginModules: [] },
+    { plugins: [] },
     "import * as React from 'react';",
     "import * as React from 'react';",
     'it should not transform when emotion imports are not present'
@@ -528,16 +530,19 @@ describe('emotion-to-compiled transformer', () => {
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
     {
-      pluginModules: [
+      plugins: [
         {
-          migrationTransform: {
-            buildImport: ({ j }) =>
-              j.expressionStatement(
-                j.callExpression(j.memberExpression(j.identifier('console'), j.identifier('log')), [
-                  j.literal('Bring back Netscape'),
-                ])
-              ),
-          },
+          create: (_: FileInfo, { jscodeshift: j }: API) => ({
+            transform: {
+              buildImport: () =>
+                j.expressionStatement(
+                  j.callExpression(
+                    j.memberExpression(j.identifier('console'), j.identifier('log')),
+                    [j.literal('Bring back Netscape')]
+                  )
+                ),
+            },
+          }),
         },
       ],
     },
@@ -549,22 +554,24 @@ describe('emotion-to-compiled transformer', () => {
   defineInlineTest(
     { default: transformer, parser: 'tsx' },
     {
-      pluginModules: [
+      plugins: [
         {
-          visitor: {
-            program: ({ j, program }: { j: JSCodeshift; program: Program }) => {
-              j(program)
-                .find(j.ImportDeclaration)
-                .insertBefore(() =>
-                  j.expressionStatement(
-                    j.callExpression(
-                      j.memberExpression(j.identifier('console'), j.identifier('log')),
-                      [j.literal('Bring back Netscape')]
+          create: (_: FileInfo, { jscodeshift: j }: API) => ({
+            visitor: {
+              program: ({ program }: ProgramVisitorContext<void>) => {
+                j(program)
+                  .find(j.ImportDeclaration)
+                  .insertBefore(() =>
+                    j.expressionStatement(
+                      j.callExpression(
+                        j.memberExpression(j.identifier('console'), j.identifier('log')),
+                        [j.literal('Bring back Netscape')]
+                      )
                     )
-                  )
-                );
+                  );
+              },
             },
-          },
+          }),
         },
       ],
     },


### PR DESCRIPTION
Updates the `@compiled/codemods` plugin system to support some use-cases necessary for usage in Jira, using an API that is similar to `eslint`.

## Changes
* Add a `minor` version changeset, since the codemod plugin has not been published yet
* Update `README.md` with the new usage
* Update `withPlugin` to:
  * Accept both `plugin` from the CLI and `plugins` for programmatic usage
  * Handle both plugin paths and plugin objects
  * Resolve synchronously when provided a plugin object is provided, so that the tests can use the public API
  * Add the `normalizedPlugins` over `pluginModules` option (naming similar-ish to babel)
* Update the plugin configuration, and associated usages
  * Flatten `metadata` 
  * Rename `migrationTransform` to `transform`
  * Place `transform` and `visitor` in a `create` function, which has access to the information from jscodeshift
* Remove `processedPlugins` as it is not needed in the short term, it can be re-added once it becomes necessary
* Rename
  * `EmotionToCompiled` to `emotionToCompiled`
  * `StyledComponentsToCompiled` to `styledComponentsToCompiled`
* Add types
  * `BuildImportContext`
  * `ProgramVisitorContext`
  * `CodemodPluginInstance`
* Use `plugins` over `pluginModules` in tests