### PR TITLE
Update pkg jsdoc/json/rule

### DIFF
--- a/.changeset/eleven-geckos-grow.md
+++ b/.changeset/eleven-geckos-grow.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Adds url to lint rules

--- a/.changeset/pink-apples-appear.md
+++ b/.changeset/pink-apples-appear.md
@@ -12,4 +12,4 @@
 '@compiled/webpack-loader': patch
 ---
 
-Package jsons have had their homepage and other properties updated.
+Update `homepage` and other `package.json` properties

--- a/.changeset/pink-apples-appear.md
+++ b/.changeset/pink-apples-appear.md
@@ -1,0 +1,15 @@
+---
+'@compiled/babel-plugin': patch
+'@compiled/babel-plugin-strip-runtime': patch
+'@compiled/cli': patch
+'@compiled/codemods': patch
+'@compiled/css': patch
+'@compiled/eslint-plugin': patch
+'@compiled/jest': patch
+'@compiled/parcel-transformer': patch
+'@compiled/react': patch
+'@compiled/utils': patch
+'@compiled/webpack-loader': patch
+---
+
+Package jsons have had their homepage and other properties updated.

--- a/.changeset/rare-pillows-warn.md
+++ b/.changeset/rare-pillows-warn.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+JSDoc descriptions for all exports have been updated, let us know what you think!

--- a/.changeset/selfish-hounds-do.md
+++ b/.changeset/selfish-hounds-do.md
@@ -2,4 +2,4 @@
 '@compiled/react': patch
 ---
 
-Class name component now has its style prop passed through children as function typed as `CSSProperties` instead of a string map.
+`ClassNames` component now has its style prop typed as `CSSProperties` instead of a string map

--- a/.changeset/selfish-hounds-do.md
+++ b/.changeset/selfish-hounds-do.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Class name component now has its style prop passed through children as function typed as `CSSProperties` instead of a string map.

--- a/packages/babel-plugin-strip-runtime/package.json
+++ b/packages/babel-plugin-strip-runtime/package.json
@@ -2,7 +2,7 @@
   "name": "@compiled/babel-plugin-strip-runtime",
   "version": "0.11.1",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "homepage": "https://compiledcssinjs.com",
+  "homepage": "https://compiledcssinjs.com/docs/pkg-babel-plugin-strip-runtime",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
     "type": "git",

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "@compiled/babel-plugin",
   "version": "0.11.1",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "homepage": "https://compiledcssinjs.com",
+  "homepage": "https://compiledcssinjs.com/docs/pkg-babel-plugin",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
     "type": "git",
