### PR TITLE
Add config to typecheck parcel example

### DIFF
--- a/.changeset/witty-adults-hug.md
+++ b/.changeset/witty-adults-hug.md
@@ -1,0 +1,5 @@
+---
+'@compiled/parcel-app': patch
+---
+
+Update parcel example to use type checking

--- a/examples/parcel/src/ui/typescript.tsx
+++ b/examples/parcel/src/ui/typescript.tsx
@@ -1,4 +1,5 @@
-import '@compiled/react';
+/** @jsxImportSource @compiled/react */
+// @ts-expect-error
 import { primary } from '../constants';
 
 interface TypeScriptProps {

--- a/examples/parcel/tsconfig.json
+++ b/examples/parcel/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "files": [],
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": true
+  },
   "references": [
     { "path": "../../fixtures/parcel-resolver-alias/tsconfig.json" },
     { "path": "../../packages/parcel-transformer/tsconfig.json" },


### PR DESCRIPTION
Parcel does not type check by default so we need to ensure typescript does this for us.