### PR TITLE
Add Type support to no-styled-tagged-template-expression ESLint rule

### DIFF
--- a/.changeset/stale-parents-pretend.md
+++ b/.changeset/stale-parents-pretend.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Add Type support to no-styled-tagged-template-expression ESLint rule

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -20,6 +20,7 @@
     "src"
   ],
   "devDependencies": {
+    "@typescript-eslint/parser": "^5.43.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.32.0",
     "prettier": "^2.5.1",

--- a/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/__tests__/rule.test.ts
@@ -5,7 +5,8 @@ import type { RuleTester } from 'eslint';
 import {
   createAliasedInvalidTestCase,
   createDeclarationInvalidTestCases,
-  tester,
+  createTypedInvalidTestCase,
+  typeScriptTester as tester
 } from '../../../test-utils';
 import { noStyledTaggedTemplateExpressionRule } from '../index';
 
@@ -31,6 +32,9 @@ const replaceAlias = (str: string) =>
     .replace('styled.div', 'styled2.div')
     .replace('styled(Base)', 'styled2(Base)');
 
+const replaceType = (str: string) =>
+  str.replace('styled.div', 'styled.div<{color: string}>');
+
 const createInvalidTestCases = (tests: InvalidTestCase[]) =>
   tests
     .map((t) => ({
@@ -42,7 +46,8 @@ const createInvalidTestCases = (tests: InvalidTestCase[]) =>
       ...createDeclarationInvalidTestCases(t, 'Component', replaceDeclaration, replaceDeclaration),
     ])
     .flatMap((t) => [t, createComposedComponentTestCase(t)])
-    .flatMap((t) => [t, createAliasedInvalidTestCase(t, replaceAlias, replaceAlias)]);
+    .flatMap((t) => [t, createAliasedInvalidTestCase(t, replaceAlias, replaceAlias)])
+    .flatMap((t) => [t, createTypedInvalidTestCase(t, replaceType, replaceType)]);
 
 tester.run('no-styled-tagged-template-expression', noStyledTaggedTemplateExpressionRule, {
   valid: [

--- a/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/__tests__/rule.test.ts
@@ -6,7 +6,7 @@ import {
   createAliasedInvalidTestCase,
   createDeclarationInvalidTestCases,
   createTypedInvalidTestCase,
-  typeScriptTester as tester
+  typeScriptTester as tester,
 } from '../../../test-utils';
 import { noStyledTaggedTemplateExpressionRule } from '../index';
 
@@ -32,8 +32,7 @@ const replaceAlias = (str: string) =>
     .replace('styled.div', 'styled2.div')
     .replace('styled(Base)', 'styled2(Base)');
 
-const replaceType = (str: string) =>
-  str.replace('styled.div', 'styled.div<{color: string}>');
+const replaceType = (str: string) => str.replace('styled.div', 'styled.div<{color: string}>');
 
 const createInvalidTestCases = (tests: InvalidTestCase[]) =>
   tests

--- a/packages/eslint-plugin/src/test-utils.ts
+++ b/packages/eslint-plugin/src/test-utils.ts
@@ -17,13 +17,17 @@ import { RuleTester } from 'eslint';
   });
 };
 
-export const tester = new RuleTester({
+const baseTesterConfig = {
   parser: require.resolve('babel-eslint'),
   parserOptions: {
     ecmaVersion: 6,
     sourceType: 'module',
   },
-});
+};
+
+export const tester = new RuleTester(baseTesterConfig);
+
+export const typeScriptTester = new RuleTester({ ...baseTesterConfig, parser: require.resolve('@typescript-eslint/parser')});
 
 export const createAliasedInvalidTestCase = (
   test: RuleTester.InvalidTestCase,
@@ -68,3 +72,14 @@ export const createDeclarationInvalidTestCases = (
     },
   ];
 };
+
+export const createTypedInvalidTestCase = (
+  test: RuleTester.InvalidTestCase,
+  replaceCode: (code: string) => string,
+  replaceOutput: (output: string) => string
+): RuleTester.InvalidTestCase => ({
+  ...test,
+  filename: `typed-${basename(test.filename!)}.ts`,
+  code: replaceCode(test.code),
+  output: replaceOutput(test.output!),
+});

--- a/packages/eslint-plugin/src/test-utils.ts
+++ b/packages/eslint-plugin/src/test-utils.ts
@@ -27,7 +27,10 @@ const baseTesterConfig = {
 
 export const tester = new RuleTester(baseTesterConfig);
 
-export const typeScriptTester = new RuleTester({ ...baseTesterConfig, parser: require.resolve('@typescript-eslint/parser')});
+export const typeScriptTester = new RuleTester({
+  ...baseTesterConfig,
+  parser: require.resolve('@typescript-eslint/parser'),
+});
 
 export const createAliasedInvalidTestCase = (
   test: RuleTester.InvalidTestCase,

--- a/packages/eslint-plugin/src/utils/create-no-tagged-template-expression-rule/index.ts
+++ b/packages/eslint-plugin/src/utils/create-no-tagged-template-expression-rule/index.ts
@@ -47,18 +47,16 @@ export const createNoTaggedTemplateExpressionRule =
           // becomes
           // styled.div<Props>
           const withoutQuasi = oldCode.replace(source.getText(quasi), '');
-          const newCode = withoutQuasi + 
+          const newCode =
+            withoutQuasi +
             // Indent the arguments after the tagged template expression range
-            generate(toArguments(source, quasi), getTaggedTemplateExpressionOffset(node))
+            generate(toArguments(source, quasi), getTaggedTemplateExpressionOffset(node));
 
           if (oldCode === newCode) {
             return;
           }
 
-          yield fixer.insertTextBefore(
-            node,
-            newCode
-          );
+          yield fixer.insertTextBefore(node, newCode);
           yield fixer.remove(node);
         },
       });

