### PR TITLE
Remove .yarnrc config

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-registry "https://registry.yarnpkg.com/"


### PR DESCRIPTION
This file may be related to the release job failing on master. It doesn't appear to be working on my machine anymore, so we may as well remove it.