### PR TITLE
Remove changeset task on renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,10 +14,6 @@
   "lockFileMaintenance": {
     "enabled": true
   },
-  "postUpgradeTasks": {
-    "commands": ["yarn changeset --empty"],
-    "fileFilters": [".changeset/*", "yarn.lock"]
-  },
   "packageRules": [
     {
       "managers": ["npm"],


### PR DESCRIPTION
We're starting to get warnings from renovate with this changeset task, as it is no longer supported