### PR TITLE
Account for nested rules in webpack config 

### DIFF
--- a/.changeset/stale-fans-laugh.md
+++ b/.changeset/stale-fans-laugh.md
@@ -1,0 +1,5 @@
+---
+'@compiled/webpack-loader': patch
+---
+
+Account for nested rules in webpack config when setting plugin configured option on compiled webpack loader


### PR DESCRIPTION
This PR refactors setting the plugin configured option on the compiled webpack loader and accounts for nested rules in the webpack config https://webpack.js.org/configuration/module/#nested-rules

Fixes this bug https://github.com/atlassian-labs/compiled/issues/1137