### PR TITLE
Correctly include config.json in package release

### DIFF
--- a/.changeset/wicked-ears-film.md
+++ b/.changeset/wicked-ears-film.md
@@ -1,0 +1,5 @@
+---
+'@compiled/parcel-config': patch
+---
+
+Include config.json in package release

--- a/packages/parcel-config/package.json
+++ b/packages/parcel-config/package.json
@@ -13,8 +13,7 @@
   "sideEffects": false,
   "main": "./config.json",
   "files": [
-    "dist",
-    "src"
+    "config.json"
   ],
   "dependencies": {
     "@compiled/parcel-optimizer": "^0.1.1",


### PR DESCRIPTION
Resolves #1215

The current package configuration for `@compiled/parcel-config` is incorrect and excludes `config.json`. This is likely the reason our release does not include the file.