### PR TITLE
Patch inexact type causing compatibility issues and update flowconfig

### DIFF
--- a/.changeset/curvy-wasps-shake.md
+++ b/.changeset/curvy-wasps-shake.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Patch inexact flow type on styled

--- a/.flowconfig
+++ b/.flowconfig
@@ -10,11 +10,19 @@ packages/.*/*.js.flow
 .*/node_modules/.*
 
 [lints]
+deprecated-utility=warn
+unnecessary-optional-chain=warn
+implicit-inexact-object=error
+untyped-type-import=error
 
 [options]
+exact_by_default=true
 
 [strict]
+deprecated-type
+deprecated-utility
 nonstrict-import
+sketchy-null
 unclear-type
 unsafe-getters-setters
 untyped-import

--- a/packages/react/src/styled/index.js.flow
+++ b/packages/react/src/styled/index.js.flow
@@ -33,7 +33,7 @@ export interface StyledFunctionFromTag<TTag: $Keys<$JSXIntrinsics>> {
     ...interpolations: Interpolations<TProps>
   ): React$ComponentType<{
     ...TProps,
-    ...$ElementType<$JSXIntrinsics, TTag>,
+    ...$Exact<$ElementType<$JSXIntrinsics, TTag>>,
     ...StyledProps,
   }>;
 }

--- a/scripts/flow-types.sh
+++ b/scripts/flow-types.sh
@@ -31,6 +31,9 @@ generate() {
     # Rename JSX.IntrinsicElements to existing flow type
     sed -i.bak -E 's/JSX.IntrinsicElements/$JSXIntrinsics/g' "$file" && rm "$file.bak"
 
+    # Rename $ElementType<$JSXIntrinsics, TTag> to exact flow typs
+    sed -i.bak -E 's/\$ElementType<\$JSXIntrinsics, TTag>/$Exact<$ElementType<$JSXIntrinsics, TTag>>/g' "$file" && rm "$file.bak"
+
     # Rename jest.CustomMatcherResult type to existing flow type
     sed -i.bak -E 's/jest.CustomMatcherResult/JestMatcherResult/g' "$file" && rm "$file.bak"
 


### PR DESCRIPTION
Our tests did not catch this issue that occurred in Jira, as we had a different `.flowconfig`. Simple patch using `sed` to allow compatibility. 

The issue is with:
```
const x = styled.div`
   ...
`;
```

Throws the error:
```
Cannot call `styled.div` because inexact  object type [1] is incompatible with exact  object type [2].Flow(incompatible-exact)
react-dom.js(252, 8): [1] object type
index.js.flow(34, 26): [2] object type
```