### PR TITLE
Preserve unresolved imports codemod

### DIFF
--- a/.changeset/twenty-wasps-care.md
+++ b/.changeset/twenty-wasps-care.md
@@ -1,0 +1,5 @@
+---
+'@compiled/codemods': minor
+---
+
+Preserve unresolved imports in codemods instead of removing and adding a comment

--- a/packages/codemods/src/plugins/default.ts
+++ b/packages/codemods/src/plugins/default.ts
@@ -7,10 +7,14 @@ const defaultCodemodPlugin: CodemodPlugin = {
   create: (_, { jscodeshift: j }) => ({
     transform: {
       buildImport({ compiledImportPath, currentNode, specifiers }) {
+        if (specifiers.length === 0) {
+          return null;
+        }
+
         const newImport = j.importDeclaration(specifiers, j.literal(compiledImportPath));
 
         // Copy the comments from the previous import to the new one
-        newImport.comments = currentNode.comments;
+        newImport.comments = currentNode?.comments;
 
         return newImport;
       },

--- a/packages/codemods/src/plugins/types.ts
+++ b/packages/codemods/src/plugins/types.ts
@@ -24,9 +24,9 @@ export type BuildImportContext<T> = ValidateConfig<
   T,
   {
     // The original import node in the source code
-    originalNode: ImportDeclaration;
+    originalNode: ImportDeclaration | null;
     // The existing import node that will be replaced
-    currentNode: ImportDeclaration;
+    currentNode: ImportDeclaration | null;
     // The specifiers to include in the new import declaration
     specifiers: ImportSpecifier[];
     // The import path for Compiled
@@ -78,7 +78,7 @@ export interface Transform {
    * @param context {BuildImportContext} The context applied to the build import
    * @returns {ImportDeclaration} The import to replace config.currentNode
    */
-  buildImport?<T>(context: BuildImportContext<T>): ImportDeclaration;
+  buildImport?<T>(context: BuildImportContext<T>): ImportDeclaration | null;
 
   /**
    * Build the compiled import replacing the existing import

--- a/packages/codemods/src/transforms/emotion-to-compiled/README.md
+++ b/packages/codemods/src/transforms/emotion-to-compiled/README.md
@@ -61,3 +61,19 @@ const Component = (props) => (
   </>
 );
 ```
+
+## Gotchas
+
+Some imports from Emotion are unsupported in Compiled. These imports will not be migrated by the codemod and will need to be manually removed.
+
+Example:
+
+```javascript
+// Before
+import { ClassNames, CSSObject, css as c, jsx } from '@emotion/core';
+
+// After
+import { CSSObject } from '@emotion/core';
+
+import { ClassNames, css as c } from '@compiled/react';
+```

--- a/packages/codemods/src/transforms/emotion-to-compiled/__tests__/transformer.test.ts
+++ b/packages/codemods/src/transforms/emotion-to-compiled/__tests__/transformer.test.ts
@@ -395,8 +395,9 @@ describe('emotion-to-compiled transformer', () => {
     );
     `,
     `
-    /* TODO(@compiled/react codemod): "CSSObject" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
     import * as React from 'react';
+    import { CSSObject } from '@emotion/core';
+
     import { ClassNames, css as c } from '@compiled/react';
 
     let cssObject: CSSObject = {};
@@ -424,7 +425,7 @@ describe('emotion-to-compiled transformer', () => {
       </ClassNames>
     );
     `,
-    'it adds TODO comment for imports which are not resolved'
+    'it preserves imports which are not resolved'
   );
 
   defineInlineTest(
@@ -439,7 +440,10 @@ describe('emotion-to-compiled transformer', () => {
     import * as React from 'react';
     `,
     `
-    /* TODO(@compiled/react codemod): "CSSObject" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    // @top-level comment
+
+    import { CSSObject } from '@emotion/core';
+
     // @top-level comment
 
     import { ClassNames, css as c } from '@compiled/react';
@@ -462,10 +466,11 @@ describe('emotion-to-compiled transformer', () => {
     import { ClassNames, CSSObject, css as c, jsx } from '@emotion/core';
     `,
     `
-    /* TODO(@compiled/react codemod): "CSSObject" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
     // @top-level comment
 
     import * as React from 'react';
+    // comment 1
+    import { CSSObject } from '@emotion/core';
 
     // comment 1
     import { ClassNames, css as c } from '@compiled/react';

--- a/packages/codemods/src/transforms/emotion-to-compiled/index.ts
+++ b/packages/codemods/src/transforms/emotion-to-compiled/index.ts
@@ -15,7 +15,6 @@ import defaultCodemodPlugin from '../../plugins/default';
 import type { CodemodPluginInstance } from '../../plugins/types';
 import {
   addCommentBefore,
-  addCommentForUnresolvedImportSpecifiers,
   applyVisitor,
   convertDefaultImportToNamedImport,
   convertMixedImportToNamedImport,
@@ -265,12 +264,6 @@ const transformer = (fileInfo: FileInfo, api: API, options: Options): string => 
   }
 
   if (hasEmotionCoreImportDeclaration) {
-    addCommentForUnresolvedImportSpecifiers({
-      j,
-      collection,
-      importPath: imports.emotionCorePackageName,
-      allowedImportSpecifierNames: Object.values(imports.emotionCoreReactImportNames),
-    });
     replaceEmotionCoreCSSTaggedTemplateExpression(j, collection, imports.emotionCorePackageName);
     handleClassNamesBehavior(j, collection, imports.emotionCorePackageName);
     convertMixedImportToNamedImport({
@@ -284,12 +277,6 @@ const transformer = (fileInfo: FileInfo, api: API, options: Options): string => 
   }
 
   if (hasEmotionReactImportDeclaration) {
-    addCommentForUnresolvedImportSpecifiers({
-      j,
-      collection,
-      importPath: imports.emotionReactPackageName,
-      allowedImportSpecifierNames: Object.values(imports.emotionCoreReactImportNames),
-    });
     replaceEmotionCoreCSSTaggedTemplateExpression(j, collection, imports.emotionReactPackageName);
     handleClassNamesBehavior(j, collection, imports.emotionReactPackageName);
     convertMixedImportToNamedImport({

--- a/packages/codemods/src/transforms/styled-components-to-compiled/README.md
+++ b/packages/codemods/src/transforms/styled-components-to-compiled/README.md
@@ -30,11 +30,30 @@ import { styled } from '@compiled/react';
 
 ## Gotchas
 
+### Unresolved imports
+
+Some imports from styled components are unsupported in Compiled. These imports will not be migrated by the codemod and will need to be manually removed.
+
+```javascript
+// Before
+import styled, {
+  css,
+  keyframes,
+  createGlobalStyle,
+  ThemeProvider,
+  withTheme,
+} from 'styled-components';
+
+// After
+import { createGlobalStyle, ThemeProvider, withTheme } from 'styled-components';
+import { css, keyframes, styled } from '@compiled/react';
+```
+
+### Spread properties
+
 `styled.div.attrs` spread properties are not supported.
 
-_Example_
-
-```
+```javascript
 styled.div.attrs({
     style: ({ left, ...props }) => {
         left: left,

--- a/packages/codemods/src/transforms/styled-components-to-compiled/__tests__/styled-components-to-compiled-imports.test.ts
+++ b/packages/codemods/src/transforms/styled-components-to-compiled/__tests__/styled-components-to-compiled-imports.test.ts
@@ -139,28 +139,11 @@ describe('styled-components-to-compiled imports transformer', () => {
     import * as React from 'react';
     `,
     `
-    /* TODO(@compiled/react codemod): "createGlobalStyle" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
-    /* TODO(@compiled/react codemod): "ThemeProvider" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
-    /* TODO(@compiled/react codemod): "withTheme" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
+    import { createGlobalStyle, ThemeProvider, withTheme } from 'styled-components';
     import { css, keyframes, styled } from '@compiled/react';
     import * as React from 'react';
     `,
-    'it adds TODO comment for imports which are not resolved'
-  );
-
-  defineInlineTest(
-    { default: transformer, parser: 'tsx' },
-    { plugins: [] },
-    `
-    import { multiple, unsupported, imports } from 'styled-components';
-    `,
-    `
-    /* TODO(@compiled/react codemod): "multiple" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
-    /* TODO(@compiled/react codemod): "unsupported" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
-    /* TODO(@compiled/react codemod): "imports" is not exported from "@compiled/react" at the moment. Please find an alternative for it. */
-    import '@compiled/react';
-    `,
-    'it properly handles import statements with no supported imports'
+    'it leaves imports alone which are not resolved'
   );
 
   defineInlineTest(

--- a/packages/codemods/src/transforms/styled-components-to-compiled/index.ts
+++ b/packages/codemods/src/transforms/styled-components-to-compiled/index.ts
@@ -3,7 +3,6 @@ import type { API, FileInfo, Options, Program, TaggedTemplateExpression } from '
 import defaultCodemodPlugin from '../../plugins/default';
 import type { CodemodPluginInstance } from '../../plugins/types';
 import {
-  addCommentForUnresolvedImportSpecifiers,
   applyVisitor,
   convertMixedImportToNamedImport,
   hasImportDeclaration,
@@ -41,13 +40,6 @@ const transformer = (fileInfo: FileInfo, api: API, options: Options): string => 
   if (!hasStyledComponentsImportDeclaration) {
     return source;
   }
-
-  addCommentForUnresolvedImportSpecifiers({
-    j,
-    collection,
-    importPath: imports.styledComponentsPackageName,
-    allowedImportSpecifierNames: imports.styledComponentsSupportedImportNames,
-  });
 
   convertMixedImportToNamedImport({
     j,

--- a/packages/codemods/src/utils/add-comment.ts
+++ b/packages/codemods/src/utils/add-comment.ts
@@ -1,19 +1,6 @@
-import type {
-  Collection,
-  ImportDeclaration,
-  JSCodeshift,
-  Node,
-  Program,
-  Identifier,
-  JSXIdentifier,
-  TSTypeParameter,
-} from 'jscodeshift';
+import type { Collection, JSCodeshift, Program } from 'jscodeshift';
 
 import { COMPILED_IMPORT_PATH } from '../constants';
-
-import { getImportDeclarationCollection } from './import-declarations';
-
-type Identifiers = (Identifier | JSXIdentifier | TSTypeParameter)[];
 
 // not replacing newlines (which \s does)
 const spacesAndTabs = /[ \t]{2,}/g;
@@ -48,74 +35,4 @@ export const addCommentBefore = ({
 
     path.value.comments.push(j.commentBlock(content));
   });
-};
-
-const getAllImportSpecifiers = ({
-  j,
-  importDeclarationCollection,
-}: {
-  j: JSCodeshift;
-  importDeclarationCollection: Collection<ImportDeclaration>;
-}): Identifiers => {
-  const importSpecifiersImportedNodes: Identifiers = [];
-
-  importDeclarationCollection.find(j.ImportSpecifier).forEach((importSpecifierPath) => {
-    const node = importSpecifierPath.node.imported;
-
-    if (node) {
-      importSpecifiersImportedNodes.push(node);
-    }
-  });
-
-  return importSpecifiersImportedNodes;
-};
-
-const addCommentToStartOfFile = ({
-  j,
-  collection,
-  message,
-}: {
-  j: JSCodeshift;
-  collection: Collection<Node>;
-  message: string;
-}): void => {
-  addCommentBefore({
-    j,
-    collection: collection.find(j.Program),
-    message,
-  });
-};
-
-export const addCommentForUnresolvedImportSpecifiers = ({
-  j,
-  collection,
-  importPath,
-  allowedImportSpecifierNames,
-}: {
-  j: JSCodeshift;
-  collection: Collection<Node>;
-  importPath: string;
-  allowedImportSpecifierNames: string[];
-}): void => {
-  const importDeclarationCollection: Collection<ImportDeclaration> = getImportDeclarationCollection(
-    {
-      j,
-      collection,
-      importPath,
-    }
-  );
-  const importSpecifiers: Identifiers = getAllImportSpecifiers({
-    j,
-    importDeclarationCollection,
-  });
-
-  importSpecifiers
-    .filter((identifierPath) => !allowedImportSpecifierNames.includes(identifierPath.name))
-    .forEach((importSpecifierPath) => {
-      addCommentToStartOfFile({
-        j,
-        collection,
-        message: `"${importSpecifierPath.name}" is not exported from "${COMPILED_IMPORT_PATH}" at the moment. Please find an alternative for it.`,
-      });
-    });
 };

--- a/packages/codemods/src/utils/convert-to-named-import.ts
+++ b/packages/codemods/src/utils/convert-to-named-import.ts
@@ -161,6 +161,18 @@ export const convertMixedImportToNamedImport = ({
       specifiers: newSpecifiers,
     });
 
-    j(importDeclarationPath).replaceWith(newImport);
+    // Remove all moved import specifiers from the original import
+    importDeclarationPath.node.specifiers = importDeclarationPath.node.specifiers?.filter(
+      (specifier) =>
+        specifier.type !== 'ImportDefaultSpecifier' &&
+        !(
+          specifier.type === 'ImportSpecifier' &&
+          allowedImportSpecifierNames.includes(specifier?.imported?.name)
+        )
+    );
+
+    j(importDeclarationPath).insertAfter(newImport);
+
+    if (importDeclarationPath.node.specifiers?.length === 0) j(importDeclarationPath).remove();
   });
 };

--- a/packages/codemods/src/utils/convert-to-named-import.ts
+++ b/packages/codemods/src/utils/convert-to-named-import.ts
@@ -17,7 +17,7 @@ const applyBuildImport = ({
   specifiers,
 }: {
   plugins: CodemodPluginInstance[];
-  originalNode: ImportDeclaration;
+  originalNode: ImportDeclaration | null;
   specifiers: ImportSpecifier[];
 }) =>
   plugins.reduce((currentNode, plugin) => {

--- a/packages/codemods/src/utils/index.ts
+++ b/packages/codemods/src/utils/index.ts
@@ -1,4 +1,4 @@
-export { addCommentBefore, addCommentForUnresolvedImportSpecifiers } from './add-comment';
+export { addCommentBefore } from './add-comment';
 export { applyVisitor } from './apply-visitor';
 export {
   convertDefaultImportToNamedImport,


### PR DESCRIPTION
Currently, we remove unresolved imports and add a comment explaining this. There are some imports that have no replacement so it makes more sense to preserve them, which will make code mods require less manual intervention to land changes.

We could consider still adding the comment for documentation purposes but it seemed a bit noisy to me.