### PR TITLE
Resolve css-what and nth-check in @compiled/css

### DIFF
--- a/.changeset/lazy-roses-wonder.md
+++ b/.changeset/lazy-roses-wonder.md
@@ -1,0 +1,6 @@
+---
+'@compiled/babel-plugin': patch
+'@compiled/css': patch
+---
+
+Resolve css-what and nth-check to new versions in @compiled/css

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -19,7 +19,9 @@
     "src"
   ],
   "resolutions": {
-    "cssnano-preset-default": "^5.1.7"
+    "css-what": "^5.1.0",
+    "cssnano-preset-default": "^5.1.7",
+    "nth-check": "^2.0.1"
   },
   "dependencies": {
     "@compiled/utils": "^0.6.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6155,9 +6155,9 @@ color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-string@^1.6.0:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.8.2.tgz#08bd49fa5f3889c27b0c670052ed746dd7a671de"
-  integrity sha1-CL1J+l84icJ7DGcAUu10bdemcd4=
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.0.tgz#63b6ebd1bec11999d1df3a79a7569451ac2be8aa"
+  integrity sha1-Y7br0b7BGZnR3zp5p1aUUawr6Ko=
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
@@ -6867,7 +6867,7 @@ cssnano-preset-default@^4.0.8:
     postcss-svgo "^4.0.3"
     postcss-unique-selectors "^4.0.1"
 
-cssnano-preset-default@^5.1.4, cssnano-preset-default@^5.1.7:
+cssnano-preset-default@^5.1.7, cssnano-preset-default@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/cssnano-preset-default/-/cssnano-preset-default-5.1.8.tgz#7525feb1b72f7b06e57f55064cbdae341d79dea2"
   integrity sha1-dSX+sbcvewblf1UGTL2uNB153qI=
@@ -6932,7 +6932,7 @@ cssnano-utils@^2.0.1:
 cssnano@^4.1.10, cssnano@^4.1.11:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-4.1.11.tgz#c7b5f5b81da269cb1fd982cb960c1200910c9a99"
-  integrity sha512-6gZm2htn7xIPJOHY824ERgj8cNPgPxyCSnkXc4v7YvNW+TdVfzgngHcEhy/8D11kUWRUMbke+tC+AUcUsnMz2g==
+  integrity sha1-x7X1uB2iacsf2YLLlgwSAJEMmpk=
   dependencies:
     cosmiconfig "^5.0.0"
     cssnano-preset-default "^4.0.8"
@@ -6940,11 +6940,11 @@ cssnano@^4.1.10, cssnano@^4.1.11:
     postcss "^7.0.0"
 
 cssnano@^5.0.2:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.0.8.tgz#39ad166256980fcc64faa08c9bb18bb5789ecfa9"
-  integrity sha512-Lda7geZU0Yu+RZi2SGpjYuQz4HI4/1Y+BhdD0jL7NXAQ5larCzVn+PUGuZbDMYz904AXXCOgO5L1teSvgu7aFg==
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-5.0.12.tgz#2c083a1c786fc9dc2d5522bd3c0e331b7cd302ab"
+  integrity sha1-LAg6HHhvydwtVSK9PA4zG3zTAqs=
   dependencies:
-    cssnano-preset-default "^5.1.4"
+    cssnano-preset-default "^5.1.8"
     is-resolvable "^1.1.0"
     lilconfig "^2.0.3"
     yaml "^1.10.2"


### PR DESCRIPTION
Another whack at resolving the VULN tickets. The theory is the package.json is getting picked up in the `@compiled/css` and but not the root of the repo.