### PR TITLE
Fix: Prevent usages of extraneous packages.

### DIFF
--- a/.changeset/clean-humans-sparkle.md
+++ b/.changeset/clean-humans-sparkle.md
@@ -1,0 +1,9 @@
+---
+'@compiled-private/module-a': patch
+'@compiled/babel-plugin': patch
+'@compiled/codemods': patch
+'@compiled/react': patch
+'@compiled/webpack-loader': patch
+---
+
+Added ESLint rule to prevent use of extraneous packages, and added these usages of these packages as dependencies. Added new namespace `@compiled-private` to prevent name clashes with existing npm packages.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
         'import/export': 'off',
         // We will let TypeScript handle this for tsx? files, and ignore it on jsx? files to enable linting without
         // building packages
+        'import/no-extraneous-dependencies': 'error',
         'import/no-unresolved': 'off',
         'import/order': ['error', {
           alphabetize: {

--- a/fixtures/module-a/package.json
+++ b/fixtures/module-a/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "module-a",
+  "name": "@compiled-private/module-a",
   "version": "0.0.1",
   "private": true,
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "@babel/preset-react": "^7.16.5",
     "@babel/preset-typescript": "^7.16.5",
     "@changesets/cli": "^2.19.0",
+    "@compiled-private/module-a": "*",
+    "@compiled/babel-plugin": "*",
     "@compiled/jest": "*",
     "@compiled/react": "*",
     "@size-limit/preset-big-lib": "^7.0.5",

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -22,6 +22,7 @@
     "@babel/core": "^7.16.5",
     "@babel/generator": "^7.16.5",
     "@babel/helper-plugin-utils": "^7.16.5",
+    "@babel/parser": "^7.16.3",
     "@babel/plugin-syntax-jsx": "^7.16.5",
     "@babel/plugin-transform-flow-strip-types": "^7.16.5",
     "@babel/template": "^7.16.0",
@@ -33,10 +34,14 @@
     "resolve": "^1.21.0"
   },
   "devDependencies": {
+    "@compiled-private/module-a": "^0.0.1",
+    "@compiled/benchmark": "1.0.1",
     "@types/babel__core": "^7.1.18",
     "@types/benchmark": "^2.1.1",
     "@types/resolve": "^1.20.1",
     "benchmark": "^2.1.4",
-    "prettier": "^2.5.1"
+    "prettier": "^2.5.1",
+    "ts-node": "^10.4.0",
+    "tsconfig-paths": "^3.12.0"
   }
 }

--- a/packages/babel-plugin/src/__fixtures__/mixins/reexport.js
+++ b/packages/babel-plugin/src/__fixtures__/mixins/reexport.js
@@ -1,4 +1,4 @@
-import { colors } from 'module-a';
+import { colors } from '@compiled-private/module-a';
 
 export const reexport = colors.primary;
 

--- a/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
+++ b/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
@@ -100,7 +100,7 @@ describe('module traversal', () => {
       `
       import '@compiled/react';
       import React from 'react';
-      import { colors } from 'module-a';
+      import { colors } from '@compiled-private/module-a';
 
       <div css={{ color: colors.primary }} />
     `

--- a/packages/babel-plugin/src/utils/resolve-binding.ts
+++ b/packages/babel-plugin/src/utils/resolve-binding.ts
@@ -229,7 +229,12 @@ export const resolveBinding = (
     }
 
     const moduleImportSource = binding.path.parentPath.node.source.value;
-    if (moduleImportSource.startsWith('@compiled')) {
+
+    // Babel Plugin cannot differentiate between a variable and reserved keywords (e.g keyframes)
+    // It will therefore try to parse and resolve both.
+    // This workaround shortcircuits when we call `resolveBinding` on a Compiled module.
+    // Documented in Issue ##1010: https://github.com/atlassian-labs/compiled/issues/1010
+    if (moduleImportSource.startsWith('@compiled/')) {
       // Ignore @compiled modules.
       return;
     }

--- a/packages/codemods/package.json
+++ b/packages/codemods/package.json
@@ -26,6 +26,7 @@
     "src"
   ],
   "dependencies": {
+    "@compiled/utils": "^0.6.14",
     "chalk": "^5.0.0",
     "jscodeshift": "^0.13.0"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -75,6 +75,7 @@
     "csstype": "^3.0.10"
   },
   "devDependencies": {
+    "@compiled/benchmark": "^1.0.1",
     "@testing-library/react": "^11.2.7",
     "@types/react-dom": "^17.0.11",
     "react": "^17.0.2",

--- a/packages/react/src/__tests__/browser.test.tsx
+++ b/packages/react/src/__tests__/browser.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { styled } from '@compiled/react';
 import { render } from '@testing-library/react';
 import React from 'react';

--- a/packages/react/src/__tests__/display-names.test.tsx
+++ b/packages/react/src/__tests__/display-names.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { styled } from '@compiled/react';
 
 describe('display names', () => {

--- a/packages/react/src/__tests__/jest-matcher.test.tsx
+++ b/packages/react/src/__tests__/jest-matcher.test.tsx
@@ -1,4 +1,6 @@
 /** @jsxImportSource @compiled/react */
+// This test belongs in @compiled/jest - but can't be placed there due to a circular dependency.
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { styled } from '@compiled/react';
 import { render } from '@testing-library/react';
 

--- a/packages/react/src/__tests__/ssr.test.tsx
+++ b/packages/react/src/__tests__/ssr.test.tsx
@@ -1,7 +1,9 @@
 /**
  * @jest-environment node
  */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { styled } from '@compiled/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { CC as CompiledRoot } from '@compiled/react/runtime';
 import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';

--- a/packages/react/src/class-names/__tests__/index.test.tsx
+++ b/packages/react/src/class-names/__tests__/index.test.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { ClassNames } from '@compiled/react';
 import { render } from '@testing-library/react';
 import React from 'react';

--- a/packages/react/src/css/__tests__/index.test.tsx
+++ b/packages/react/src/css/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource @compiled/react */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { css } from '@compiled/react';
 import { render } from '@testing-library/react';
 

--- a/packages/react/src/jsx/__tests__/jsx-pragma.test.tsx
+++ b/packages/react/src/jsx/__tests__/jsx-pragma.test.tsx
@@ -1,5 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { jsx } from '@compiled/react';
 import { render } from '@testing-library/react';
 

--- a/packages/react/src/keyframes/__fixtures__/index.tsx
+++ b/packages/react/src/keyframes/__fixtures__/index.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { keyframes } from '@compiled/react';
 
 export const fadeOut = keyframes({

--- a/packages/react/src/keyframes/__tests__/index.test.tsx
+++ b/packages/react/src/keyframes/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource @compiled/react */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { keyframes, styled } from '@compiled/react';
 import { render } from '@testing-library/react';
 

--- a/packages/react/src/styled/__tests__/index.test.tsx
+++ b/packages/react/src/styled/__tests__/index.test.tsx
@@ -1,4 +1,5 @@
 /** @jsxImportSource @compiled/react */
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { styled } from '@compiled/react';
 import { render } from '@testing-library/react';
 

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -24,6 +24,7 @@
     "@compiled/babel-plugin": "^0.11.3",
     "@compiled/babel-plugin-strip-runtime": "^0.11.2",
     "@compiled/css": "^0.8.0",
+    "@compiled/react": "0.10.1",
     "@compiled/utils": "^0.6.14",
     "enhanced-resolve": "^5.8.3",
     "loader-utils": "^2.0.2",
@@ -34,6 +35,9 @@
     "css-loader": "^5.2.7",
     "memfs": "^3.4.1",
     "mini-css-extract-plugin": "^1.6.2",
+    "react": "^17.0.2",
+    "ts-node": "^10.4.0",
+    "tsconfig-paths": "^3.12.0",
     "webpack": "^5.61.0"
   },
   "peerDependencies": {

--- a/stories/module-traversal.tsx
+++ b/stories/module-traversal.tsx
@@ -1,5 +1,5 @@
+import { colors, objectStyles } from '@compiled-private/module-a';
 import { styled } from '@compiled/react';
-import { colors, objectStyles } from 'module-a';
 
 import { hoverObjectLiteral } from './mixins';
 

--- a/stories/simple-function-mixins.tsx
+++ b/stories/simple-function-mixins.tsx
@@ -1,5 +1,5 @@
+import { colorMixin, colors, objectStyles } from '@compiled-private/module-a';
 import { styled } from '@compiled/react';
-import { colorMixin, colors, objectStyles } from 'module-a';
 
 export default {
   title: 'mixins/simple functions',

--- a/yarn.lock
+++ b/yarn.lock
@@ -347,7 +347,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.11", "@babel/parser@^7.13.16", "@babel/parser@^7.16.0", "@babel/parser@^7.16.5", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.11", "@babel/parser@^7.13.16", "@babel/parser@^7.16.0", "@babel/parser@^7.16.3", "@babel/parser@^7.16.5", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0":
   version "7.16.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.6.tgz#8f194828193e8fa79166f34a4b4e52f3e769a314"
   integrity sha512-Gr86ujcNuPDnNOY8mi383Hvi8IYrJVJYuf3XcuBM/Dgd+bINn/7tHqsj+tKkoreMbmGsFLsltI/JJd8fOFWGDQ==


### PR DESCRIPTION
This pull request adds a new ESLint rule: `import/no-extraneous-dependencies`.

It makes a few changes to allow Compiled to work with this rule:
- Added imported extraneous packages as dependencies in relevant package.json files.
- Changed 'module-a' package to '@compiled-private/module-a' to prevent name clashes.
- Updated references to '@compiled-private/module-a'.

We then documented a workaround for issue #1010: https://github.com/atlassian-labs/compiled/issues/1010