### PR TITLE
Add disable directives for css prop

### DIFF
--- a/.changeset/dull-mangos-whisper.md
+++ b/.changeset/dull-mangos-whisper.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Add comment directive `// @compiled-disable(-next-line) transform-css-prop` to disable Compiled processing on CSS prop

--- a/.changeset/dull-mangos-whisper.md
+++ b/.changeset/dull-mangos-whisper.md
@@ -2,4 +2,4 @@
 '@compiled/babel-plugin': patch
 ---
 
-Add comment directive `// @compiled-disable(-next-line) transform-css-prop` to disable Compiled processing on CSS prop
+Add comment directive `// @compiled-disable(-next)-line) transform-css-prop` to disable Compiled processing on CSS prop

--- a/examples/stories/css-prop-static-object.tsx
+++ b/examples/stories/css-prop-static-object.tsx
@@ -82,3 +82,19 @@ export const ObjectLiteralMapWithKeys = (): JSX.Element => (
     ))}
   </div>
 );
+
+export const ObjectLiteralDisabledSameLine = (): JSX.Element => (
+  <h1
+    css={{ color: 'red' }} // @compiled-disable transform-css-prop
+  >
+    Black text
+  </h1>
+);
+
+export const ObjectLiteralDisabledNextLine = (): JSX.Element => (
+  <h1
+    // @compiled-disable-next-line transform-css-prop
+    css={{ color: 'red' }}>
+    Black text
+  </h1>
+);

--- a/examples/stories/css-prop-static-object.tsx
+++ b/examples/stories/css-prop-static-object.tsx
@@ -83,15 +83,15 @@ export const ObjectLiteralMapWithKeys = (): JSX.Element => (
   </div>
 );
 