--- a/packages/eslint-plugin/src/utils/create-no-tagged-template-expression-rule/index.ts
+++ b/packages/eslint-plugin/src/utils/create-no-tagged-template-expression-rule/index.ts
@@ -25,7 +25,7 @@ export const createNoTaggedTemplateExpressionRule =
         messageId,
         node,
         *fix(fixer: RuleFixer) {
-          const { quasi, tag } = node;
+          const { quasi } = node;
           const source = context.getSourceCode();
 
           // TODO Eventually handle comments instead of skipping them
@@ -39,11 +39,25 @@ export const createNoTaggedTemplateExpressionRule =
             return;
           }
 
+          const oldCode = source.getText(node);
+          // Remove quasi:
+          // styled.div<Props>`
+          //    color: red;
+          // `
+          // becomes
+          // styled.div<Props>
+          const withoutQuasi = oldCode.replace(source.getText(quasi), '');
+          const newCode = withoutQuasi + 
+            // Indent the arguments after the tagged template expression range
+            generate(toArguments(source, quasi), getTaggedTemplateExpressionOffset(node))
+
+          if (oldCode === newCode) {
+            return;
+          }
+
           yield fixer.insertTextBefore(
             node,
-            source.getText(tag) +
-              // Indent the arguments after the tagged template expression range
-              generate(toArguments(source, quasi), getTaggedTemplateExpressionOffset(node))
+            newCode
           );
           yield fixer.remove(node);
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4319,7 +4319,7 @@
 
 "@typescript-eslint/parser@^5.43.0":
   version "5.43.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/parser/-/parser-5.43.0.tgz#9c86581234b88f2ba406f0b99a274a91c11630fd"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.43.0.tgz#9c86581234b88f2ba406f0b99a274a91c11630fd"
   integrity sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==
   dependencies:
     "@typescript-eslint/scope-manager" "5.43.0"
@@ -4337,7 +4337,7 @@
 
 "@typescript-eslint/scope-manager@5.43.0":
   version "5.43.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz#566e46303392014d5d163704724872e1f2dd3c15"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz#566e46303392014d5d163704724872e1f2dd3c15"
   integrity sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==
   dependencies:
     "@typescript-eslint/types" "5.43.0"
@@ -4350,7 +4350,7 @@
 
 "@typescript-eslint/types@5.43.0":
   version "5.43.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/types/-/types-5.43.0.tgz#e4ddd7846fcbc074325293515fa98e844d8d2578"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.43.0.tgz#e4ddd7846fcbc074325293515fa98e844d8d2578"
   integrity sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==
 
 "@typescript-eslint/typescript-estree@4.33.0":
@@ -4368,7 +4368,7 @@
 
 "@typescript-eslint/typescript-estree@5.43.0":
   version "5.43.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz#b6883e58ba236a602c334be116bfc00b58b3b9f2"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz#b6883e58ba236a602c334be116bfc00b58b3b9f2"
   integrity sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==
   dependencies:
     "@typescript-eslint/types" "5.43.0"
