### PR TITLE
fix: fixes jsx-pragma rule to update react imports

### DIFF
--- a/.changeset/pretty-starfishes-protect.md
+++ b/.changeset/pretty-starfishes-protect.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+The `jsx-pragma` rule now removes the default react import when moving to the automatic runtime and it isn't used.

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.tsx
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.tsx
@@ -238,5 +238,73 @@ import { useState } from 'react';
         },
       ],
     },
+    {
+      code: `
+        import { useState } from 'react';
+        import { css } from '@compiled/react';
+
+        useState();
+
+        <div css={css({ display: 'block' })} />
+      `,
+      output: `
+        /** @jsxImportSource @compiled/react */
+import { useState } from 'react';
+        import { css } from '@compiled/react';
+
+        useState();
+
+        <div css={css({ display: 'block' })} />
+      `,
+      errors: [
+        {
+          messageId: 'missingPragma',
+        },
+      ],
+    },
+    {
+      code: `
+        import * as React from 'react';
+        import { css } from '@compiled/react';
+
+        React.useState();
+
+        <div css={css({ display: 'block' })} />
+      `,
+      output: `
+        /** @jsxImportSource @compiled/react */
+import * as React from 'react';
+        import { css } from '@compiled/react';
+
+        React.useState();
+
+        <div css={css({ display: 'block' })} />
+      `,
+      errors: [
+        {
+          messageId: 'missingPragma',
+        },
+      ],
+    },
+    {
+      code: `
+        import * as React from 'react';
+        import { css } from '@compiled/react';
+
+        <div css={css({ display: 'block' })} />
+      `,
+      output: `
+        /** @jsxImportSource @compiled/react */
+
+        import { css } from '@compiled/react';
+
+        <div css={css({ display: 'block' })} />
+      `,
+      errors: [
+        {
+          messageId: 'missingPragma',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.tsx
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.tsx
@@ -148,5 +148,95 @@ import { css } from '@compiled/react';
         },
       ],
     },
