### PR TITLE
1087 - Handle ExportNamedDeclarations with source for resolve binding

### DIFF
--- a/.changeset/purple-bugs-carry.md
+++ b/.changeset/purple-bugs-carry.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+Handle export named declarations with source when resolving modules

--- a/packages/babel-plugin/src/__fixtures__/mixins/reexport.js
+++ b/packages/babel-plugin/src/__fixtures__/mixins/reexport.js
@@ -5,3 +5,5 @@ export const reexport = colors.primary;
 export const objectReexport = {
   foo: colors.danger,
 };
+
+export { primary as default, secondary, default as reexportedDefault } from './simple';

--- a/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
+++ b/packages/babel-plugin/src/__tests__/module-traversal.test.tsx
@@ -593,4 +593,39 @@ describe('module traversal', () => {
       expect(result).toInclude(':hover{padding-top:10px}');
     });
   });
+
+  describe('Direct re-exports', () => {
+    it('should resolve identifier when re-exported as a named export', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import { secondary } from '../__fixtures__/mixins/reexport';
+
+        <div css={{ color: secondary }} />
+      `);
+
+      expect(result).toInclude('{color:pink}');
+    });
+
+    it('should resolve identifier when re-exported as default export', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import defaultColor from '../__fixtures__/mixins/reexport';
+
+        <div css={{ color: defaultColor }} />
+      `);
+
+      expect(result).toInclude('{color:red}');
+    });
+
+    it('should resolve identifier when re-exported default has an alias', () => {
+      const result = transform(`
+        import '@compiled/react';
+        import { reexportedDefault } from '../__fixtures__/mixins/reexport';
+
+        <div css={{ color: reexportedDefault }} />
+      `);
+
+      expect(result).toInclude('{color:red}');
+    });
+  });
 });

--- a/packages/babel-plugin/src/utils/traversers/get-export.tsx
+++ b/packages/babel-plugin/src/utils/traversers/get-export.tsx
@@ -22,6 +22,15 @@ export const getDefaultExport = (ast: t.File): Result<t.ExportDefaultDeclaration
       result = { path, node: path.node.declaration };
       path.stop();
     },
+    // Handle `export {alias as default}`
+    ExportNamedDeclaration(path) {
+      path.get('specifiers')?.forEach(({ node }) => {
+        if (t.isExportSpecifier(node) && t.isIdentifier(node.exported, { name: 'default' })) {
+          result = { path, node: node.local };
+          path.stop();
+        }
+      });
+    },
   });
 
   return result;


### PR DESCRIPTION
Resolves: #1087

Adds functionality to module resolution to resolve exports like:
`export { default as A, B, default as C } from 'foo';`