### PR TITLE
Move changeset config to run for each PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,36 +14,11 @@
   "lockFileMaintenance": {
     "enabled": true
   },
+  "postUpgradeTasks": {
+    "commands": ["yarn changeset --empty"],
+    "fileFilters": [".changeset/*", "yarn.lock"]
+  },
   "packageRules": [
-    {
-      "depTypeList": ["devDependencies"],
-      "updateTypes": ["patch", "minor"],
-
-      "groupName": "devDependencies (non-major)",
-      "postUpgradeTasks": {
-        "commands": ["yarn changeset --empty"],
-        "fileFilters": [".changeset/*", "yarn.lock"]
-      }
-    },
-    {
-      "depTypeList": ["devDependencies"],
-      "postUpgradeTasks": {
-        "commands": ["yarn changeset --empty"],
-        "fileFilters": [".changeset/*", "yarn.lock"]
-      }
-    },
-    {
-      "depTypeList": ["dependencies"],
-      "prPriority": 1,
-      "postUpgradeTasks": {
-        "commands": ["ts-node scripts/generate-renovate-changeset.ts"],
-        "fileFilters": [".changeset/*", "yarn.lock"]
-      }
-    },
-    {
-      "packagePatterns": ["^@types"],
-      "prPriority": -1
-    },
     {
       "managers": ["npm"],
       "updateTypes": ["minor", "patch"],


### PR DESCRIPTION
I think the reason renovate isn't working with changesets currently is the grouping applied. I'm moving the changeset task to run on every commit as the script works in this scenario anyway.