-export const ObjectLiteralDisabledSameLine = (): JSX.Element => (
+export const ObjectExpressionDisabledSameLine = (): JSX.Element => (
   <h1
-    css={{ color: 'red' }} // @compiled-disable transform-css-prop
+    css={{ color: 'red' }} // @compiled-disable-line transform-css-prop
   >
     Black text
   </h1>
 );
 
-export const ObjectLiteralDisabledNextLine = (): JSX.Element => (
+export const ObjectExpressionDisabledNextLine = (): JSX.Element => (
   <h1
     // @compiled-disable-next-line transform-css-prop
     css={{ color: 'red' }}>

--- a/packages/babel-plugin/src/constants.tsx
+++ b/packages/babel-plugin/src/constants.tsx
@@ -1,1 +1,3 @@
 export const PROPS_IDENTIFIER_NAME = 'props';
+export const COMPILED_DIRECTIVE_DISABLE_SAME_LINE = '@compiled-disable';
+export const COMPILED_DIRECTIVE_DISABLE_NEXT_LINE = '@compiled-disable-next-line';

--- a/packages/babel-plugin/src/constants.tsx
+++ b/packages/babel-plugin/src/constants.tsx
@@ -1,3 +1,5 @@
 export const PROPS_IDENTIFIER_NAME = 'props';
-export const COMPILED_DIRECTIVE_DISABLE_SAME_LINE = '@compiled-disable';
+
+export const COMPILED_DIRECTIVE_DISABLE_LINE = '@compiled-disable-line';
 export const COMPILED_DIRECTIVE_DISABLE_NEXT_LINE = '@compiled-disable-next-line';
+export const COMPILED_DIRECTIVE_TRANSFORM_CSS_PROP = 'transform-css-prop';

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
@@ -633,29 +633,29 @@ describe('css prop behaviour', () => {
 
   it('should not transform css prop with comment directive', () => {
     const actual = transform(`
-      import "@compiled/react";
+      import { css } from '@compiled/react';
 
       // @compiled-disable-next-line transform-css-prop
-      const RedDiv = <div css={{ color: "red" }} />;
+      const RedDiv = <div css={{ color: 'red' }} />;
 
       const GreenDiv = () => (
         <div
-          css={{ color: "green" }} // @compiled-disable transform-css-prop
+          css={ css\`color: green\` } // @compiled-disable-line transform-css-prop
         />
       );
 
       const BlueDiv = () => (
         <div
           // @compiled-disable-next-line transform-css-prop
-          css={{ color: "blue" }}
+          css={{ color: 'blue' }}
         />
       );
     `);
 
     expect(actual).toIncludeMultiple([
-      'css={{color:"red"}}',
-      'css={{color:"green"}}',
-      'css={{color:"blue"}}',
+      "css={{color:'red'}}",
+      "css={null}",
+      "css={{color:'blue'}}",
     ]);
   });
 });

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.tsx
@@ -630,4 +630,32 @@ describe('css prop behaviour', () => {
 
     expect(actual).toInclude('<CC key={str}>');
   });
+
+  it('should not transform css prop with comment directive', () => {
+    const actual = transform(`
+      import "@compiled/react";
+
+      // @compiled-disable-next-line transform-css-prop
+      const RedDiv = <div css={{ color: "red" }} />;
+
+      const GreenDiv = () => (
+        <div
+          css={{ color: "green" }} // @compiled-disable transform-css-prop
+        />
+      );
+
+      const BlueDiv = () => (
+        <div
+          // @compiled-disable-next-line transform-css-prop
+          css={{ color: "blue" }}
+        />
+      );
+    `);
+
+    expect(actual).toIncludeMultiple([
+      'css={{color:"red"}}',
+      'css={{color:"green"}}',
+      'css={{color:"blue"}}',
+    ]);
+  });
 });

--- a/packages/babel-plugin/src/css-prop/index.tsx
+++ b/packages/babel-plugin/src/css-prop/index.tsx
@@ -4,12 +4,11 @@ import { buildCompiledComponent } from '../utils/ast-builders';
 import { buildCss } from '../utils/css-builders';
 import {
   COMPILED_DIRECTIVE_DISABLE_NEXT_LINE,
-  COMPILED_DIRECTIVE_DISABLE_SAME_LINE,
+  COMPILED_DIRECTIVE_DISABLE_LINE,
+  COMPILED_DIRECTIVE_TRANSFORM_CSS_PROP,
 } from '../constants';
-import { getNodeDirectiveComments } from '../utils/ast';
+import { getNodeComments } from '../utils/comments';
 import type { Metadata } from '../types';
-
-const COMPILED_DIRECTIVE_TRANSFORM_CSS_PROP = 'transform-css-prop';
 
 const getJsxAttributeExpression = (node: t.JSXAttribute) => {
   if (t.isStringLiteral(node.value)) {
@@ -24,9 +23,9 @@ const getJsxAttributeExpression = (node: t.JSXAttribute) => {
 };
 
 const isCssPropDisabled = (path: NodePath<t.Node>, meta: Metadata): boolean => {
-  const { before, same } = getNodeDirectiveComments(path, meta);
+  const { before, current } = getNodeComments(path, meta);
 
-  // Disable the prop if there's a disable next line comment or disable on same line
+  // Disable the prop if there's a disable next line comment or disable on current line
   return (
     before.some((comment) =>
       comment.value
@@ -35,12 +34,10 @@ const isCssPropDisabled = (path: NodePath<t.Node>, meta: Metadata): boolean => {
           `${COMPILED_DIRECTIVE_DISABLE_NEXT_LINE} ${COMPILED_DIRECTIVE_TRANSFORM_CSS_PROP}`
         )
     ) ||
-    same.some((comment) =>
+    current.some((comment) =>
       comment.value
         .trim()
-        .startsWith(
-          `${COMPILED_DIRECTIVE_DISABLE_SAME_LINE} ${COMPILED_DIRECTIVE_TRANSFORM_CSS_PROP}`
-        )
+        .startsWith(`${COMPILED_DIRECTIVE_DISABLE_LINE} ${COMPILED_DIRECTIVE_TRANSFORM_CSS_PROP}`)
     )
   );
 };

--- a/packages/babel-plugin/src/utils/ast.tsx
+++ b/packages/babel-plugin/src/utils/ast.tsx
@@ -1,5 +1,4 @@
 import * as t from '@babel/types';
-import type { BabelFile } from '@babel/core';
 import type { NodePath } from '@babel/traverse';
 import traverse from '@babel/traverse';
 import { parse } from '@babel/parser';
@@ -741,40 +740,3 @@ const tryWrappingBlockStatementInIIFE = (node: t.BlockStatement | t.Expression) 
  */
 export const pickFunctionBody = (node: t.Function): t.Expression =>
   tryWrappingBlockStatementInIIFE(node.body);
-
-/**
- * Get comments for `path` in both the line before and on the same line.
- *
- * e.g.
- * `<div css={{color: 'green'}} /> // @compiled-disable` will output `{before: [], same: [...]}
- *
- * @param path {NodePath<t.Node>}
- * @param meta {Metadata} Context for the transform
- * @returns {before: t.CommentLine[], same: t.CommentLine[]} Comments before and on the same line as the input path
- */
-export const getNodeDirectiveComments = (
-  path: NodePath<t.Node>,
-  meta: Metadata
-): { before: t.CommentLine[]; same: t.CommentLine[] } => {
-  const lineNumber = path.node?.loc?.start.line;
-  if (!lineNumber || lineNumber !== path.node?.loc?.end.line) {
-    return { before: [], same: [] };
-  }
-
-  const file: BabelFile = meta.state.file;
-  const commentLines =
-    file.ast.comments?.filter<t.CommentLine>(
-      (comment: t.CommentLine | t.CommentBlock): comment is t.CommentLine =>
-        comment.type === 'CommentLine'
-    ) ?? [];
-
-  return {
-    before: commentLines.filter(
-      (comment) =>
-        comment.loc.start.line === lineNumber - 1 && comment.loc.end.line === lineNumber - 1
-    ),
-    same: commentLines.filter(
-      (comment) => comment.loc.start.line === lineNumber && comment.loc.end.line === lineNumber
-    ),
-  };
-};

--- a/packages/babel-plugin/src/utils/ast.tsx
+++ b/packages/babel-plugin/src/utils/ast.tsx
@@ -1,4 +1,5 @@
 import * as t from '@babel/types';
+import type { BabelFile } from '@babel/core';
 import type { NodePath } from '@babel/traverse';
 import traverse from '@babel/traverse';
 import { parse } from '@babel/parser';
@@ -740,3 +741,40 @@ const tryWrappingBlockStatementInIIFE = (node: t.BlockStatement | t.Expression) 
  */
 export const pickFunctionBody = (node: t.Function): t.Expression =>
   tryWrappingBlockStatementInIIFE(node.body);
+
+/**
+ * Get comments for `path` in both the line before and on the same line.
+ *
+ * e.g.
+ * `<div css={{color: 'green'}} /> // @compiled-disable` will output `{before: [], same: [...]}
+ *
+ * @param path {NodePath<t.Node>}
+ * @param meta {Metadata} Context for the transform
+ * @returns {before: t.CommentLine[], same: t.CommentLine[]} Comments before and on the same line as the input path
+ */
+export const getNodeDirectiveComments = (
+  path: NodePath<t.Node>,
+  meta: Metadata
+): { before: t.CommentLine[]; same: t.CommentLine[] } => {
+  const lineNumber = path.node?.loc?.start.line;
+  if (!lineNumber || lineNumber !== path.node?.loc?.end.line) {
+    return { before: [], same: [] };
+  }
+
+  const file: BabelFile = meta.state.file;
+  const commentLines =
+    file.ast.comments?.filter<t.CommentLine>(
+      (comment: t.CommentLine | t.CommentBlock): comment is t.CommentLine =>
+        comment.type === 'CommentLine'
+    ) ?? [];
+
+  return {
+    before: commentLines.filter(
+      (comment) =>
+        comment.loc.start.line === lineNumber - 1 && comment.loc.end.line === lineNumber - 1
+    ),
+    same: commentLines.filter(
+      (comment) => comment.loc.start.line === lineNumber && comment.loc.end.line === lineNumber
+    ),
+  };
+};

--- a/packages/babel-plugin/src/utils/comments.ts
+++ b/packages/babel-plugin/src/utils/comments.ts
@@ -1,0 +1,41 @@
+import type * as t from '@babel/types';
+import type { BabelFile } from '@babel/core';
+import type { NodePath } from '@babel/traverse';
+import type { Metadata } from '../types';
+
+/**
+ * Get comments for `path` in both the line before and on the current line.
+ *
+ * e.g.
+ * `<div css={{color: 'green'}} /> // @compiled-disable-line` will output `{before: [], current: [...]}
+ *
+ * @param path {NodePath<t.Node>}
+ * @param meta {Metadata} Context for the transform
+ * @returns {before: t.CommentLine[], current: t.CommentLine[]} Comments before and on the current line as the input path
+ */
+export const getNodeComments = (
+  path: NodePath<t.Node>,
+  meta: Metadata
+): { before: t.CommentLine[]; current: t.CommentLine[] } => {
+  const lineNumber = path.node?.loc?.start.line;
+  if (!lineNumber || lineNumber !== path.node?.loc?.end.line) {
+    return { before: [], current: [] };
+  }
+
+  const file: BabelFile = meta.state.file;
+  const commentLines =
+    file.ast.comments?.filter<t.CommentLine>(
+      (comment: t.CommentLine | t.CommentBlock): comment is t.CommentLine =>
+        comment.type === 'CommentLine'
+    ) ?? [];
+
+  return {
+    before: commentLines.filter(
+      (comment) =>
+        comment.loc.start.line === lineNumber - 1 && comment.loc.end.line === lineNumber - 1
+    ),
+    current: commentLines.filter(
+      (comment) => comment.loc.start.line === lineNumber && comment.loc.end.line === lineNumber
+    ),
+  };
+};


### PR DESCRIPTION
Usages like the following do not work:

```
import { css as cssSC } from "styled-components";
import { css as cssCompiled } from "@compiled/react";

const stylesSC = cssSC`
  color: red;
`;

const stylesCompiled = cssCompiled`
  color: blue;
`;

<>
  <div css={stylesSC}>Red text</div>
  <div css={stylesCompiled}>Blue text</div>
</>;
```

This is because Compiled cannot tell that `stylesSC` is defined with styled-components. To allow usages to opt-out, we should add a comment directive to allow the Compiled babel plugin to ignore certain props. e.g.

```
{isCompiledEnabled()
  ? <div css={{ color: 'red' }} />
  // @compiled-disable-next-line transform-css-prop
  : <div css={{ color: 'blue' }} />
}
```

This PR introduces `// @compiled-disable-next-line transform-css-prop` and `// @compiled-disable transform-css-prop` as comment directives in the babel plugin. When these directives are placed on either the CSS prop or the JSX opening element, Compiled will ignore the AST node and not traverse.