### PR TITLE
Fix flex shorthand expansion when flex basis is 0

### DIFF
--- a/.changeset/chilled-rocks-kick.md
+++ b/.changeset/chilled-rocks-kick.md
@@ -1,0 +1,5 @@
+---
+'@compiled/css': patch
+---
+
+Fix flex shorthand expansion when flex basis is 0

--- a/packages/css/src/plugins/expand-shorthands/__tests__/flex.test.ts
+++ b/packages/css/src/plugins/expand-shorthands/__tests__/flex.test.ts
@@ -137,7 +137,7 @@ describe('flex property expander', () => {
               "
                     flex-grow: 1;
                     flex-shrink: 1;
-                    flex-basis: 0px;
+                    flex-basis: 0%;
                   "
           `);
     });

--- a/packages/css/src/plugins/expand-shorthands/__tests__/flex.test.ts
+++ b/packages/css/src/plugins/expand-shorthands/__tests__/flex.test.ts
@@ -127,6 +127,20 @@ describe('flex property expander', () => {
                   "
           `);
     });
+
+    it('should expand flex 0 basis', () => {
+      const result = transform`
+      flex: 1 1 0;
+    `;
+
+      expect(result).toMatchInlineSnapshot(`
+              "
+                    flex-grow: 1;
+                    flex-shrink: 1;
+                    flex-basis: 0px;
+                  "
+          `);
+    });
   });
 
   describe('is invalid', () => {

--- a/packages/css/src/plugins/expand-shorthands/flex.ts
+++ b/packages/css/src/plugins/expand-shorthands/flex.ts
@@ -1,16 +1,11 @@
 import type { ChildNode, Numeric, Word, Func } from 'postcss-values-parser';
 
 import type { ConversionFunction } from './types';
-import { getWidth, isWidth } from './utils';
+import { flexBasisDefaultValue, getWidth, isWidth } from './utils';
 
 const isFlexNumber = (node: ChildNode): node is Numeric => node.type === 'numeric' && !node.unit;
 const isFlexBasis = (node: ChildNode): node is Numeric | Word | Func =>
   (node.type === 'word' && node.value === 'content') || isWidth(node);
-
-// According to the spec, the default value of flex-basis is 0.
-// However, '0%' is used by major browsers due to compatibility issues
-// https://github.com/w3c/csswg-drafts/issues/5742
-const flexBasisDefaultValue = '0%';
 
 /**
  * https://drafts.csswg.org/css-flexbox-1/#flex-property

--- a/packages/css/src/plugins/expand-shorthands/utils.ts
+++ b/packages/css/src/plugins/expand-shorthands/utils.ts
@@ -5,11 +5,6 @@ import type { Node, Numeric, Word, Func } from 'postcss-values-parser';
  */
 export const globalValues = ['inherit', 'initial', 'unset', 'revert', 'revert-layer'];
 
-// According to the spec, the default value of flex-basis is 0.
-// However, '0%' is used by major browsers due to compatibility issues
-// https://github.com/w3c/csswg-drafts/issues/5742
-export const flexBasisDefaultValue = '0%';
-
 /**
  * Returns `true` if the node is a color,
  * else `false`.
@@ -53,12 +48,8 @@ const widthUnits = new Set([
  * @param node
  */
 export const isWidth = (node: Node): boolean => {
-  if (node.type === 'numeric') {
-    if (widthUnits.has(node.unit)) {
-      return true;
-    } else if (node.unit === '' && node.value === '0') {
-      return true;
-    }
+  if (node.type === 'numeric' && widthUnits.has(node.unit)) {
+    return true;
   }
 
   if (
@@ -83,9 +74,6 @@ export const isWidth = (node: Node): boolean => {
  */
 export const getWidth = (node: Numeric | Word | Func): string => {
   if (node.type === 'numeric') {
-    if (node.value === '0' && node.unit === '') {
-      return flexBasisDefaultValue;
-    }
     return `${node.value}${node.unit}`;
   }
 

--- a/packages/css/src/plugins/expand-shorthands/utils.ts
+++ b/packages/css/src/plugins/expand-shorthands/utils.ts
@@ -48,8 +48,12 @@ const widthUnits = new Set([
  * @param node
  */
 export const isWidth = (node: Node): boolean => {
-  if (node.type === 'numeric' && widthUnits.has(node.unit)) {
-    return true;
+  if (node.type === 'numeric') {
+    if (widthUnits.has(node.unit)) {
+      return true;
+    } else if (node.unit === '' && node.value === '0') {
+      return true;
+    }
   }
 
   if (
@@ -74,6 +78,9 @@ export const isWidth = (node: Node): boolean => {
  */
 export const getWidth = (node: Numeric | Word | Func): string => {
   if (node.type === 'numeric') {
+    if (node.value === '0' && node.unit === '') {
+      return `0px`;
+    }
     return `${node.value}${node.unit}`;
   }
 

--- a/packages/css/src/plugins/expand-shorthands/utils.ts
+++ b/packages/css/src/plugins/expand-shorthands/utils.ts
@@ -5,6 +5,11 @@ import type { Node, Numeric, Word, Func } from 'postcss-values-parser';
  */
 export const globalValues = ['inherit', 'initial', 'unset', 'revert', 'revert-layer'];
 
+// According to the spec, the default value of flex-basis is 0.
+// However, '0%' is used by major browsers due to compatibility issues
+// https://github.com/w3c/csswg-drafts/issues/5742
+export const flexBasisDefaultValue = '0%';
+
 /**
  * Returns `true` if the node is a color,
  * else `false`.
@@ -79,7 +84,7 @@ export const isWidth = (node: Node): boolean => {
 export const getWidth = (node: Numeric | Word | Func): string => {
   if (node.type === 'numeric') {
     if (node.value === '0' && node.unit === '') {
-      return `0px`;
+      return flexBasisDefaultValue;
     }
     return `${node.value}${node.unit}`;
   }


### PR DESCRIPTION
Fixes #1350

We should expand 0 flex-basis values to 0px despite it being different in the W3 spec. This is because browsers all transform to 0px so we should match that instead.