@@ -16,8 +16,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "src",
-    "README.md"
+    "src"
   ],
   "dependencies": {
     "@babel/core": "^7.16.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@compiled/cli",
   "version": "2.1.3",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "homepage": "https://compiledcssinjs.com",
+  "homepage": "https://compiledcssinjs.com/docs/pkg-cli",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
     "type": "git",

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@compiled/codemods",
   "version": "0.3.2",
-  "description": "Codemods (with JSCodeshift) for Compiled CSS-in-JS.",
+  "description": "A familiar and performant compile time CSS-in-JS library for React.",
   "keywords": [
     "codemod",
     "compiled",
     "css-in-js",
     "typescript"
   ],
-  "homepage": "https://compiledcssinjs.com",
+  "homepage": "https://compiledcssinjs.com/docs/pkg-cli",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
     "type": "git",

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -2,7 +2,7 @@
   "name": "@compiled/css",
   "version": "0.7.1",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "homepage": "https://compiledcssinjs.com",
+  "homepage": "https://compiledcssinjs.com/docs/pkg-css",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
     "type": "git",
@@ -16,8 +16,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "src",
-    "README.md"
+    "src"
   ],
   "dependencies": {
     "@compiled/utils": "^0.6.12",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,7 +1,15 @@
 {
   "name": "@compiled/eslint-plugin",
   "version": "0.2.1",
-  "repository": "https://github.com/atlassian-labs/compiled",
+  "description": "A familiar and performant compile time CSS-in-JS library for React.",
+  "homepage": "https://compiledcssinjs.com/docs/pkg-eslint-plugin",
+  "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atlassian-labs/compiled.git",
+    "directory": "packages/eslint-plugin"
+  },
+  "license": "Apache-2.0",
   "author": "Atlassian Pty Ltd",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.tsx
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.tsx
@@ -31,6 +31,10 @@ const rule: Rule.RuleModule = {
   meta: {
     fixable: 'code',
     type: 'problem',
+    docs: {
+      recommended: true,
+      url: 'https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/jsx-pragma',
+    },
     messages: {
       missingPragma: 'To use the `css` prop you must set the {{ pragma }} pragma.',
       preferJsxImportSource:

--- a/packages/eslint-plugin/src/rules/no-emotion-css/README.md
+++ b/packages/eslint-plugin/src/rules/no-emotion-css/README.md
@@ -1,11 +1,9 @@
 # @compiled/eslint-plugin/emotion-to-compiled
 
 Ensures usage of the `@compiled/react` library over `@emotion/core` or `@emotion/styled`.
-This rule acts as a form of codemod.
+The `--fix` option [on the command line] automatically fixes problems reported by this rule.
 
-## Examples
-
-👎 Example of **incorrect** code for this rule:
+## Fail
 
 ```js
 import styled from '@emotion/styled';
@@ -24,7 +22,7 @@ import { jsx } from '@emotion/core';
                      ^^^^^^^^^
 ```
 
-👍 Example of **correct** code for this rule:
+## Pass
 
 ```js
 import { styled } from '@compiled/react';

--- a/packages/eslint-plugin/src/rules/no-emotion-css/index.tsx
+++ b/packages/eslint-plugin/src/rules/no-emotion-css/index.tsx
@@ -28,6 +28,9 @@ const rule: Rule.RuleModule = {
   meta: {
     fixable: 'code',
     type: 'problem',
+    docs: {
+      url: 'https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/no-emotion-css',
+    },
     messages: {
       noEmotionCSS: `{{ version }} should not be used use ${COMPILED_IMPORT} instead.`,
     },

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -2,7 +2,7 @@
   "name": "@compiled/jest",
   "version": "0.7.0",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "homepage": "https://compiledcssinjs.com",
+  "homepage": "https://compiledcssinjs.com/docs/pkg-jest",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
     "type": "git",
@@ -17,8 +17,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "src",
-    "README.md"
+    "src"
   ],
   "dependencies": {
     "css": "^3.0.0"

--- a/packages/parcel-transformer/package.json
+++ b/packages/parcel-transformer/package.json
@@ -2,7 +2,7 @@
   "name": "@compiled/parcel-transformer",
   "version": "0.6.18",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "homepage": "https://compiledcssinjs.com",
+  "homepage": "https://compiledcssinjs.com/docs/pkg-parcel-transformer",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,7 +8,7 @@
     "styled-components",
     "typescript"
   ],
-  "homepage": "https://compiledcssinjs.com",
+  "homepage": "https://compiledcssinjs.com/docs/pkg-react",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
     "type": "git",

--- a/packages/react/src/class-names/index.tsx
+++ b/packages/react/src/class-names/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import type { ReactNode, CSSProperties } from 'react';
 
 import type { BasicTemplateInterpolations, CssFunction } from '../types';
 import { createSetupError } from '../utils/error';
@@ -8,36 +8,46 @@ export type Interpolations = (BasicTemplateInterpolations | CssFunction | CssFun
 export interface ClassNamesProps {
   children: (opts: {
     css: (css: CssFunction | CssFunction[], ...interpolations: Interpolations) => string;
-    style: { [key: string]: string };
+    style: CSSProperties;
   }) => ReactNode;
 }
 
 /**
- * Use a component where styles are not necessarily tied to an element.
+ * ## Class names
  *
+ * Use a component where styles are not necessarily used on a JSX element.
+ * For further details [read the documentation](https://compiledcssinjs.com/docs/api-class-names).
+ *
+ * ### Style with objects
+ *
+ * @example
  * ```
- * // Object CSS
  * <ClassNames>
  *   {({ css, style }) => children({ className: css({ fontSize: 12 }) })}
  * </ClassNames>
+ * ```
  *
- * // Template literal CSS
+ * ### Style with template literals
+ *
+ * @example
+ * ```
  * <ClassNames>
  *   {({ css, style }) => children({ className: css`font-size: 12px;` })}
  * </ClassNames>
- *
- * // Array CSS
- * <ClassNames>
- *   {({ css, style }) =>
- *    children({ className: css([{ fontSize: 12 }, `font-size: 12px`]) })}
- * </ClassNames>
  * ```
  *
- * For more help, read the docs:
- * https://compiledcssinjs.com/docs/api-class-names
+ * ### Compose styles with arrays
  *
- * @param props
+ * @example
+ * ```
+ * <ClassNames>
+ *   {({ css, style }) =>
+ *    children({ className: css([{ fontSize: 12 }, css`font-size: 12px`]) })}
+ * </ClassNames>
+ * ```
  */
-export function ClassNames(_: ClassNamesProps): JSX.Element {
+export function ClassNames({ children }: ClassNamesProps): JSX.Element;
+
+export function ClassNames(_props: ClassNamesProps): JSX.Element {
   throw createSetupError();
 }

--- a/packages/react/src/css/index.tsx
+++ b/packages/react/src/css/index.tsx
@@ -9,21 +9,36 @@ import type {
 import { createSetupError } from '../utils/error';
 
 /**
- * Create styles that can be re-used between components with a template literal.
+ * ## CSS
  *
+ * Define styles that are statically typed and useable with other Compiled APIs.
+ * For further details [read the documentation](https://compiledcssinjs.com/docs/api-css).
+ *
+ * ### Style with template literals
+ *
+ * @example
  * ```
- * css`color: red;`;
+ * const redText = css({
+ *   color: 'red',
+ * });
+ *
+ * <div css={redText} />
  * ```
  *
- * For more help, read the docs:
- * https://compiledcssinjs.com/docs/api-css
+ * ### Style with objects
  *
- * @param css
- * @param values
+ * @example
+ * ```
+ * const redText = css`
+ *   color: red;
+ * `;
+ *
+ * <div css={redText} />
+ * ```
  */
 export default function css<T = void>(
-  _css: TemplateStringsArray,
-  ..._values: (BasicTemplateInterpolations | FunctionInterpolation<T>)[]
+  styles: TemplateStringsArray,
+  ...interpolations: (BasicTemplateInterpolations | FunctionInterpolation<T>)[]
 ): CSSProps;
 
 /**
@@ -38,11 +53,11 @@ export default function css<T = void>(
  *
  * @param css
  */
-export default function css(_css: AnyKeyCssProps<void> | CSSProps): CSSProps;
+export default function css(styles: AnyKeyCssProps<void> | CSSProps): CSSProps;
 
 export default function css<T = void>(
-  _css: TemplateStringsArray | CSSProps,
-  ..._values: (BasicTemplateInterpolations | FunctionInterpolation<T>)[]
+  _styles: TemplateStringsArray | CSSProps,
+  ..._interpolations: (BasicTemplateInterpolations | FunctionInterpolation<T>)[]
 ): CSSProps {
   throw createSetupError();
 }

--- a/packages/react/src/css/index.tsx
+++ b/packages/react/src/css/index.tsx
@@ -41,18 +41,6 @@ export default function css<T = void>(
   ...interpolations: (BasicTemplateInterpolations | FunctionInterpolation<T>)[]
 ): CSSProps;
 
-/**
- * Create styles that can be re-used between components with an object
- *
- * ```
- * css({ color: 'red' });
- * ```
- *
- * For more help, read the docs:
- * https://compiledcssinjs.com/docs/api-css
- *
- * @param css
- */
 export default function css(styles: AnyKeyCssProps<void> | CSSProps): CSSProps;
 
 export default function css<T = void>(

--- a/packages/react/src/css/index.tsx
+++ b/packages/react/src/css/index.tsx
@@ -14,7 +14,7 @@ import { createSetupError } from '../utils/error';
  * Define styles that are statically typed and useable with other Compiled APIs.
  * For further details [read the documentation](https://compiledcssinjs.com/docs/api-css).
  *
- * ### Style with template literals
+ * ### Style with objects
  *
  * @example
  * ```
@@ -25,7 +25,7 @@ import { createSetupError } from '../utils/error';
  * <div css={redText} />
  * ```
  *
- * ### Style with objects
+ * ### Style with template literals
  *
  * @example
  * ```

--- a/packages/react/src/jsx/jsx-local-namespace.tsx
+++ b/packages/react/src/jsx/jsx-local-namespace.tsx
@@ -4,16 +4,42 @@ type WithConditionalCSSProp<TProps> = 'className' extends keyof TProps
   ? string extends TProps['className' & keyof TProps]
     ? {
         /**
-         * Tie styles to an element.
+         * ## CSS prop
          *
+         * Style a JSX element.
+         * For further details [read the API documentation](https://compiledcssinjs.com/docs/api-css-prop).
+         *
+         * ### Style with objects
+         *
+         * @example
          * ```
-         * css={{ fontSize: 12 }} // Object CSS
-         * css={`font-size: 12px;`} // Template literal CSS
-         * css={[{ fontSize: 12 }, `font-size: 12px;`]} // Array CSS
+         * import { css } from '@compiled/react';
+         *
+         * <div css={css({ fontSize: 12 })} />
          * ```
          *
-         * For more help, read the docs:
-         * https://compiledcssinjs.com/docs/api-css-prop
+         * ### Style with template literals
+         *
+         * @example
+         * ```
+         * import { css } from '@compiled/react';
+         *
+         * <div css={css`color: red;`} />
+         * ```
+         *
+         * ### Compose styles with arrays
+         *
+         * @example
+         * ```
+         * import { css } from '@compiled/react';
+         *
+         * <div
+         *  css={[
+         *    css({ fontSize: 12 }),
+         *    css`color: red;`,
+         *  ]}
+         * />
+         * ```
          */
         css?: CssFunction | CssFunction[];
       }

--- a/packages/react/src/keyframes/index.tsx
+++ b/packages/react/src/keyframes/index.tsx
@@ -4,28 +4,14 @@ import { createSetupError } from '../utils/error';
 export type KeyframeSteps = string | Record<string, CSSProps>;
 
 /**
- * Create keyframes using a tagged template expression:
+ * ## Keyframes
  *
- * ```
- * const fadeOut = keyframes`
- *   from { opacity: 1; }
- *   to   { opacity: 0; }
- * `;
- * ```
+ * Define keyframes to be used in a [CSS animation](https://developer.mozilla.org/en-US/docs/Web/CSS/animation).
+ * For further details [read the API documentation](https://compiledcssinjs.com/docs/api-keyframes).
  *
- * @param _strings The input string values
- * @param _interpolations The arguments used in the expression
- */
-export function keyframes(
-  _strings: TemplateStringsArray,
-  ..._interpolations: BasicTemplateInterpolations[]
-): string;
-
-/**
- * Create keyframes using:
+ * ### Style with objects
  *
- * 1. An object expression
- *
+ * @example
  * ```
  * const fadeOut = keyframes({
  *   from: {
@@ -35,23 +21,33 @@ export function keyframes(
  *     opacity: 0,
  *   },
  * });
+ *
+ * <div css={{ animation: `${fadeOut} 2s` }} />
  * ```
  *
- * 2. A string
+ * ### Style with template literals
  *
+ * @example
  * ```
- * const fadeOut = keyframes('from { opacity: 1; } to { opacity: 0; }');
- * ```
+ * const fadeOut = keyframes`
+ *   from {
+ *     opacity: 1;
+ *   }
  *
- * 3. A template literal
+ *   to {
+ *     opacity: 0;
+ *   }
+ * `;
  *
+ * <div css={{ animation: `${fadeOut} 2s` }} />
  * ```
- * const fadeOut = keyframes(`from { opacity: 1; } to { opacity: 0; }`);
- * ```
- *
- * @param _steps The waypoints along the animation sequence
  */
-export function keyframes(_steps: KeyframeSteps): string;
+export function keyframes(steps: KeyframeSteps): string;
+
+export function keyframes(
+  strings: TemplateStringsArray,
+  ...interpolations: BasicTemplateInterpolations[]
+): string;
 
 export function keyframes(
   _stringsOrSteps: TemplateStringsArray | KeyframeSteps,

--- a/packages/react/src/styled/index.tsx
+++ b/packages/react/src/styled/index.tsx
@@ -58,17 +58,45 @@ export interface StyledComponentInstantiator extends StyledComponentMap {
 }
 
 /**
- * Create a component that ties styles to an element which comes with built-in behavior such as `ref` and `as` prop support.
+ * ## Styled component
  *
+ * Create a component that styles a JSX element which comes with built-in behavior such as `ref` and `as` prop support.
+ * For further details [read the documentation](https://compiledcssinjs.com/docs/api-styled).
+ *
+ * ### Style with objects
+ *
+ * @example
  * ```
- * styled.div`font-size: 12px`; // Template literal CSS
- * styled.div({ fontSize: 12 }); // Object CSS
- * styled.div([{ fontSize: 12 }, `font-size: 12px;`]) // Array CSS
- * styled.div({ fontSize: 12 }, `font-size: 12px`) Multi arguments CSS
+ * styled.div({
+ *   fontSize: 12,
+ * });
  * ```
  *
- * For more help, read the docs:
- * https://compiledcssinjs.com/docs/api-styled
+ * ### Style with template literals
+ *
+ * @example
+ * ```
+ * styled.div`
+ *   font-size: 12px
+ * `;
+ * ```
+ *
+ * ### Compose styles with arrays
+ *
+ * @example
+ * ```
+ * import { css } from '@compiled/react';
+ *
+ * styled.div([
+ *   { fontSize: 12 },
+ *   css`font-size: 12px;`
+ * ]);
+ *
+ * styled.div(
+ *   { fontSize: 12 },
+ *   css`font-size: 12px`
+ * );
+ * ```
  */
 export const styled: StyledComponentInstantiator = new Proxy(
   {},

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,8 +16,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "src",
-    "README.md"
+    "src"
   ],
   "dependencies": {
     "convert-source-map": "^1.8.0",

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -2,7 +2,7 @@
   "name": "@compiled/webpack-loader",
   "version": "0.7.3",
   "description": "A familiar and performant compile time CSS-in-JS library for React.",
-  "homepage": "https://compiledcssinjs.com",
+  "homepage": "https://compiledcssinjs.com/docs/pkg-webpack-loader",
   "bugs": "https://github.com/atlassian-labs/compiled/issues/new?assignees=&labels=bug&template=bug_report.md",
   "repository": {
     "type": "git",
@@ -17,8 +17,7 @@
   "files": [
     "css-loader",
     "dist",
-    "src",
-    "README.md"
+    "src"
   ],
   "dependencies": {
     "@babel/core": "^7.16.0",


### PR DESCRIPTION
This pull request:

- updates the jsdoc descriptions for the `@compiled/react` package 
- removes redundant files in `files` field in pkg json in most packages
- updates homepage in pkg json for most packages
- updates the type signature of the class names component style prop
- adds url to the lint rules