+    {
+      code: `
+        import React from 'react';
+        import { css } from '@compiled/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      output: `
+        /** @jsxImportSource @compiled/react */
+
+        import { css } from '@compiled/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      errors: [
+        {
+          messageId: 'missingPragma',
+        },
+      ],
+    },
+    {
+      code: `
+        import React from 'react';
+        import { css } from '@compiled/react';
+
+        React.useState();
+
+        <div css={css({ display: 'block' })} />
+      `,
+      output: `
+        /** @jsxImportSource @compiled/react */
+import React from 'react';
+        import { css } from '@compiled/react';
+
+        React.useState();
+
+        <div css={css({ display: 'block' })} />
+      `,
+      errors: [
+        {
+          messageId: 'missingPragma',
+        },
+      ],
+    },
+    {
+      code: `
+        import React, { useState } from 'react';
+        import { css } from '@compiled/react';
+
+        useState();
+
+        <div css={css({ display: 'block' })} />
+      `,
+      output: `
+        /** @jsxImportSource @compiled/react */
+import { useState } from 'react';
+        import { css } from '@compiled/react';
+
+        useState();
+
+        <div css={css({ display: 'block' })} />
+      `,
+      errors: [
+        {
+          messageId: 'missingPragma',
+        },
+      ],
+    },
+    {
+      code: `
+        import React,{useState } from 'react';
+        import { css } from '@compiled/react';
+
+        useState();
+
+        <div css={css({ display: 'block' })} />
+      `,
+      output: `
+        /** @jsxImportSource @compiled/react */
+import { useState } from 'react';
+        import { css } from '@compiled/react';
+
+        useState();
+
+        <div css={css({ display: 'block' })} />
+      `,
+      errors: [
+        {
+          messageId: 'missingPragma',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.tsx
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.tsx
@@ -1,10 +1,30 @@
-import type { Rule } from 'eslint';
+import type { Rule, SourceCode } from 'eslint';
+import type { ImportDeclaration, ImportDefaultSpecifier } from 'estree';
 
 import { findCompiledImportDeclarations, findDeclarationWithImport } from '../../utils/ast';
 import { addImportToDeclaration, removeImportFromDeclaration } from '../../utils/ast-to-string';
 
 type Options = {
   runtime: 'classic' | 'automatic';
+};
+
+const findReactDeclaration = (
+  source: SourceCode
+): [ImportDeclaration, ImportDefaultSpecifier] | undefined => {
+  for (let i = 0; i < source.ast.body.length; i++) {
+    const statement = source.ast.body[i];
+    if (statement.type === 'ImportDeclaration' && statement.source.value === 'react') {
+      const defaultSpecifier = statement.specifiers.find(
+        (spec): spec is ImportDefaultSpecifier =>
+          spec.type === 'ImportDefaultSpecifier' && spec.local.name === 'React'
+      );
+      if (defaultSpecifier) {
+        return [statement, defaultSpecifier];
+      }
+    }
+  }
+
+  return undefined;
 };
 
 const rule: Rule.RuleModule = {
@@ -113,6 +133,25 @@ const rule: Rule.RuleModule = {
           },
           node,
           *fix(fixer) {
+            const reactImport = findReactDeclaration(source);
+            if (reactImport) {
+              const [declaration, defaultImport] = reactImport;
+              const [defaultImportVariable] = context.getDeclaredVariables(defaultImport);
+
+              if (defaultImportVariable && defaultImportVariable.references.length === 0) {
+                if (declaration.specifiers.length === 1) {
+                  // Only the default specifier exists and it isn't used - remove the whole declaration!
+                  yield fixer.remove(declaration);
+                } else {
+                  // Multiple specifiers exist but the default one isn't used - remove the default specifier!
+                  yield fixer.replaceText(
+                    declaration,
+                    removeImportFromDeclaration(declaration, [])
+                  );
+                }
+              }
+            }
+
             yield fixer.insertTextBefore(source.ast.body[0], `/** ${pragma} */\n`);
 
             const compiledImports = findCompiledImportDeclarations(context);

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.tsx
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.tsx
@@ -8,7 +8,7 @@ type Options = {
   runtime: 'classic' | 'automatic';
 };
 
-const findReactDeclaration = (
+const findReactDeclarationWithDefaultImport = (
   source: SourceCode
 ): [ImportDeclaration, ImportDefaultSpecifier] | undefined => {
   for (let i = 0; i < source.ast.body.length; i++) {
@@ -133,7 +133,7 @@ const rule: Rule.RuleModule = {
           },
           node,
           *fix(fixer) {
-            const reactImport = findReactDeclaration(source);
+            const reactImport = findReactDeclarationWithDefaultImport(source);
             if (reactImport) {
               const [declaration, defaultImport] = reactImport;
               const [defaultImportVariable] = context.getDeclaredVariables(defaultImport);

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.tsx
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.tsx
@@ -1,5 +1,5 @@
 import type { Rule, SourceCode } from 'eslint';
-import type { ImportDeclaration, ImportDefaultSpecifier } from 'estree';
+import type { ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier } from 'estree';
 
 import { findCompiledImportDeclarations, findDeclarationWithImport } from '../../utils/ast';
 import { addImportToDeclaration, removeImportFromDeclaration } from '../../utils/ast-to-string';
@@ -10,13 +10,13 @@ type Options = {
 
 const findReactDeclarationWithDefaultImport = (
   source: SourceCode
-): [ImportDeclaration, ImportDefaultSpecifier] | undefined => {
-  for (let i = 0; i < source.ast.body.length; i++) {
-    const statement = source.ast.body[i];
+): [ImportDeclaration, ImportDefaultSpecifier | ImportNamespaceSpecifier] | undefined => {
+  for (const statement of source.ast.body) {
     if (statement.type === 'ImportDeclaration' && statement.source.value === 'react') {
       const defaultSpecifier = statement.specifiers.find(
-        (spec): spec is ImportDefaultSpecifier =>
-          spec.type === 'ImportDefaultSpecifier' && spec.local.name === 'React'
+        (spec): spec is ImportDefaultSpecifier | ImportNamespaceSpecifier =>
+          (spec.type === 'ImportDefaultSpecifier' || spec.type === 'ImportNamespaceSpecifier') &&
+          spec.local.name === 'React'
       );
       if (defaultSpecifier) {
         return [statement, defaultSpecifier];

--- a/packages/eslint-plugin/src/utils/ast-to-string.tsx
+++ b/packages/eslint-plugin/src/utils/ast-to-string.tsx
@@ -35,6 +35,7 @@ export const addImportToDeclaration = (decl: ImportDeclaration, imports: string[
 export const removeImportFromDeclaration = (decl: ImportDeclaration, imports: string[]): string => {
   const specifiersString = decl.specifiers
     .map(buildNamedImport)
+    .filter(Boolean)
     .filter((spec) => !imports.includes(spec));
 
   if (specifiersString.length === 0) {


### PR DESCRIPTION
This pull request fixes a use case not initially considered in the lint rule - removing the default import of the React package when the fixer moves to the automatic pragma.