### PR TITLE
Pass through babel parser plugins in parcel transformer

### DIFF
--- a/.changeset/fast-tips-hear.md
+++ b/.changeset/fast-tips-hear.md
@@ -1,0 +1,5 @@
+---
+'@compiled/parcel-transformer': patch
+---
+
+Use parser babel plugins in parcel transformer

--- a/examples/parcel/.compiledcssrc
+++ b/examples/parcel/.compiledcssrc
@@ -8,7 +8,8 @@
     ".customjsx"
   ],
   "parserBabelPlugins": [
-    "typescript"
+    "typescript",
+    "jsx"
   ],
   "transformerBabelPlugins": [
     [

--- a/examples/parcel/.parcelrc
+++ b/examples/parcel/.parcelrc
@@ -1,9 +1,17 @@
 {
-  "extends": ["@parcel/config-default", "@compiled/parcel-config"],
+  "extends": [
+    "@parcel/config-default",
+    "@compiled/parcel-config"
+  ],
   "transformers": {
+    "*.{js,mjs,jsx,cjs,ts,tsx}": [
+      // Manually remove the babel transformer so we don't use the root babel config
+      "@compiled/parcel-transformer",
+      "@parcel/transformer-js",
+      "@parcel/transformer-react-refresh-wrap"
+    ],
     "*.customjsx": [
       "@compiled/parcel-transformer",
-      "@parcel/transformer-babel",
       "@parcel/transformer-js",
       "@parcel/transformer-react-refresh-wrap",
       "..."

--- a/packages/parcel-transformer/src/index.ts
+++ b/packages/parcel-transformer/src/index.ts
@@ -62,6 +62,9 @@ export default new Transformer<ParcelTransformerOpts>({
       filename: asset.filePath,
       caller: { name: 'compiled' },
       rootMode: 'upward-optional',
+      parserOpts: {
+        plugins: config.parserBabelPlugins ?? undefined,
+      },
       plugins: config.transformerBabelPlugins ?? undefined,
     });
 
@@ -90,6 +93,9 @@ export default new Transformer<ParcelTransformerOpts>({
       babelrc: false,
       configFile: false,
       sourceMaps: true,
+      parserOpts: {
+        plugins: config.parserBabelPlugins ?? undefined,
+      },
       plugins: [
         ...(config.transformerBabelPlugins ?? []),
         asset.isSource && [


### PR DESCRIPTION
I missed this in the previous PR but we should be passing the parser plugin into the babel operations in the parcel transformer.

Also to allow this behaviour to be tested, we have to manually specify the transformers in our example configuration, so that the root babel config is not used.