### PR TITLE
Add property to loader options when the extract plugin is enabled 

### DIFF
--- a/.changeset/unlucky-pumas-rest.md
+++ b/.changeset/unlucky-pumas-rest.md
@@ -1,0 +1,5 @@
+---
+'@compiled/webpack-loader': patch
+---
+
+Add property to loader options when CompiledExtractPlugin has been set up correctly.

--- a/packages/webpack-loader/src/compiled-loader.tsx
+++ b/packages/webpack-loader/src/compiled-loader.tsx
@@ -28,6 +28,7 @@ function getLoaderOptions(context: LoaderContext<CompiledLoaderOptions>) {
     resolve = {},
     extensions = undefined,
     babelPlugins = [],
+    [pluginName]: isPluginEnabled = false,
   }: CompiledLoaderOptions = typeof context.getOptions === 'undefined'
     ? // Webpack v4 flow
       getOptions(context)
@@ -56,6 +57,9 @@ function getLoaderOptions(context: LoaderContext<CompiledLoaderOptions>) {
           babelPlugins: {
             type: 'array',
           },
+          [pluginName]: {
+            type: 'boolean',
+          },
         },
       });
 
@@ -67,6 +71,7 @@ function getLoaderOptions(context: LoaderContext<CompiledLoaderOptions>) {
     resolve,
     extensions,
     babelPlugins,
+    [pluginName]: isPluginEnabled,
   };
 }
 
