### PR TITLE
Bug/fix Webpack plugin extraction error

### DIFF
--- a/.changeset/tidy-numbers-do.md
+++ b/.changeset/tidy-numbers-do.md
@@ -1,0 +1,5 @@
+---
+'@compiled/webpack-loader': patch
+---
+
+Fix error when using @compiled/webpack-loader via a path and with extraction enabled

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "clean:parcel-cache": "rm -rf .parcel-cache/",
     "clean:ts-cache": "find . -name \"*.tsbuildinfo\" -type f -delete",
     "flow-types": "scripts/flow-types.sh",
-    "postinstall": "npx yarn-deduplicate && yarn --ignore-scripts",
+    "postinstall": "scripts/postinstall.sh",
     "lint": "eslint --config .eslintrc.js --ext js,json,jsx,ts,tsx .",
     "lint:fix": "yarn lint -- --fix",
     "prettier:check": "prettier ./ --check",

--- a/packages/webpack-loader/src/__tests__/extract-plugin.test.ts
+++ b/packages/webpack-loader/src/__tests__/extract-plugin.test.ts
@@ -32,6 +32,14 @@ describe('CompiledExtractPlugin', () => {
     ]);
   }, 10000);
 
+  it('works when the loader is configured with a path instead of a package name', async () => {
+    const result = await bundle(join(fixturesPath, 'local-styles.tsx'), {
+      requireResolveLoaderSyntax: true,
+    });
+
+    expect(result).toBeDefined();
+  }, 10000);
+
   it('should not generate a single style sheet if cacheGroup is disabled', async () => {
     const actual = await bundle(join(fixturesPath, 'local-styles.tsx'), {
       disableCacheGroup: true,

--- a/packages/webpack-loader/src/__tests__/test-utils.ts
+++ b/packages/webpack-loader/src/__tests__/test-utils.ts
@@ -7,9 +7,12 @@ import webpack from 'webpack';
 import { CompiledExtractPlugin } from '../index';
 import type { ResolveOptions } from '../index';
 
+const nodeModulesPath = join(__dirname, '..', '..', '..', '..', 'node_modules');
+
 export interface BundleOptions {
   extract?: boolean;
   disableExtractPlugin?: boolean;
+  requireResolveLoaderSyntax?: boolean;
   disableCacheGroup?: boolean;
   mode: 'development' | 'production';
   resolve?: ResolveOptions;
@@ -20,6 +23,7 @@ export function bundle(
   {
     extract = false,
     disableExtractPlugin = false,
+    requireResolveLoaderSyntax = false,
     disableCacheGroup = false,
     mode,
     resolve = {},
@@ -44,7 +48,9 @@ export function bundle(
               },
             },
             {
-              loader: '@compiled/webpack-loader',
+              loader: requireResolveLoaderSyntax
+                ? join(nodeModulesPath, '@compiled', 'webpack-loader')
+                : '@compiled/webpack-loader',
               options: {
                 extract,
                 importReact: false,

--- a/packages/webpack-loader/src/utils.ts
+++ b/packages/webpack-loader/src/utils.ts
@@ -12,7 +12,11 @@ const setOptionOnCompiledWebpackLoader = (use: RuleSetRule['use'], pluginName: s
   }
 
   for (const nestedUse of use) {
-    if (typeof nestedUse === 'object' && nestedUse.loader === '@compiled/webpack-loader') {
+    if (
+      typeof nestedUse === 'object' &&
+      (nestedUse.loader === '@compiled/webpack-loader' ||
+        nestedUse.loader?.includes('/node_modules/@compiled/webpack-loader'))
+    ) {
       const { options } = nestedUse;
       if (options !== undefined && typeof options === 'object' && options.extract !== undefined) {
         options[pluginName] = true;

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+cleanup() {
+  trap - SIGINT SIGTERM ERR EXIT
+
+  rm -f yarn.lock.bak
+}
+
+# Remove any atlassian mirrors
+sed -i.bak -E 's/https:\/\/packages.atlassian.com\/api\/npm\/npm-remote\//https:\/\/registry.yarnpkg.com\//g' yarn.lock
+
+# Deduplicate
+npx yarn-deduplicate
+
+# Run yarn again to transform any changes
+yarn --ignore-scripts


### PR DESCRIPTION
Fixes #1137

A simple fix for this bug as we currently only check the package name. Webpack supports absolute paths so we should check for these as well.
