### PR TITLE
Fix usage of Babel to work better with SWC transform in Parcel

### DIFF
--- a/.changeset/seven-pumpkins-relax.md
+++ b/.changeset/seven-pumpkins-relax.md
@@ -1,0 +1,6 @@
+---
+'@compiled/parcel-app': minor
+'@compiled/parcel-transformer': minor
+---
+
+Use separate Babel env for parsing source files in the Parcel Transformer plugin to allow usage of plugins/presets that aren't needed with the SWC Transformer in Parcel.

--- a/examples/parcel/babel.config.json
+++ b/examples/parcel/babel.config.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "compiledcss": {
+      "presets": ["@babel/preset-typescript", "@babel/preset-react"]
+    }
+  }
+}

--- a/examples/parcel/package.json
+++ b/examples/parcel/package.json
@@ -12,6 +12,8 @@
     "react-dom": "17.0.2"
   },
   "devDependencies": {
+    "@babel/preset-react": "^7.16.7",
+    "@babel/preset-typescript": "^7.16.7",
     "@compiled/parcel-transformer": "*",
     "@parcel/optimizer-htmlnano": "^2.3.2",
     "@parcel/packager-html": "^2.3.2",

--- a/packages/parcel-transformer/README.md
+++ b/packages/parcel-transformer/README.md
@@ -10,4 +10,4 @@ npm i @compiled/parcel-transformer
 
 ## Usage
 
-Detailed docs and example usage can be [found on the documentation website](https://compiledcssinjs.com/docs/pkg-parcel).
+Detailed docs and example usage can be [found on the documentation website](https://compiledcssinjs.com/docs/pkg-parcel-transformer).

--- a/packages/parcel-transformer/src/transformer.ts
+++ b/packages/parcel-transformer/src/transformer.ts
@@ -74,7 +74,6 @@ export default new Transformer<UserlandOpts>({
     const includedFiles: string[] = [];
     const code = asset.isASTDirty() ? undefined : await asset.getCode();
 
-    console.log(`Transforming ${asset.filePath}`);
     const result = await transformFromAstAsync(ast.program, code, {
       code: false,
       ast: true,
@@ -96,7 +95,6 @@ export default new Transformer<UserlandOpts>({
         name: 'compiled',
       },
     });
-    console.log(`Transformed ${asset.filePath}`);
 
     includedFiles.forEach((file) => {
       // Included files are those which have been statically evaluated into this asset.

--- a/packages/parcel-transformer/src/transformer.ts
+++ b/packages/parcel-transformer/src/transformer.ts
@@ -53,6 +53,7 @@ export default new Transformer<UserlandOpts>({
       filename: asset.filePath,
       caller: { name: 'compiled' },
       rootMode: 'upward-optional',
+      envName: 'compiledcss',
     });
 
     return {
@@ -73,6 +74,7 @@ export default new Transformer<UserlandOpts>({
     const includedFiles: string[] = [];
     const code = asset.isASTDirty() ? undefined : await asset.getCode();
 
+    console.log(`Transforming ${asset.filePath}`);
     const result = await transformFromAstAsync(ast.program, code, {
       code: false,
       ast: true,
@@ -94,6 +96,7 @@ export default new Transformer<UserlandOpts>({
         name: 'compiled',
       },
     });
+    console.log(`Transformed ${asset.filePath}`);
 
     includedFiles.forEach((file) => {
       // Included files are those which have been statically evaluated into this asset.


### PR DESCRIPTION
Since Parcel moved from Babel to SWC internally for it's JavaScript transformation, it is perfectly valid to have a React/Typescript project built with Parcel without the need for a `babel.config.json` at all. However, the Compiled Parcel Transform still uses `@babel/core` in order to read and parse JavaScript files for use with Compiled. 

Migrating this usage to use Parcel's transformations is a bit of a larger project, but in the meantime in order to still be able to use Compiled with Parcel we need a way of configuring Compiled's Babel without affecting Parcel's babel transform which is designed to warn on usages of TS transforms for example.

The proposed solution for this is that when the Compiled transform calls Babel it does so with an `env` of `compiledcss`. This allows the consumer to create a `babel.config.json` with required presets just for Compiled to be able to read their code, without affecting their Parcel compilation.