### PR TITLE
fix: updates css func object types

### DIFF
--- a/.changeset/chilly-rats-design.md
+++ b/.changeset/chilly-rats-design.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Fixes `css` function types to allow nested styles

--- a/packages/react/src/css/__tests__/index.test.tsx
+++ b/packages/react/src/css/__tests__/index.test.tsx
@@ -29,6 +29,13 @@ describe('css prop', () => {
     expect(getByText('hello world')).toHaveCompiledCss('font-size', '13px');
   });
 
+  it('should create hover styles', () => {
+    const styles = css({ ':hover': { color: 'red' } });
+    const { getByText } = render(<div css={styles}>hello world</div>);
+
+    expect(getByText('hello world')).toHaveCompiledCss('color', 'red', { target: ':hover' });
+  });
+
   it('should create css from tagged template expression variable', () => {
     const style = css`
       font-size: 13px;

--- a/packages/react/src/css/index.tsx
+++ b/packages/react/src/css/index.tsx
@@ -1,6 +1,11 @@
 /* eslint-disable import/export */
 
-import type { AnyKeyCssProps, BasicTemplateInterpolations, CSSProps, FunctionInterpolation } from '../types';
+import type {
+  AnyKeyCssProps,
+  BasicTemplateInterpolations,
+  CSSProps,
+  FunctionInterpolation,
+} from '../types';
 import { createSetupError } from '../utils/error';
 
 /**
@@ -33,7 +38,7 @@ export default function css<T = void>(
  *
  * @param css
  */
-export default function css(_css: AnyKeyCssProps | CSSProps): CSSProps;
+export default function css(_css: AnyKeyCssProps<void> | CSSProps): CSSProps;
 
 export default function css<T = void>(
   _css: TemplateStringsArray | CSSProps,

--- a/packages/react/src/css/index.tsx
+++ b/packages/react/src/css/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable import/export */
 
-import type { BasicTemplateInterpolations, CSSProps, FunctionInterpolation } from '../types';
+import type { AnyKeyCssProps, BasicTemplateInterpolations, CSSProps, FunctionInterpolation } from '../types';
 import { createSetupError } from '../utils/error';
 
 /**
@@ -33,7 +33,7 @@ export default function css<T = void>(
  *
  * @param css
  */
-export default function css(_css: CSSProps): CSSProps;
+export default function css(_css: AnyKeyCssProps | CSSProps): CSSProps;
 
 export default function css<T = void>(
   _css: TemplateStringsArray | CSSProps,


### PR DESCRIPTION
This pull request fixes the `css` function call to allow passing in psuedo declarations.