### PR TITLE
Bump trim-newlines to v3.0.1

### DIFF
--- a/.changeset/red-dots-remember.md
+++ b/.changeset/red-dots-remember.md
@@ -1,0 +1,6 @@
+---
+'@compiled/cli': patch
+'@compiled/codemods': patch
+---
+
+Bump trim-newlines to v3.0.1

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "start": "ts-node --files src/index.tsx"
   },
   "dependencies": {
-    "@compiled/codemods": ">=0.4.0",
+    "@compiled/codemods": "^0.4.1",
     "app-root-path": "^3.0.0",
     "chalk": "^4.1.2",
     "enquirer": "^2.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16086,9 +16086,9 @@ traverse@0.6.6:
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
 
 trim-newlines@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
-  integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-trailing-lines@^1.0.0:
   version "1.1.4"


### PR DESCRIPTION
Manually bump `trim-newlines` to the newest patch version.

No need to bump meow to the major version yet - lets continue to wait until node esm support is improved.