### PR TITLE
Lint js and jsx files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,16 @@
 module.exports = {
   root: true,
-  ignorePatterns: ['dist', '*.d.ts'],
+  ignorePatterns: [
+    'dist',
+    'flow-typed',
+    '*.d.ts',
+    'babel-cjs.js',
+    'babel-esm.js',
+  ],
   overrides: [
     {
-      files: ['*.{ts,tsx}'],
+      files: ['*.{js,jsx,ts,tsx}'],
       extends: [
-        'plugin:@typescript-eslint/recommended',
         'plugin:import/recommended',
         'plugin:react/recommended',
       ],
@@ -19,11 +24,26 @@ module.exports = {
       },
       plugins: ['react-hooks'],
       rules: {
-        'react-hooks/exhaustive-deps': 'warn',
-        'react-hooks/rules-of-hooks': 'error',
         'react/display-name': 'off',
         'react/prop-types': 'off',
         'react/react-in-jsx-scope': 'off',
+        'react-hooks/exhaustive-deps': 'warn',
+        'react-hooks/rules-of-hooks': 'error',
+        // We will let TypeScript handle this for tsx? files, and ignore it on jsx? files to enable linting without
+        // building packages
+        'import/no-unresolved': 'off',
+        'import/order': ['error', {
+          alphabetize: {
+            order: 'asc'
+          },
+          'newlines-between': 'always'
+        }],
+      },
+    },
+    {
+      files: ['*.{ts,tsx}'],
+      extends: ['plugin:@typescript-eslint/recommended'],
+      rules: {
         '@typescript-eslint/array-type': 'error',
         '@typescript-eslint/ban-ts-comment': 'off',
         '@typescript-eslint/ban-ts-ignore': 'off',
@@ -45,14 +65,6 @@ module.exports = {
             ignoreRestSiblings: true,
           },
         ],
-        // TypeScript already enforces this
-        'import/no-unresolved': 'off',
-        'import/order': ['error', {
-          alphabetize: {
-            order: 'asc'
-          },
-          'newlines-between': 'always'
-        }],
       },
     },
     {

--- a/examples/packages/parcel/src/index.js
+++ b/examples/packages/parcel/src/index.js
@@ -1,5 +1,6 @@
 import React, { StrictMode } from 'react';
 import { render } from 'react-dom';
+
 import { App } from './app';
 
 render(

--- a/examples/packages/ssr/src/client.js
+++ b/examples/packages/ssr/src/client.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { hydrate } from 'react-dom';
+
 import App from './app';
 
 hydrate(<App />, document.getElementById('root'));

--- a/examples/packages/ssr/src/server.js
+++ b/examples/packages/ssr/src/server.js
@@ -1,6 +1,7 @@
-import React from 'react';
 import express from 'express';
+import React from 'react';
 import { renderToString } from 'react-dom/server';
+
 import App from './app';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/examples/packages/webpack/src/app.js
+++ b/examples/packages/webpack/src/app.js
@@ -1,6 +1,6 @@
-import { Suspense, lazy } from 'react';
 import '@compiled/react';
 import BabelComponent from '@private/babel-component';
+import { Suspense, lazy } from 'react';
 
 import { primary } from './common/constants';
 import { TypeScript } from './ui/typescript';

--- a/examples/packages/webpack/webpack.config.js
+++ b/examples/packages/webpack/webpack.config.js
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+const { join } = require('path');
+
 const { CompiledExtractPlugin } = require('@compiled/webpack-loader');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const { join } = require('path');
 const webpack = require('webpack');
 
 const extractCSS = process.env.EXTRACT_TO_CSS === 'true';

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clean:ts-cache": "find . -name \"*.tsbuildinfo\" -type f -delete",
     "flow-types": "scripts/flow-types.sh",
     "postinstall": "npx yarn-deduplicate && yarn --ignore-scripts",
-    "lint": "eslint --config .eslintrc.js --ext flow,json,ts,tsx .",
+    "lint": "eslint --config .eslintrc.js --ext js,json,jsx,ts,tsx .",
     "lint:fix": "yarn lint -- --fix",
     "prettier:check": "prettier ./ --check",
     "prettier:fix": "prettier ./ --write",


### PR DESCRIPTION
## Changes
* Fix eslint violations
* Target `js` and `jsx` files in root `eslint` script
* Update eslint config to share common rules in the first override, and rely on override merging for applying additional rules