### PR TITLE
fix for jsx-runtime when used with vitejs

### DIFF
--- a/.changeset/forty-plants-return.md
+++ b/.changeset/forty-plants-return.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+use explicit exports from `react/jsx-dev-runtime` and `react/jsx-runtime`. some bundlers, namely vitejs, appear to optimize the need functions away when `export * from` is used

--- a/examples/parcel/src/react.d.ts
+++ b/examples/parcel/src/react.d.ts
@@ -1,0 +1,3 @@
+declare module 'react/jsx-dev-runtime';
+
+declare module 'react/jsx-runtime';

--- a/packages/react/src/jsx/jsx-dev-runtime.ts
+++ b/packages/react/src/jsx/jsx-dev-runtime.ts
@@ -2,4 +2,6 @@ export type { CompiledJSX as JSX } from './jsx-local-namespace';
 
 // Pass through the (automatic) jsx dev runtime.
 // Compiled currently doesn't define its own and uses this purely to enable a local jsx namespace.
-export * from 'react/jsx-dev-runtime';
+// https://github.com/facebook/react/blob/main/packages/react/jsx-dev-runtime.js#L10
+// @ts-expect-error these don't appear to be typed
+export { Fragment, jsxDEV } from 'react/jsx-dev-runtime';

--- a/packages/react/src/jsx/jsx-runtime.ts
+++ b/packages/react/src/jsx/jsx-runtime.ts
@@ -2,4 +2,6 @@ export type { CompiledJSX as JSX } from './jsx-local-namespace';
 
 // Pass through the (automatic) jsx runtime.
 // Compiled currently doesn't define its own and uses this purely to enable a local jsx namespace.
-export * from 'react/jsx-runtime';
+// https://github.com/facebook/react/blob/main/packages/react/jsx-runtime.js#L9
+// @ts-expect-error these don't appear to be typed
+export { Fragment, jsx, jsxs } from 'react/jsx-runtime';

--- a/packages/react/tsconfig.options.json
+++ b/packages/react/tsconfig.options.json
@@ -1,5 +1,6 @@
 {
   "extends": "../tsconfig.options.json",
+  "exclude": ["dist"],
   "compilerOptions": {
     "rootDir": "src",
     "plugins": [


### PR DESCRIPTION
fixes https://github.com/atlassian-labs/compiled/issues/1237

vitejs appears to optimize the needed functions away. have tried by manually adjusting the file at dist/esm/jsx/jsx-dev-runtime.js and this works