### PR TITLE
APP-298 update compiled/webpack-loader to use compiled-css.css

### DIFF
--- a/packages/webpack-loader/css-loader/README.md
+++ b/packages/webpack-loader/css-loader/README.md
@@ -1,6 +1,6 @@
 # @compiled/webpack-loader/css-loader
 
-## What's `extract.css`
+## What's `compiled-css.css`
 
 It's a placeholder CSS file we use for style extraction,
 used for two reasons:

--- a/packages/webpack-loader/src/compiled-loader.tsx
+++ b/packages/webpack-loader/src/compiled-loader.tsx
@@ -7,7 +7,7 @@ import { CachedInputFileSystem, ResolverFactory } from 'enhanced-resolve';
 import { getOptions } from 'loader-utils';
 import type { LoaderContext } from 'webpack';
 
-import { pluginName } from './extract-plugin';
+import { pluginName, styleSheetName } from './extract-plugin';
 import type { CompiledLoaderOptions } from './types';
 import { toURIComponent } from './utils';
 
@@ -160,7 +160,7 @@ export default async function compiledLoader(
         // We use require instead of import so it works with both ESM and CJS source.
         // If we used ESM it would blow up with CJS source, unfortunately.
         output = `
-  require("@compiled/webpack-loader/css-loader!@compiled/webpack-loader/css-loader/extract.css?style=${params}");
+  require("@compiled/webpack-loader/css-loader!@compiled/webpack-loader/css-loader/${styleSheetName}.css?style=${params}");
   ${output}`;
       });
     }


### PR DESCRIPTION
Update compiled/webpack-loader to use compiled-css.css instead of extract.css so we can reference the public css file in jfe (compiled-css.css) instead of the internal one (extract.css). https://product-fabric.atlassian.net/browse/APP-298