### PR TITLE
Fix ternary condition applying all styles when taking truthy path

### DIFF
--- a/.changeset/cold-toes-perform.md
+++ b/.changeset/cold-toes-perform.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+**Breaking change:** Ternary conditionals will no longer add falsy path styles when expression evaluates truthy

--- a/examples/stories/conditional-rules-styled.tsx
+++ b/examples/stories/conditional-rules-styled.tsx
@@ -72,6 +72,10 @@ const KeyValueString = styled.div<TextProps>`
   ${(props) => (props.isPrimary ? 'color: green' : `color: red`)};
 `;
 
+const NoValuePath = styled.div<TextProps>`
+  ${(props) => (props.isPrimary ? undefined : 'color: red')}
+`;
+
 export const PrimaryTextWithTemplateLiteral = (): JSX.Element => {
   return <TextWithTemplateLiteral isPrimary>Hello primary</TextWithTemplateLiteral>;
 };
@@ -175,3 +179,12 @@ export const TextWithKeyValueString = (): JSX.Element => (
     <KeyValueString isPrimary={false}>color: red</KeyValueString>
   </div>
 );
+
+export const ConditionWithNoValuePath = (): JSX.Element => {
+  return (
+    <div>
+      <NoValuePath isPrimary>Primary path with no given CSS</NoValuePath>
+      <NoValuePath>Secondary path with CSS</NoValuePath>
+    </div>
+  );
+};

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.tsx
@@ -475,7 +475,7 @@ describe('styled component behaviour', () => {
     expect(actual).toIncludeMultiple([
       '._syazbf54{color:green}',
       '._syaz5scu{color:red}',
-      'className={ax(["_syaz5scu",props.isPrimary&&"_syazbf54",props.className])}',
+      'className={ax(["",props.isPrimary&&"_syazbf54",!props.isPrimary&&"_syaz5scu",props.className])}',
     ]);
   });
 
@@ -491,7 +491,7 @@ describe('styled component behaviour', () => {
     expect(actual).toIncludeMultiple([
       '._syazbf54{color:green}',
       '._syaz5scu{color:red}',
-      'className={ax(["_syaz5scu",props.isPrimary&&"_syazbf54",props.className])}',
+      'className={ax(["",props.isPrimary&&"_syazbf54",!props.isPrimary&&"_syaz5scu",props.className])}',
     ]);
   });
 
@@ -691,11 +691,8 @@ describe('styled component behaviour', () => {
       '._syaz13q2{color:blue}',
       '._syaz5scu{color:red}',
       '._1wybgktf{font-size:20px}',
+      'className={ax(["_1wybgktf",props.isPrimary&&props.isBolded&&"_syaz13q2",!(props.isPrimary&&props.isBolded)&&"_syaz5scu",props.className])}/',
     ]);
-
-    expect(actual).toInclude(
-      'className={ax(["_1wybgktf _syaz5scu",props.isPrimary&&props.isBolded&&"_syaz13q2",props.className])}/'
-    );
   });
 
   it('should only evaluate the last unconditional CSS rule for each property', () => {
@@ -718,28 +715,36 @@ describe('styled component behaviour', () => {
     expect(actual).toInclude('className={ax(["_syazruxl _bfhk1x77",props.className])}');
   });
 
-  it('should only evaluate the last unconditional CSS rule for each property along with logical CSS', () => {
+  it('should only add falsy condition when truthy condition has no value', () => {
     const actual = transform(`
       import { styled } from '@compiled/react';
 
       const Component = styled.div(
-        { color: 'red' },
-        { background: 'white' },
-        props => props.isPrimary ? ({ color: 'blue', background: 'white' }) : ({ color: 'green', background: 'black' }),
-        { color: 'white', background: 'black' },
+        props => props.isPrimary ? undefined : { color: 'green', background: 'black' },
       );
     `);
 
     expect(actual).toIncludeMultiple([
-      '._bfhk1x77{background-color:white}',
-      '._syaz13q2{color:blue}',
+      '._syazbf54{color:green}',
       '._bfhk11x8{background-color:black}',
-      '._syaz1x77{color:white}',
+      'className={ax(["",!props.isPrimary&&"_syazbf54 _bfhk11x8",props.className])}',
     ]);
+  });
 
-    expect(actual).toInclude(
-      'className={ax(["_syaz1x77 _bfhk11x8",props.isPrimary&&"_syaz13q2 _bfhk1x77",props.className])}'
-    );
+  it('should only add truthy condition when falsy condition has no value', () => {
+    const actual = transform(`
+      import { styled } from '@compiled/react';
+
+      const Component = styled.div(
+        props => props.isPrimary ? { color: 'green', background: 'black' } : undefined,
+      );
+    `);
+
+    expect(actual).toIncludeMultiple([
+      '._syazbf54{color:green}',
+      '._bfhk11x8{background-color:black}',
+      'className={ax(["",props.isPrimary&&"_syazbf54 _bfhk11x8",props.className])}',
+    ]);
   });
 
   it('should conditionally apply CSS mixins', () => {


### PR DESCRIPTION
Resolves #871 

This PR changes the behaviour of ternary conditionals to not apply falsy path styles by default, instead making both paths into logical CSS items. This behaviour only works for situations like:
```
${() => ABTest() ? 'color: blue' : 'color: red'};
```
As the style property is the same on both paths can be overridden with the truthy path style. However when styles on both paths don't match up. For example:
```
${() => ABTest() ? 'font-weight: bold' : css`font-size: 20px; color: red;`};
```
Then we get unwanted styles for the falsy path.