### PR TITLE
Take hashed asset name into consideration when optimizing css asset

### DIFF
--- a/.changeset/loud-walls-remember.md
+++ b/.changeset/loud-walls-remember.md
@@ -1,0 +1,5 @@
+---
+'@compiled/webpack-loader': patch
+---
+
+Take hashed asset name into consideration when optimizating css asset

--- a/packages/webpack-loader/src/__tests__/test-utils.ts
+++ b/packages/webpack-loader/src/__tests__/test-utils.ts
@@ -68,7 +68,7 @@ export function bundle(
       path: outputPath,
     },
     plugins: [
-      new MiniCssExtractPlugin({ filename: 'static/[name].css' }),
+      new MiniCssExtractPlugin({ filename: 'static/[name].[contenthash].css' }),
       ...(disableExtractPlugin
         ? []
         : [new CompiledExtractPlugin(disableCacheGroup ? { cacheGroupExclude: true } : {})]),

--- a/packages/webpack-loader/src/extract-plugin.ts
+++ b/packages/webpack-loader/src/extract-plugin.ts
@@ -23,7 +23,7 @@ export const styleSheetName = 'compiled-css';
 const getCSSAssets = (assets: Compilation['assets']) => {
   return Object.keys(assets)
     .filter((assetName) => {
-      return assetName.endsWith(`${styleSheetName}.css`);
+      return assetName.includes(styleSheetName) && assetName.endsWith('.css');
     })
     .map((assetName) => ({ name: assetName, source: assets[assetName], info: {} }));
 };


### PR DESCRIPTION
In the CompiledExtractPlugin, we check if the asset name ends with ‘compiled-css.css’:
https://github.com/atlassian-labs/compiled/blob/master/packages/webpack-loader/src/extract-plugin.ts#L26
However, this assumption can be incorrect if the asset name is something like [name].[contenthash].css. This will cause the following optimisation (e.g. mergeDuplicateAtRules and sortAtomicStyleSheet) not happening.