### PR TITLE
fix(webpack-loader): add missing `options.parserBabelPlugins`

### DIFF
--- a/.changeset/ten-trees-shave.md
+++ b/.changeset/ten-trees-shave.md
@@ -1,0 +1,5 @@
+---
+'@compiled/webpack-loader': patch
+---
+
+Add missing parserBabelPlugins options to webpack loader

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = {
               extract: extractCSS,
               importReact: false,
               extensions: ['.js', '.jsx', '.ts', '.tsx', '.customjsx'],
-              parserBabelPlugins: ['typescript'],
+              parserBabelPlugins: ['typescript', 'jsx'],
               transformerBabelPlugins: [['@babel/plugin-proposal-decorators', { legacy: true }]],
               optimizeCss: false,
             },

--- a/packages/webpack-loader/src/compiled-loader.ts
+++ b/packages/webpack-loader/src/compiled-loader.ts
@@ -118,6 +118,9 @@ export default async function compiledLoader(
       filename: this.resourcePath,
       caller: { name: 'compiled' },
       rootMode: 'upward-optional',
+      parserOpts: {
+        plugins: options.parserBabelPlugins ?? undefined,
+      },
       plugins: options.transformerBabelPlugins ?? undefined,
     });
 
@@ -139,6 +142,9 @@ export default async function compiledLoader(
       configFile: false,
       sourceMaps: true,
       filename: this.resourcePath,
+      parserOpts: {
+        plugins: options.parserBabelPlugins ?? undefined,
+      },
       plugins: [
         ...(options.transformerBabelPlugins ?? []),
         options.extract && [


### PR DESCRIPTION
The PR follows #1225.

In #1225 @JakeLane introduced two new options, `parserBabelPlugins` and `transformerBabelPlugins`. Although both two options were added to the parcel transformer, only `transformerBabelPlugins` was added to the webpack loader while `parserBabelPlugins` is missing. The PR fixes that.