### PR TITLE
Support namespace imports & export specifiers

### DIFF
--- a/.changeset/small-swans-approve.md
+++ b/.changeset/small-swans-approve.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+Add support for namespace imports and export specifiers

--- a/packages/babel-plugin/src/__fixtures__/mixins/objects.js
+++ b/packages/babel-plugin/src/__fixtures__/mixins/objects.js
@@ -9,6 +9,7 @@ export const style = {
 };
 
 const danger = 'blue';
+export { danger };
 
 export const styleInlining = {
   fontSize: 14,

--- a/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
+++ b/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
@@ -536,9 +536,9 @@ describe('module traversal', () => {
 
       expect(result).toIncludeMultiple([
         '{color:red}',
-        // Cannot be resolved statically because of bug where
-        // we assume parent path of member expression is the same throughout
-        // the entire chain
+        // We're not handling statically evaluating param values used from a namespace chain,
+        // as the long term strategy is to only statically evaluate expressions scoped locally
+        // to the current file.
         '{background-color:var(--_1w9snyi)}',
       ]);
     });

--- a/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
+++ b/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
@@ -36,7 +36,7 @@ describe('module traversal', () => {
     expect(result).toInclude('{color:blue}');
   });
 
-  it('should replace an identifier referencing a default import specificer string literal', () => {
+  it('should replace an identifier referencing a default import specifier string literal', () => {
     const result = transform(
       `
       import '@compiled/react';
@@ -50,7 +50,7 @@ describe('module traversal', () => {
     expect(result).toInclude('{color:red}');
   });
 
-  it('should replace an identifier referencing a default import specificer string literal', () => {
+  it('should replace an identifier referencing a default import specifier string literal', () => {
     const result = transform(
       `
       import '@compiled/react';
@@ -64,7 +64,7 @@ describe('module traversal', () => {
     expect(result).toInclude('{color:red}');
   });
 
-  it('should replace an identifier referencing a named import specifier object', () => {
+  it('should replace an identifier referencing a named import specifier object from a variable declaration export', () => {
     const result = transform(
       `
       import '@compiled/react';
@@ -76,6 +76,20 @@ describe('module traversal', () => {
     );
 
     expect(result).toInclude('{color:red}');
+  });
+
+  it('should replace an identifier referencing a named import specifier object from an export specifier', () => {
+    const result = transform(
+      `
+      import '@compiled/react';
+      import React from 'react';
+      import { danger } from '../__fixtures__/mixins/objects';
+
+      <div css={{ color: danger }} />
+    `
+    );
+
+    expect(result).toInclude('{color:blue}');
   });
 
   it('should replace an identifier referencing a node modules named import specifier object', () => {
@@ -106,7 +120,7 @@ describe('module traversal', () => {
     expect(result).toInclude('{font-size:12px}');
   });
 
-  it('should inline css from a object spread referencing a named import object', () => {
+  it('should inline css from an object spread referencing a named import object', () => {
     const result = transform(
       `
       import '@compiled/react';
@@ -121,7 +135,7 @@ describe('module traversal', () => {
     expect(result).toInclude('{font-size:12px}');
   });
 
-  it('should inline css from a object with multiple identifiers referenced from a named import', () => {
+  it('should inline css from an object with multiple identifiers referenced from a named import', () => {
     const result = transform(
       `
       import '@compiled/react';
@@ -434,5 +448,110 @@ describe('module traversal', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toInclude('compiled/packages/babel-plugin/src/__fixtures__/mixins/simple.js');
+  });
+
+  describe('Namespace imports', () => {
+    it('should replace a member expression referencing a default export', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import React from 'react';
+        import * as objects from '../__fixtures__/mixins/objects';
+
+        <div css={{ color: objects.default.primary }} />
+      `);
+
+      expect(result).toInclude('{color:blue}');
+    });
+
+    it('should replace a member expression referencing a named variable export', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import React from 'react';
+        import * as objects from '../__fixtures__/mixins/objects';
+
+        <div css={{ color: objects.colors.primary }} />
+      `);
+
+      expect(result).toInclude('{color:red}');
+    });
+
+    it('should replace a member expression referencing an export specifier', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import React from 'react';
+        import * as objects from '../__fixtures__/mixins/objects';
+
+        <div css={{ color: objects.danger }} />
+      `);
+
+      expect(result).toInclude('{color:blue}');
+    });
+
+    it('should inline css from an object spread', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import React from 'react';
+        import * as objects from '../__fixtures__/mixins/objects';
+
+        <div css={{ ...objects.style }} />
+      `);
+
+      expect(result).toInclude('{font-size:12px}');
+    });
+
+    it('should inline css from an call expression', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import React from 'react';
+        import * as objects from '../__fixtures__/mixins/objects';
+
+        <div css={{ ...objects.colorMixin() }} />
+      `);
+
+      expect(result).toIncludeMultiple(['{color:red}', '{background-color:pink}']);
+    });
+
+    it('should inline css from an identifier with an IIFE property', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import * as objects from '../__fixtures__/mixins/objects';
+
+        <div css={{ ...objects.fontMixin }} />
+      `);
+
+      expect(result).toInclude('{font-size:12px}');
+    });
+
+    it('should inline css from a function mixin with parameters', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import * as objects from '../__fixtures__/mixins/objects';
+
+        const color = { blue: 'blue' };
+
+        const Component = (props) => {
+          return <div css={{ ...objects.colorMixin2(color.blue) }} />
+        };
+    `);
+
+      expect(result).toIncludeMultiple([
+        '{color:red}',
+        // Cannot be resolved statically because of bug where
+        // we assume parent path of member expression is the same throughout
+        // the entire chain
+        '{background-color:var(--_1w9snyi)}',
+      ]);
+    });
+
+    it('should inline css from a directly called function mixin', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import * as objects from '../__fixtures__/mixins/objects';
+
+        <div css={{':hover': { paddingTop: objects.spacingMixin.padding.top() }}} />
+      `);
+
+      expect(result).toInclude(':hover{padding-top:10px}');
+    });
   });
 });

--- a/packages/babel-plugin/src/utils/ast.tsx
+++ b/packages/babel-plugin/src/utils/ast.tsx
@@ -378,35 +378,6 @@ export const babelEvaluateExpression = (
   return fallbackNode;
 };
 
-const findDefaultExportModuleNode = (
-  ast: t.File
-): {
-  foundNode: t.Node | undefined;
-  foundParentPath: NodePath | undefined;
-} => {
-  const result = getDefaultExport(ast);
-
-  return {
-    foundNode: result?.node,
-    foundParentPath: result?.path,
-  };
-};
-
-const findNamedExportModuleNode = (
-  ast: t.File,
-  exportName: string
-): {
-  foundNode: t.Node | undefined;
-  foundParentPath: NodePath | undefined;
-} => {
-  const result = getNamedExport(ast, exportName);
-
-  return {
-    foundNode: result?.node,
-    foundParentPath: result?.path,
-  };
-};
-
 /**
  * Will recursively checks if identifier name is coming from destructuring. If yes,
  * then will return the resolved identifer. We can look for identifier name
@@ -643,7 +614,14 @@ export const resolveBindingNode = (
       ({ foundNode, foundParentPath } = meta.state.cache.load({
         namespace: 'find-default-export-module-node',
         cacheKey: modulePath,
-        value: () => findDefaultExportModuleNode(ast),
+        value: () => {
+          const result = getDefaultExport(ast);
+
+          return {
+            foundNode: result?.node,
+            foundParentPath: result?.path,
+          };
+        },
       }));
     } else if (binding.path.isImportSpecifier()) {
       const { imported } = binding.path.node;
@@ -652,7 +630,14 @@ export const resolveBindingNode = (
       ({ foundNode, foundParentPath } = meta.state.cache.load({
         namespace: 'find-named-export-module-node',
         cacheKey: `modulePath=${modulePath}&exportName=${exportName}`,
-        value: () => findNamedExportModuleNode(ast, exportName),
+        value: () => {
+          const result = getNamedExport(ast, exportName);
+
+          return {
+            foundNode: result?.node,
+            foundParentPath: result?.path,
+          };
+        },
       }));
     } else if (binding.path.isImportNamespaceSpecifier()) {
       // There's no node inside the file to reference for namespace imports

--- a/packages/babel-plugin/src/utils/evaluate-expression.tsx
+++ b/packages/babel-plugin/src/utils/evaluate-expression.tsx
@@ -142,7 +142,9 @@ const evaluateNamespaceImportExpression = (accessPath: t.Identifier[], meta: Met
     exportName === 'default' ? getDefaultExport(file) : getNamedExport(file, exportName);
 
   if (result) {
-    updatedMeta.parentPath = result.path.parentPath;
+    updatedMeta.ownPath = result.path;
+    // Set parentPath to the path where the import is being used
+    updatedMeta.parentPath = meta.parentPath;
 
     if (t.isObjectExpression(result.node) && accessPath.length > 1) {
       return evaluateObjectExpression(result.node, accessPath.slice(1), updatedMeta);

--- a/packages/babel-plugin/src/utils/export-traversers.tsx
+++ b/packages/babel-plugin/src/utils/export-traversers.tsx
@@ -1,0 +1,87 @@
+import traverse from '@babel/traverse';
+import type { NodePath } from '@babel/traverse';
+import * as t from '@babel/types';
+
+type Result<T> = {
+  node: t.Node;
+  path: NodePath<T>;
+};
+
+/**
+ * Find the default export of a file and return the export's node and path.
+ *
+ * E.g: `export default 'blue';`
+ * Will return the string literal node for 'blue'.
+ *
+ * E.g: `export default color;`
+ * Will return the identifier node for `color`.
+ *
+ * @param ast File we want to traverse.
+ */
+export const getDefaultExport = (ast: t.File): Result<t.ExportDefaultDeclaration> | undefined => {
+  let result;
+
+  traverse(ast, {
+    ExportDefaultDeclaration(path) {
+      result = { path, node: path.node.declaration };
+      path.stop();
+    },
+  });
+
+  return result;
+};
+
+/**
+ * Find a named export in a file and return the export's node and path.
+ *
+ * Handles the two types of named exports:
+ *
+ * Variable declaration:
+ * `export const blue = 'blue';`
+ * Will return the identifier node for `blue`.
+ *
+ * Export specifier:
+ * ```
+ * const color = 'blue';
+ * export { color };
+ * ```
+ * Will return the identifier node for `color`.
+ *
+ * @param ast File we want to traverse.
+ * @param exportName Name of the export we're looking for.
+ */
+export const getNamedExport = (
+  ast: t.File,
+  exportName: string
+): Result<t.ExportNamedDeclaration> | undefined => {
+  let result;
+
+  traverse(ast, {
+    ExportNamedDeclaration(path) {
+      const { node } = path;
+      const declarations = t.isVariableDeclaration(node.declaration)
+        ? node.declaration.declarations
+        : node.specifiers;
+
+      (declarations as Array<t.VariableDeclarator | t.ExportSpecifier>).find((declaration) => {
+        const identifier = t.isVariableDeclarator(declaration)
+          ? declaration.id
+          : declaration.exported;
+
+        if (t.isIdentifier(identifier, { name: exportName })) {
+          result = {
+            path,
+            node: t.isVariableDeclarator(declaration) ? declaration.init : identifier,
+          };
+
+          path.stop();
+          return true;
+        }
+
+        return false;
+      });
+    },
+  });
+
+  return result;
+};


### PR DESCRIPTION
Resolves #630

Allows styles to be statically evaluated when using:
- Namespace imports - `import * as theme from 'theme';`
- Export specifiers - `export { colors };`

Does not address current issues where:
- Member expressions breaks early when identifiers and call expressions are used mid chain
- Member expressions assume parent path is same throughout the chain

Future work will be done to support:
- Nested namespace imports
- Deconstruction from namespace imports