### PR TITLE
[ESLint] Selector disappears when autofixing no-*-tagged-template-exp…

### DIFF
--- a/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/__tests__/rule.test.ts
@@ -1051,5 +1051,68 @@ tester.run('no-styled-tagged-template-expression', noStyledTaggedTemplateExpress
         \`;
       `,
     },
+    {
+      filename: 'single-variable-as-selector.ts',
+      code: `
+        import { styled } from '@compiled/react';
+
+        styled.div\`
+          \${Variable_Name} {
+            color: blue;
+          }
+        \`;
+      `,
+      output: `
+        import { styled } from '@compiled/react';
+
+        styled.div({
+          [\`\${Variable_Name}\`]: {
+            color: "blue"
+          }
+        });
+      `,
+    },
+    {
+      filename: 'multiple-variables-as-selector.ts',
+      code: `
+        import { styled } from '@compiled/react';
+
+        styled.div\`
+          \${Variable_Name_1} \${Variable_Name_2} {
+            color: blue;
+          }
+        \`;
+      `,
+      output: `
+        import { styled } from '@compiled/react';
+
+        styled.div({
+          [\`\${Variable_Name_1} \${Variable_Name_2}\`]: {
+            color: "blue"
+          }
+        });
+      `,
+    },
+    {
+      filename: 'variables-as-selector-have-surrounding-text.ts',
+      code: `
+        import { styled } from '@compiled/react';
+
+        styled.div\`
+          .foo \${Variable_Name_1} .bar \${Variable_Name_2} & {
+            color: blue;
+          }
+        \`;
+      `,
+      output: `
+        import { styled } from '@compiled/react';
+
+        styled.div({
+          [\`.foo \${Variable_Name_1} .bar \${Variable_Name_2} &\`]: {
+            color: "blue"
+          }
+        });
+      `,
+    },
   ]),
 });

--- a/packages/eslint-plugin/src/utils/create-no-tagged-template-expression-rule/generate.ts
+++ b/packages/eslint-plugin/src/utils/create-no-tagged-template-expression-rule/generate.ts
@@ -5,6 +5,11 @@ const createKey = (key: string) => {
     return key;
   }
 
+  // Wrap the key in square brickets if the key includes variable. i.e.`.foo ${VARIABLE_NAME} .bar`
+  if (key.charAt(0) === '`' && key.charAt(key.length - 1) === '`') {
+    return `[${key}]`;
+  }
+
   // Wrap the key in quotes if it uses unsafe characters
   if (!key.includes('"')) {
     return `"${key}"`;


### PR DESCRIPTION
The PR fixes the below scenario:

i.e.

```
const EditWrapper = styled.div`
    ${foo} {
        opacity: 0;
    }
`;
```

gets auto-fixed to

```
const EditWrapper = styled.div({
  "": {
    opacity: 0
  }
});
```