### PR TITLE
Add codemods package to cli to allow npx usage

### DIFF
--- a/.changeset/calm-chairs-juggle.md
+++ b/.changeset/calm-chairs-juggle.md
@@ -1,0 +1,5 @@
+---
+'@compiled/cli': minor
+---
+
+Use @compiled/codemods as dependency for @compiled/cli to allow npx usage

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "start": "ts-node --files src/index.tsx"
   },
   "dependencies": {
+    "@compiled/codemods": ">=0.2.0",
     "app-root-path": "^3.0.0",
     "chalk": "^4.1.2",
     "enquirer": "^2.3.6",
@@ -36,8 +37,5 @@
   },
   "devDependencies": {
     "@types/app-root-path": "^1.2.4"
-  },
-  "peerDependencies": {
-    "@compiled/codemods": ">=0.2.0"
   }
 }


### PR DESCRIPTION
Simple PR to move codemod package to a dependency for CLI. This should allow `npx @compiled/cli` usage without having to install a peer dependency.