@@ -4389,7 +4389,7 @@
 
 "@typescript-eslint/visitor-keys@5.43.0":
   version "5.43.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz#cbbdadfdfea385310a20a962afda728ea106befa"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz#cbbdadfdfea385310a20a962afda728ea106befa"
   integrity sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==
   dependencies:
     "@typescript-eslint/types" "5.43.0"
@@ -7268,7 +7268,7 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.7:
 
 debug@^4.3.4:
   version "4.3.4"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
@@ -8097,7 +8097,7 @@ eslint-visitor-keys@^2.0.0:
 
 eslint-visitor-keys@^3.3.0:
   version "3.3.0"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^7.32.0:
@@ -11468,7 +11468,7 @@ loader-utils@^2.0.0:
 
 loader-utils@^2.0.3:
   version "2.0.4"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
   integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
@@ -15099,7 +15099,7 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
 
 semver@^7.3.7:
   version "7.3.8"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4317,6 +4317,16 @@
     "@typescript-eslint/typescript-estree" "4.33.0"
     debug "^4.3.1"
 
+"@typescript-eslint/parser@^5.43.0":
+  version "5.43.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/parser/-/parser-5.43.0.tgz#9c86581234b88f2ba406f0b99a274a91c11630fd"
+  integrity sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.43.0"
+    "@typescript-eslint/types" "5.43.0"
+    "@typescript-eslint/typescript-estree" "5.43.0"
+    debug "^4.3.4"
+
 "@typescript-eslint/scope-manager@4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz#d38e49280d983e8772e29121cf8c6e9221f280a3"
@@ -4325,10 +4335,23 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
+"@typescript-eslint/scope-manager@5.43.0":
+  version "5.43.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz#566e46303392014d5d163704724872e1f2dd3c15"
+  integrity sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==
+  dependencies:
+    "@typescript-eslint/types" "5.43.0"
+    "@typescript-eslint/visitor-keys" "5.43.0"
+
 "@typescript-eslint/types@4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
+
+"@typescript-eslint/types@5.43.0":
+  version "5.43.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/types/-/types-5.43.0.tgz#e4ddd7846fcbc074325293515fa98e844d8d2578"
+  integrity sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==
 
 "@typescript-eslint/typescript-estree@4.33.0":
   version "4.33.0"
@@ -4343,6 +4366,19 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.43.0":
+  version "5.43.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz#b6883e58ba236a602c334be116bfc00b58b3b9f2"
+  integrity sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==
+  dependencies:
+    "@typescript-eslint/types" "5.43.0"
+    "@typescript-eslint/visitor-keys" "5.43.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/visitor-keys@4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz#2a22f77a41604289b7a186586e9ec48ca92ef1dd"
@@ -4350,6 +4386,14 @@
   dependencies:
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.43.0":
+  version "5.43.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz#cbbdadfdfea385310a20a962afda728ea106befa"
+  integrity sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==
+  dependencies:
+    "@typescript-eslint/types" "5.43.0"
+    eslint-visitor-keys "^3.3.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
@@ -7222,6 +7266,13 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
+
 decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -8043,6 +8094,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint-visitor-keys@^3.3.0:
+  version "3.3.0"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz#f6480fa6b1f30efe2d1968aa8ac745b862469826"
+  integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^7.32.0:
   version "7.32.0"
@@ -11401,10 +11457,19 @@ loader-utils@^1.1.0, loader-utils@^1.2.3:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^2.0.0, loader-utils@^2.0.2:
+loader-utils@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.2.tgz#d6e3b4fb81870721ae4e0868ab11dd638368c129"
   integrity sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^2.1.2"
+
+loader-utils@^2.0.3:
+  version "2.0.4"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
@@ -15031,6 +15096,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.7:
+  version "7.3.8"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.18.0:
   version "0.18.0"


### PR DESCRIPTION
This fixed the issue: `no-styled-tagged-template-expression` ESLint rule  strips out type.

Example:
```
const Foo = styled2.div<{ color: string }>`
    box-shadow: 0 0 0 2px ${({ color }) => color} inset;
`;
```
Becomes:
```
const Foo = styled2.div({
    boxShadow: `0 0 0 2px ${({ color }) => color} inset`,
});
```