### PR TITLE
fix(eslint-plugin): handle importing whole modules

### DIFF
--- a/.changeset/loud-clouds-look.md
+++ b/.changeset/loud-clouds-look.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Handle whole module imports

--- a/packages/eslint-plugin/src/rules/no-emotion-css/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-emotion-css/__tests__/rule.test.ts
@@ -7,6 +7,7 @@ tester.run('no-emotion-css', noEmotionCssRule, {
     `import { css } from '@compiled/react';`,
     `import { ClassNames } from '@compiled/react';`,
     `import { css, ClassNames, styled } from '@compiled/react';`,
+    `import '@compiled/react'`,
     `/** @jsx jsx */`,
     `/** @jsxImportSource @compiled/react */`,
   ],

--- a/packages/eslint-plugin/src/rules/no-emotion-css/index.ts
+++ b/packages/eslint-plugin/src/rules/no-emotion-css/index.ts
@@ -57,7 +57,7 @@ export const noEmotionCssRule: Rule.RuleModule = {
         }
       },
       ImportDeclaration(node) {
-        if (node.specifiers[0].type === 'ImportNamespaceSpecifier') {
+        if (node.specifiers[0]?.type === 'ImportNamespaceSpecifier') {
           return;
         }
 


### PR DESCRIPTION
## Issue

Currently, the eslint rule breaks for the whole consuming project if there are module imports

```
❯ yarn lint

Oops! Something went wrong! :(

ESLint: 8.4.1

TypeError: Cannot read property 'type' of undefined
Occurred while linting /Users/mmansour/dev/product-pricing-portal-frontend/packages/nav/src/ui/styled.tsx:4
Rule: "@compiled/no-emotion-css"
    at ImportDeclaration (/Users/mmansour/dev/product-pricing-portal-frontend/node_modules/@compiled/eslint-plugin/dist/rules/no-emotion-css/index.js:54:40)
    at ruleErrorHandler (/Users/mmansour/dev/product-pricing-portal-frontend/node_modules/eslint/lib/linter/linter.js:1076:28)
    at /Users/mmansour/dev/product-pricing-portal-frontend/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/mmansour/dev/product-pricing-portal-frontend/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/Users/mmansour/dev/product-pricing-portal-frontend/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (/Users/mmansour/dev/product-pricing-portal-frontend/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
    at NodeEventGenerator.enterNode (/Users/mmansour/dev/product-pricing-portal-frontend/node_modules/eslint/lib/linter/node-event-generator.js:340:14)
    at CodePathAnalyzer.enterNode (/Users/mmansour/dev/product-pricing-portal-frontend/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:795:23)
    at /Users/mmansour/dev/product-pricing-portal-frontend/node_modules/eslint/lib/linter/linter.js:1107:32
```

## Cause
That's due to such imports having an empty `specifiers` array
<img width="1422" alt="image" src="https://user-images.githubusercontent.com/33766083/199632529-2b00a485-08f1-4295-bf9d-6c9c0043dc74.png">

## Fix
This change adds optional chaining when accessing the array element in case it doesn't exist.
