### PR TITLE
Opt-out of low risk VULNs due to recent change

### DIFF
--- a/security-assistant.yml
+++ b/security-assistant.yml
@@ -1,4 +1,3 @@
 owner: jbrown2@atlassian.com
 paths:
   - 'packages/**'
-fileAllSnykTicketsNow: true


### PR DESCRIPTION
A recent change in VULN filing allows us to opt out of no/low-risk issues.