### PR TITLE
Preserve the original node in the codemod plugin API

### DIFF
--- a/.changeset/chatty-apes-film.md
+++ b/.changeset/chatty-apes-film.md
@@ -1,0 +1,5 @@
+---
+'@compiled/codemods': patch
+---
+
+Preserve original node in build import API for codemods

--- a/packages/codemods/src/transforms/emotion-to-compiled/__tests__/transformer.test.ts
+++ b/packages/codemods/src/transforms/emotion-to-compiled/__tests__/transformer.test.ts
@@ -396,9 +396,8 @@ describe('emotion-to-compiled transformer', () => {
     `,
     `
     import * as React from 'react';
-    import { CSSObject } from '@emotion/core';
-
     import { ClassNames, css as c } from '@compiled/react';
+    import { CSSObject } from '@emotion/core';
 
     let cssObject: CSSObject = {};
 
@@ -442,12 +441,9 @@ describe('emotion-to-compiled transformer', () => {
     `
     // @top-level comment
 
-    import { CSSObject } from '@emotion/core';
-
-    // @top-level comment
-
     import { ClassNames, css as c } from '@compiled/react';
 
+    import { CSSObject } from '@emotion/core';
     // comment 1
     import * as React from 'react';
     `,
@@ -469,11 +465,11 @@ describe('emotion-to-compiled transformer', () => {
     // @top-level comment
 
     import * as React from 'react';
-    // comment 1
-    import { CSSObject } from '@emotion/core';
 
     // comment 1
     import { ClassNames, css as c } from '@compiled/react';
+
+    import { CSSObject } from '@emotion/core';
     `,
     'it should not remove comments before transformed statement when not on top'
   );

--- a/packages/codemods/src/transforms/styled-components-to-compiled/__tests__/styled-components-to-compiled-imports.test.ts
+++ b/packages/codemods/src/transforms/styled-components-to-compiled/__tests__/styled-components-to-compiled-imports.test.ts
@@ -139,8 +139,8 @@ describe('styled-components-to-compiled imports transformer', () => {
     import * as React from 'react';
     `,
     `
-    import { createGlobalStyle, ThemeProvider, withTheme } from 'styled-components';
     import { css, keyframes, styled } from '@compiled/react';
+    import { createGlobalStyle, ThemeProvider, withTheme } from 'styled-components';
     import * as React from 'react';
     `,
     'it leaves imports alone which are not resolved'


### PR DESCRIPTION
In #1343 I introduced a fix to preserve unresolved imports from emotion and styled components. This unfortunately causes issues in practice as we don't preserve the original node correctly. This change preserves the change correctly.