### PR TITLE
1295 - Improve support for computed object property keys

### DIFF
--- a/.changeset/violet-ties-cheat.md
+++ b/.changeset/violet-ties-cheat.md
@@ -1,0 +1,6 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+- Fixes bug where more than one import cannot be used in template literal object property key
+- Support string binary operation in object property keys

--- a/packages/babel-plugin/src/__tests__/module-traversal.test.ts
+++ b/packages/babel-plugin/src/__tests__/module-traversal.test.ts
@@ -353,9 +353,10 @@ describe('module traversal', () => {
       import { styled } from '@compiled/react';
 
       import { JOINED_SELECTOR } from '../__fixtures__/mixins/strings';
+      import { primary } from '../__fixtures__/mixins/simple';
 
       const BackgroundWithSelector = styled.div({
-        [\`\${JOINED_SELECTOR}\`]: {
+        [\`\${JOINED_SELECTOR}, .\${primary}\`]: {
           backgroundColor: 'green',
         },
       });
@@ -365,7 +366,9 @@ describe('module traversal', () => {
       </BackgroundWithSelector>;
     `);
 
-    expect(actual).toInclude('._15rzbf54 #joined-selector{background-color:green}');
+    expect(actual).toInclude(
+      '._15rzbf54 #joined-selector, ._1khrbf54 .red{background-color:green}'
+    );
   });
 
   describe('should call onIncludedFiles with the filepath', () => {

--- a/packages/babel-plugin/src/utils/__tests__/object-property-to-string.test.ts
+++ b/packages/babel-plugin/src/utils/__tests__/object-property-to-string.test.ts
@@ -1,0 +1,217 @@
+import { parse } from '@babel/parser';
+import type { NodePath } from '@babel/traverse';
+import traverse from '@babel/traverse';
+import * as t from '@babel/types';
+
+import type { Metadata } from '../../types';
+import { evaluateExpression } from '../evaluate-expression';
+import { objectPropertyToString } from '../object-property-to-string';
+
+jest.mock('../evaluate-expression');
+
+const evaluateExpressionMock = <jest.MockedFn<typeof evaluateExpression>>evaluateExpression;
+
+type TraverseState = { result: string };
+
+describe('objectPropertyToString', () => {
+  const mockMeta = {
+    state: {
+      key: 'originalMock',
+    },
+  } as Metadata;
+
+  const testSetupVisitor = {
+    ObjectProperty(this: TraverseState, path: NodePath<t.ObjectProperty>) {
+      this.result = objectPropertyToString(path.node, mockMeta);
+      path.stop();
+    },
+  };
+
+  const transform = (code: string) => {
+    const ast = parse(code, { sourceType: 'module' });
+    const state: TraverseState = { result: '' };
+
+    traverse(ast, testSetupVisitor, undefined, state);
+
+    return state.result;
+  };
+
+  afterEach(jest.resetAllMocks);
+
+  describe('Identifier', () => {
+    it('gets key value when property is not computed', () => {
+      const key = 'name';
+      const actual = transform(`const obj = { ${key}: "value"};`);
+
+      expect(actual).toBe(key);
+    });
+
+    it('gets key value when property is computed', () => {
+      const key = 'name';
+
+      evaluateExpressionMock.mockReturnValue({
+        value: t.stringLiteral(key),
+        meta: mockMeta,
+      });
+
+      const actual = transform(`
+        const field = '${key}';
+        const obj = {
+          [field]: "value"
+        };
+      `);
+
+      expect(actual).toBe(key);
+    });
+  });
+
+  describe('StringLiteral & NumericLiteral', () => {
+    it('gets key value when property is string', () => {
+      const key = 'name';
+      const actual = transform(`const obj = { '${key}': "value"};`);
+
+      expect(actual).toBe(key);
+    });
+
+    it('gets key value when property is number', () => {
+      const key = 100;
+      const actual = transform(`const obj = { ${key}: "value"};`);
+
+      expect(actual).toBe(String(key));
+    });
+  });
+
+  describe('TemplateLiteral', () => {
+    it('combines quasis and expressions into key value', () => {
+      const selectorId = '#id';
+      const classSelector = '.hidden';
+
+      evaluateExpressionMock.mockReturnValueOnce({
+        value: t.stringLiteral(selectorId),
+        meta: mockMeta,
+      });
+
+      evaluateExpressionMock.mockReturnValueOnce({
+        value: t.stringLiteral(classSelector),
+        meta: mockMeta,
+      });
+
+      const actual = transform(`
+        const ID = '${selectorId}';
+        const hideClass = '${classSelector}';
+
+        const obj = {
+          [\`\${ID}, \${hideClass}\`]: "value",
+        };
+      `);
+
+      expect(actual).toBe(`${selectorId}, ${classSelector}`);
+    });
+
+    it('handles nested template literals while making sure metadata is correctly scoped', () => {
+      const headerSelector = 'header';
+      const headerComponentSelector = `[data-selector="${headerSelector}"]`;
+      const itemSelector = 'item';
+      const itemComponentSelector = `[data-selector="${itemSelector}"]`;
+
+      const headerImportMeta = {
+        state: {
+          key: 'headerScope',
+        },
+      } as Metadata;
+
+      const itemImportMeta = {
+        state: {
+          key: 'itemScope',
+        },
+      } as Metadata;
+
+      evaluateExpressionMock.mockReturnValueOnce({
+        value: t.templateLiteral(
+          [t.templateElement({ raw: '[data-selector="' }), t.templateElement({ raw: '"]' })],
+          [t.identifier('HEADER')]
+        ),
+        meta: headerImportMeta,
+      });
+
+      evaluateExpressionMock.mockReturnValueOnce({
+        value: t.stringLiteral(headerSelector),
+        meta: headerImportMeta,
+      });
+
+      evaluateExpressionMock.mockReturnValueOnce({
+        value: t.templateLiteral(
+          [t.templateElement({ raw: '[data-selector="' }), t.templateElement({ raw: '"]' })],
+          [t.identifier('ITEM')]
+        ),
+        meta: itemImportMeta,
+      });
+
+      evaluateExpressionMock.mockReturnValueOnce({
+        value: t.stringLiteral(itemSelector),
+        meta: itemImportMeta,
+      });
+
+      const actual = transform(`
+        import { HEADER_SELECTOR } from './header';
+        import { ITEM_SELECTOR } from './item';
+
+        const obj = {
+          [\`\${HEADER_SELECTOR}, \${ITEM_SELECTOR}\`]: "value",
+        };
+    `);
+
+      // asserts correct metadata is used when using nested evaluations
+      expect(evaluateExpressionMock).nthCalledWith(1, expect.anything(), mockMeta);
+      expect(evaluateExpressionMock).nthCalledWith(2, expect.anything(), headerImportMeta);
+      expect(evaluateExpressionMock).nthCalledWith(3, expect.anything(), mockMeta);
+      expect(evaluateExpressionMock).nthCalledWith(4, expect.anything(), itemImportMeta);
+
+      expect(actual).toBe(`${headerComponentSelector}, ${itemComponentSelector}`);
+    });
+
+    it('throws error when has TSType expression', () => {
+      evaluateExpressionMock.mockReturnValue({
+        value: t.stringLiteral('name'),
+        meta: mockMeta,
+      });
+
+      expect(() => {
+        transform('const obj = { [`key-${name: any}`]: "value"};');
+      }).toThrow();
+    });
+  });
+
+  describe('BinaryExpression', () => {
+    it('concatenates expressions', () => {
+      const s1 = 'field';
+      const s2 = 'Name';
+      const num = 1;
+      const actual = transform(`const obj = { ['${s1}' + '${s2}' + ${num}]: "value"};`);
+
+      expect(actual).toBe(`${s1}${s2}${num}`);
+    });
+
+    it('throws error when illegal string operator used', () => {
+      expect(() => {
+        transform('const obj = { ["illegal" * "op"]: "value"};');
+      }).toThrow();
+    });
+  });
+
+  describe('illegal expressions', () => {
+    it('throws when unsupported expression used', () => {
+      evaluateExpressionMock.mockReturnValue({
+        value: t.arrayExpression([]),
+        meta: mockMeta,
+      });
+
+      expect(() => {
+        transform(`
+          const array = [];
+          const obj = { [array]: "value" };
+        `);
+      }).toThrow();
+    });
+  });
+});

--- a/packages/babel-plugin/src/utils/css-builders.ts
+++ b/packages/babel-plugin/src/utils/css-builders.ts
@@ -5,7 +5,7 @@ import { hash, kebabCase } from '@compiled/utils';
 
 import type { Metadata } from '../types';
 
-import { buildCodeFrameError, getKey } from './ast';
+import { buildCodeFrameError } from './ast';
 import { CONDITIONAL_PATHS } from './constants';
 import { evaluateExpression } from './evaluate-expression';
 import {
@@ -21,6 +21,7 @@ import {
   optimizeConditionalStatement,
   recomposeTemplateLiteral,
 } from './manipulate-template-literal';
+import { objectPropertyToString } from './object-property-to-string';
 import { resolveBinding } from './resolve-binding';
 import type {
   CSSOutput,
@@ -458,7 +459,7 @@ const extractObjectExpression = (node: t.ObjectExpression, meta: Metadata): CSSO
 
   node.properties.forEach((prop) => {
     if (t.isObjectProperty(prop)) {
-      const key = getKey(prop.computed ? evaluateExpression(prop.key, meta).value : prop.key, meta);
+      const key = objectPropertyToString(prop, meta);
       // Don't use prop.value directly as it extracts constants from identifiers if needed.
       const { value: propValue, meta: updatedMeta } = evaluateExpression(
         prop.value as t.Expression,

--- a/packages/babel-plugin/src/utils/object-property-to-string.ts
+++ b/packages/babel-plugin/src/utils/object-property-to-string.ts
@@ -1,0 +1,88 @@
+import * as t from '@babel/types';
+
+import type { Metadata } from '../types';
+
+import { evaluateExpression } from './evaluate-expression';
+
+type ExpressionToString = (expression: t.Expression, meta: Metadata) => string;
+
+const templateLiteralToString = (
+  template: t.TemplateLiteral,
+  meta: Metadata,
+  expressionToString: ExpressionToString
+) => {
+  let result = '';
+
+  for (let i = 0; i < template.quasis.length; i += 1) {
+    result += template.quasis[i].value.raw;
+
+    if (i < template.expressions.length) {
+      const expression = template.expressions[i];
+      if (t.isTSType(expression)) {
+        // Passed a type instead of a value
+        // e.g. `${any}`
+        throw new Error(`${template.type} has a type instead of a value`);
+      }
+      const evaluatedExpression = evaluateExpression(expression, meta);
+      result += expressionToString(evaluatedExpression.value, evaluatedExpression.meta);
+    }
+  }
+
+  return result;
+};
+
+const binaryExpressionToString = (
+  expression: t.BinaryExpression,
+  meta: Metadata,
+  expressionToString: ExpressionToString
+): string => {
+  const { left, right, operator } = expression;
+
+  if (operator === '+' && t.isExpression(left)) {
+    const leftValue = expressionToString(left, meta);
+    const rightValue = expressionToString(right, meta);
+
+    return `${leftValue}${rightValue}`;
+  }
+
+  throw new Error(`Cannot use ${operator} for string operation. Use + for string concatenation`);
+};
+
+const expressionToString: ExpressionToString = (expression, meta) => {
+  // handles {'key-name': 'value'} or {1: 'value'}
+  if (t.isStringLiteral(expression) || t.isNumericLiteral(expression)) {
+    return String(expression.value);
+  }
+  // handles {[key]: 'value'}
+  if (t.isIdentifier(expression)) {
+    const evaluatedExpression = evaluateExpression(expression, meta);
+
+    return expressionToString(evaluatedExpression.value, evaluatedExpression.meta);
+  }
+  // handles {[`key-${name}`]: 'value'}
+  if (t.isTemplateLiteral(expression)) {
+    return templateLiteralToString(expression, meta, expressionToString);
+  }
+  // handles {['key-' + name]: 'value'}
+  if (t.isBinaryExpression(expression)) {
+    return binaryExpressionToString(expression, meta, expressionToString);
+  }
+
+  throw new Error(`${expression.type} has no name.'`);
+};
+
+/**
+ * Returns string output of a ObjectProperty's key
+ *
+ * @param prop ObjectProperty expression
+ * @param meta Metadata
+ */
+export const objectPropertyToString = (prop: t.ObjectProperty, meta: Metadata): string => {
+  const { computed, key } = prop;
+  // handles {key: 'value'}
+  if (t.isIdentifier(key) && !computed) {
+    return key.name;
+  }
+
+  return expressionToString(key, meta);
+};


### PR DESCRIPTION
Resolves #1295
- Fixes bug where more than one import cannot be used in template literal object property key
- Support string binary operation in object property keys