@@ -170,9 +175,7 @@ export default async function compiledLoader(
 
 export function pitch(this: LoaderContext<CompiledLoaderOptions>): void {
   const options = getLoaderOptions(this);
-
-  // @ts-expect-error No definitions for this[pluginName]
-  if (!hasErrored && options.extract && !this[pluginName]) {
+  if (!hasErrored && options.extract && !options[pluginName]) {
     this.emitError(
       createError('webpack-loader')(
         `You forgot to add the 'CompiledExtractPlugin' plugin (i.e \`{ plugins: [new CompiledExtractPlugin()] }\`), please read https://compiledcssinjs.com/docs/css-extraction-webpack`

--- a/packages/webpack-loader/src/extract-plugin.tsx
+++ b/packages/webpack-loader/src/extract-plugin.tsx
@@ -8,6 +8,7 @@ import {
   getNormalModuleHook,
   getOptimizeAssetsHook,
   getSources,
+  setPluginConfiguredOption,
 } from './utils';
 
 export const pluginName = 'CompiledExtractPlugin';
@@ -88,6 +89,7 @@ const pushNodeModulesExtractLoader = (
         // We turn off baking as we're only interested in extracting from node modules (they're already baked)!
         bake: false,
         extract: true,
+        [pluginName]: true,
       },
     },
   });
@@ -112,6 +114,8 @@ export class CompiledExtractPlugin {
     forceCSSIntoOneStyleSheet(compiler);
 
     compiler.hooks.compilation.tap(pluginName, (compilation) => {
+      setPluginConfiguredOption(compilation.options.module.rules, pluginName);
+
       getNormalModuleHook(compiler, compilation).tap(pluginName, (loaderContext) => {
         // We add some information here to tell loaders that the plugin has been configured.
         // Bundling will throw if this is missing (i.e. consumers did not setup correctly).

--- a/packages/webpack-loader/src/extract-plugin.tsx
+++ b/packages/webpack-loader/src/extract-plugin.tsx
@@ -5,7 +5,6 @@ import type { Compilation, Compiler } from 'webpack';
 import type { CompiledExtractPluginOptions } from './types';
 import {
   getAssetSourceContents,
-  getNormalModuleHook,
   getOptimizeAssetsHook,
   getSources,
   setPluginConfiguredOption,
@@ -115,12 +114,6 @@ export class CompiledExtractPlugin {
 
     compiler.hooks.compilation.tap(pluginName, (compilation) => {
       setPluginConfiguredOption(compilation.options.module.rules, pluginName);
-
-      getNormalModuleHook(compiler, compilation).tap(pluginName, (loaderContext) => {
-        // We add some information here to tell loaders that the plugin has been configured.
-        // Bundling will throw if this is missing (i.e. consumers did not setup correctly).
-        (loaderContext as any)[pluginName] = true;
-      });
 
       getOptimizeAssetsHook(compiler, compilation).tap(pluginName, (assets) => {
         const cssAssets = getCSSAssets(assets);

--- a/packages/webpack-loader/src/types.tsx
+++ b/packages/webpack-loader/src/types.tsx
@@ -1,6 +1,8 @@
 import type { ParserPlugin } from '@babel/parser';
 import type { ResolveOptions, RuleSetCondition } from 'webpack';
 
+import type { pluginName } from './extract-plugin';
+
 export type { ResolveOptions };
 
 export interface CompiledLoaderOptions {
@@ -42,6 +44,11 @@ export interface CompiledLoaderOptions {
    * List of babel plugins to be applied to evaluated files
    */
   babelPlugins?: ParserPlugin[];
+
+  /**
+   * Set to true if CompiledExtractPlugin has been set up correctly
+   */
+  [pluginName]?: boolean;
 }
 
 export interface CompiledExtractPluginOptions {

--- a/packages/webpack-loader/src/utils.tsx
+++ b/packages/webpack-loader/src/utils.tsx
@@ -44,31 +44,6 @@ export const setPluginConfiguredOption = (
 };
 
 /**
- * Gets the normal module hook for webpack 4 & webpack 5.
- *
- * @returns
- */
-export const getNormalModuleHook = (
-  compiler: Compiler,
-  compilation: CompilationType
-): CompilationType['hooks']['normalModuleLoader'] => {
-  const { NormalModule } =
-    // Webpack 5 flow
-    compiler.webpack ||
-    // Webpack 4 flow
-    require('webpack');
-
-  const normalModuleHook =
-    NormalModule && typeof NormalModule.getCompilationHooks !== 'undefined'
-      ? // Webpack 5 flow
-        NormalModule.getCompilationHooks(compilation).loader
-      : // Webpack 4 flow
-        compilation.hooks.normalModuleLoader;
-
-  return normalModuleHook;
-};
-
-/**
  * Returns the string representation of an assets source.
  *
  * @param source

--- a/packages/webpack-loader/src/utils.tsx
+++ b/packages/webpack-loader/src/utils.tsx
@@ -1,4 +1,47 @@
-import type { Compilation as CompilationType, Compiler, sources } from 'webpack';
+import type { Compilation as CompilationType, Compiler, sources, RuleSetRule } from 'webpack';
+
+/**
+ * Sets an option on the plugin config to tell loaders that the plugin has been configured.
+ * Bundling will throw if this option is missing (i.e. consumers did not setup correctly).
+ *
+ * @param rules
+ * @param pluginName
+ * @returns
+ */
+export const setPluginConfiguredOption = (
+  rules: (RuleSetRule | '...')[],
+  pluginName: string
+): void => {
+  for (const rule of rules) {
+    const use = (rule as RuleSetRule).use;
+    if (!use || typeof use === 'string') {
+      continue;
+    }
+    if (Array.isArray(use)) {
+      if (!use.length) {
+        continue;
+      }
+      for (const nestedUse of use) {
+        if (typeof nestedUse !== 'object' || nestedUse.loader !== '@compiled/webpack-loader') {
+          continue;
+        }
+        const { options } = nestedUse;
+        if (!options || typeof options !== 'object' || !options.extract) {
+          continue;
+        }
+        options[pluginName] = true;
+      }
+    } else {
+      if (typeof use === 'object' && use.loader === '@compiled/webpack-loader') {
+        const { options } = use;
+        if (!options || typeof options !== 'object' || !options.extract) {
+          continue;
+        }
+        options[pluginName] = true;
+      }
+    }
+  }
+};
 
 /**
  * Gets the normal module hook for webpack 4 & webpack 5.


### PR DESCRIPTION
When setting up the CompiledExtractPlugin (when `extract` is enabled), we set an option on the loader context to let the @compiled/webpack-loader know that everything was set up correctly. However, when the @compiled/webpack-loader is used in conjunction with the thread-loader, the CompiledExtractPlugin is set up in a different scope to where the @compiled/webpack-loader is run. This means the check to see if the plugin was set up correctly will always fail when using the thread-loader.

The approach is to modify the loader options (that are passed directly into the @compiled/webpack-loader) instead of the loader context. 