### PR TITLE
Use 0% as default value for flex-basis

### DIFF
--- a/.changeset/pink-badgers-refuse.md
+++ b/.changeset/pink-badgers-refuse.md
@@ -1,0 +1,5 @@
+---
+'@compiled/css': patch
+---
+
+Default flex-basis to 0% when expanding flex

--- a/packages/css/src/__tests__/transform.test.ts
+++ b/packages/css/src/__tests__/transform.test.ts
@@ -310,7 +310,7 @@ describe('#css-transform', () => {
     `);
 
     expect(actual.sheets.join('')).toMatchInlineSnapshot(
-      `"._16jlkb7n{flex-grow:1}._1o9zkb7n{flex-shrink:1}._i0dlidpf{flex-basis:0}"`
+      `"._16jlkb7n{flex-grow:1}._1o9zkb7n{flex-shrink:1}._i0dlf1ug{flex-basis:0%}"`
     );
   });
 

--- a/packages/css/src/plugins/expand-shorthands/__tests__/flex.test.ts
+++ b/packages/css/src/plugins/expand-shorthands/__tests__/flex.test.ts
@@ -11,156 +11,178 @@ const transform = (css: TemplateStringsArray) => {
 };
 
 describe('flex property expander', () => {
-  it('should expand flex none', () => {
-    const result = transform`
-      flex: none;
-    `;
+  describe('has one parameter', () => {
+    it('should expand flex none', () => {
+      const result = transform`
+        flex: none;
+      `;
 
-    expect(result).toMatchInlineSnapshot(`
-      "
-            flex-grow: 0;
-            flex-shrink: 0;
-            flex-basis: auto;
-          "
-    `);
+      expect(result).toMatchInlineSnapshot(`
+        "
+              flex-grow: 0;
+              flex-shrink: 0;
+              flex-basis: auto;
+            "
+      `);
+    });
+
+    it('should expand flex single', () => {
+      const result = transform`
+        flex: 2;
+      `;
+
+      expect(result).toMatchInlineSnapshot(`
+        "
+              flex-grow: 2;
+              flex-shrink: 1;
+              flex-basis: 0%;
+            "
+      `);
+    });
+
+    it('should expand flex auto', () => {
+      const result = transform`
+        flex: auto;
+      `;
+
+      expect(result).toMatchInlineSnapshot(`
+        "
+              flex-grow: 1;
+              flex-shrink: 1;
+              flex-basis: auto;
+            "
+      `);
+    });
   });
 
-  it('should expand flex single', () => {
-    const result = transform`
-      flex: 2;
-    `;
+  describe('has two parameters', () => {
+    it('should expand flex double shrink', () => {
+      const result = transform`
+        flex: 3 2;
+      `;
 
-    expect(result).toMatchInlineSnapshot(`
-      "
-            flex-grow: 2;
-            flex-shrink: 1;
-            flex-basis: 0;
-          "
-    `);
+      expect(result).toMatchInlineSnapshot(`
+        "
+              flex-grow: 3;
+              flex-shrink: 2;
+              flex-basis: 0%;
+            "
+      `);
+    });
+
+    it('should expand flex double basis', () => {
+      const result = transform`
+        flex: 3 20%;
+      `;
+
+      expect(result).toMatchInlineSnapshot(`
+        "
+              flex-grow: 3;
+              flex-shrink: 1;
+              flex-basis: 20%;
+            "
+      `);
+    });
   });
 
-  it('should expand flex double shrink', () => {
-    const result = transform`
-      flex: 3 2;
-    `;
-
-    expect(result).toMatchInlineSnapshot(`
-      "
-            flex-grow: 3;
-            flex-shrink: 2;
-            flex-basis: 0;
-          "
-    `);
-  });
-
-  it('should expand flex double basis', () => {
-    const result = transform`
-      flex: 3 20%;
-    `;
-
-    expect(result).toMatchInlineSnapshot(`
-      "
-            flex-grow: 3;
-            flex-shrink: 1;
-            flex-basis: 20%;
-          "
-    `);
-  });
-
-  it('should expand flex triple', () => {
-    const result = transform`
+  describe('has three parameters', () => {
+    it('should expand flex triple', () => {
+      const result = transform`
       flex: 3 2 20%;
     `;
 
-    expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
       "
             flex-grow: 3;
             flex-shrink: 2;
             flex-basis: 20%;
           "
     `);
-  });
+    });
 
-  it('should expand flex auto', () => {
-    const result = transform`
+    it('should expand flex auto', () => {
+      const result = transform`
       flex: 3 2 auto;
     `;
 
-    expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
       "
             flex-grow: 3;
             flex-shrink: 2;
             flex-basis: auto;
           "
     `);
-  });
+    });
 
-  it('should expand flex function call', () => {
-    const result = transform`
+    it('should expand flex function call', () => {
+      const result = transform`
       flex: 3 2 calc(50px + 50px);
     `;
 
-    expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
       "
             flex-grow: 3;
             flex-shrink: 2;
             flex-basis: calc(50px + 50px);
           "
     `);
+    });
   });
 
-  it('should remove decls for invalid single', () => {
-    const result = transform`
+  describe('is invalid', () => {
+    it('should remove decls for invalid single', () => {
+      const result = transform`
       flex: asd;
     `;
 
-    expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
       "
           "
     `);
-  });
+    });
 
-  it('should remove decls for invalid double', () => {
-    const result = transform`
+    it('should remove decls for invalid double', () => {
+      const result = transform`
       flex: 1 asd;
     `;
 
-    expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
       "
           "
     `);
-  });
+    });
 
-  it('should remove decls for invalid triple', () => {
-    const result = transform`
+    it('should remove decls for invalid triple', () => {
+      const result = transform`
       flex: 1 1 asdasd;
     `;
 
-    expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
       "
           "
     `);
-  });
+    });
 
-  it('should remove decls for invalid triple again', () => {
-    const result = transform`
+    it('should remove decls for invalid triple again', () => {
+      const result = transform`
       flex: 1 asdasd auto;
     `;
 
-    expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
       "
           "
     `);
-  });
+    });
 
-  it('should remove invalid usage of triple', () => {
-    const result = transform`
+    it('should remove invalid usage of triple', () => {
+      const result = transform`
       flex: 1 1 1;
     `;
 
-    expect(result).toMatchInlineSnapshot(`
+      expect(result).toMatchInlineSnapshot(`
           "
               "
       `);
+    });
   });
 });

--- a/packages/css/src/plugins/expand-shorthands/__tests__/flex.test.ts
+++ b/packages/css/src/plugins/expand-shorthands/__tests__/flex.test.ts
@@ -19,10 +19,10 @@ describe('flex property expander', () => {
 
       expect(result).toMatchInlineSnapshot(`
         "
-              flex-grow: 0;
-              flex-shrink: 0;
-              flex-basis: auto;
-            "
+                flex-grow: 0;
+                flex-shrink: 0;
+                flex-basis: auto;
+              "
       `);
     });
 
@@ -33,10 +33,10 @@ describe('flex property expander', () => {
 
       expect(result).toMatchInlineSnapshot(`
         "
-              flex-grow: 2;
-              flex-shrink: 1;
-              flex-basis: 0%;
-            "
+                flex-grow: 2;
+                flex-shrink: 1;
+                flex-basis: 0%;
+              "
       `);
     });
 
@@ -47,10 +47,10 @@ describe('flex property expander', () => {
 
       expect(result).toMatchInlineSnapshot(`
         "
-              flex-grow: 1;
-              flex-shrink: 1;
-              flex-basis: auto;
-            "
+                flex-grow: 1;
+                flex-shrink: 1;
+                flex-basis: auto;
+              "
       `);
     });
   });
@@ -63,10 +63,10 @@ describe('flex property expander', () => {
 
       expect(result).toMatchInlineSnapshot(`
         "
-              flex-grow: 3;
-              flex-shrink: 2;
-              flex-basis: 0%;
-            "
+                flex-grow: 3;
+                flex-shrink: 2;
+                flex-basis: 0%;
+              "
       `);
     });
 
@@ -77,10 +77,10 @@ describe('flex property expander', () => {
 
       expect(result).toMatchInlineSnapshot(`
         "
-              flex-grow: 3;
-              flex-shrink: 1;
-              flex-basis: 20%;
-            "
+                flex-grow: 3;
+                flex-shrink: 1;
+                flex-basis: 20%;
+              "
       `);
     });
   });
@@ -92,12 +92,12 @@ describe('flex property expander', () => {
     `;
 
       expect(result).toMatchInlineSnapshot(`
-      "
-            flex-grow: 3;
-            flex-shrink: 2;
-            flex-basis: 20%;
-          "
-    `);
+              "
+                    flex-grow: 3;
+                    flex-shrink: 2;
+                    flex-basis: 20%;
+                  "
+          `);
     });
 
     it('should expand flex auto', () => {
@@ -106,12 +106,12 @@ describe('flex property expander', () => {
     `;
 
       expect(result).toMatchInlineSnapshot(`
-      "
-            flex-grow: 3;
-            flex-shrink: 2;
-            flex-basis: auto;
-          "
-    `);
+              "
+                    flex-grow: 3;
+                    flex-shrink: 2;
+                    flex-basis: auto;
+                  "
+          `);
     });
 
     it('should expand flex function call', () => {
@@ -120,12 +120,12 @@ describe('flex property expander', () => {
     `;
 
       expect(result).toMatchInlineSnapshot(`
-      "
-            flex-grow: 3;
-            flex-shrink: 2;
-            flex-basis: calc(50px + 50px);
-          "
-    `);
+              "
+                    flex-grow: 3;
+                    flex-shrink: 2;
+                    flex-basis: calc(50px + 50px);
+                  "
+          `);
     });
   });
 
@@ -136,9 +136,9 @@ describe('flex property expander', () => {
     `;
 
       expect(result).toMatchInlineSnapshot(`
-      "
-          "
-    `);
+              "
+                  "
+          `);
     });
 
     it('should remove decls for invalid double', () => {
@@ -147,9 +147,9 @@ describe('flex property expander', () => {
     `;
 
       expect(result).toMatchInlineSnapshot(`
-      "
-          "
-    `);
+              "
+                  "
+          `);
     });
 
     it('should remove decls for invalid triple', () => {
@@ -158,9 +158,9 @@ describe('flex property expander', () => {
     `;
 
       expect(result).toMatchInlineSnapshot(`
-      "
-          "
-    `);
+              "
+                  "
+          `);
     });
 
     it('should remove decls for invalid triple again', () => {
@@ -169,9 +169,9 @@ describe('flex property expander', () => {
     `;
 
       expect(result).toMatchInlineSnapshot(`
-      "
-          "
-    `);
+              "
+                  "
+          `);
     });
 
     it('should remove invalid usage of triple', () => {

--- a/packages/css/src/plugins/expand-shorthands/flex.ts
+++ b/packages/css/src/plugins/expand-shorthands/flex.ts
@@ -7,6 +7,11 @@ const isFlexNumber = (node: ChildNode): node is Numeric => node.type === 'numeri
 const isFlexBasis = (node: ChildNode): node is Numeric | Word | Func =>
   (node.type === 'word' && node.value === 'content') || isWidth(node);
 
+// According to the spec, the default value of flex-basis is 0.
+// However, '0%' is used by major browsers due to compatibility issues
+// https://github.com/w3c/csswg-drafts/issues/5742
+const flexBasisDefaultValue = '0%';
+
 /**
  * https://drafts.csswg.org/css-flexbox-1/#flex-property
  */
@@ -27,7 +32,7 @@ export const flex: ConversionFunction = (value) => {
         return [
           { prop: 'flex-grow', value: left.value },
           { prop: 'flex-shrink', value: 1 },
-          { prop: 'flex-basis', value: 0 },
+          { prop: 'flex-basis', value: flexBasisDefaultValue },
         ];
       } else if (isFlexBasis(left)) {
         // flex basis
@@ -47,7 +52,7 @@ export const flex: ConversionFunction = (value) => {
           return [
             { prop: 'flex-grow', value: left.value },
             { prop: 'flex-shrink', value: middle.value },
-            { prop: 'flex-basis', value: 0 },
+            { prop: 'flex-basis', value: flexBasisDefaultValue },
           ];
         } else if (isFlexBasis(middle)) {
           // flex grow and flex basis


### PR DESCRIPTION
When expanding flex, 0% is used as default value for flex-basis by browsers. Although this is not what the Spec says, we'd have to make it compatible with the browser behavior.