### PR TITLE
Wrap with quote instead of dropping quote on strings in eslint rule

### DIFF
--- a/.changeset/early-crabs-appear.md
+++ b/.changeset/early-crabs-appear.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Wrap strings with quotes when auto-fixing tagged template expressions in ESLint rule

--- a/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/__tests__/rule.test.ts
@@ -1176,19 +1176,19 @@ tester.run('no-styled-tagged-template-expression', noStyledTaggedTemplateExpress
       `,
     },
     {
-      filename: 'space-wrapped-by-single-quotes-as-value',
+      filename: 'single-quote-strings',
       code: `
         import { styled } from '@compiled/react';
 
         styled.div\`
-          grid-template-areas: 'a b c';
+          grid-template-areas: 'vote' 'comment';
         \`;
       `,
       output: `
         import { styled } from '@compiled/react';
 
         styled.div({
-          gridTemplateAreas: "'a b c'"
+          gridTemplateAreas: "'vote' 'comment'"
         });
       `,
     },

--- a/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/__tests__/rule.test.ts
@@ -1154,7 +1154,7 @@ tester.run('no-styled-tagged-template-expression', noStyledTaggedTemplateExpress
         import { styled } from '@compiled/react';
 
         styled.div({
-          content: " "
+          content: '" "'
         });
       `,
     },
@@ -1171,7 +1171,24 @@ tester.run('no-styled-tagged-template-expression', noStyledTaggedTemplateExpress
         import { styled } from '@compiled/react';
 
         styled.div({
-          content: ' '
+          content: "' '"
+        });
+      `,
+    },
+    {
+      filename: 'space-wrapped-by-single-quotes-as-value',
+      code: `
+        import { styled } from '@compiled/react';
+
+        styled.div\`
+          grid-template-areas: 'a b c';
+        \`;
+      `,
+      output: `
+        import { styled } from '@compiled/react';
+
+        styled.div({
+          gridTemplateAreas: "'a b c'"
         });
       `,
     },

--- a/packages/eslint-plugin/src/utils/create-no-tagged-template-expression-rule/generate.ts
+++ b/packages/eslint-plugin/src/utils/create-no-tagged-template-expression-rule/generate.ts
@@ -18,6 +18,9 @@ const createKey = (key: string) => {
   return `[\`${key}\`]`;
 };
 
+const addQuotes = (literal: string): string =>
+  literal[0] === `"` ? `'${literal}'` : `"${literal}"`;
+
 const createValue = (value: DeclarationValue) => {
   const { type } = value;
   if (type === 'expression') {
@@ -25,9 +28,7 @@ const createValue = (value: DeclarationValue) => {
   }
 
   const literal = value.value;
-  return typeof literal === 'string' && !['`', '"', "'"].includes(literal[0])
-    ? '"' + literal + '"'
-    : literal;
+  return typeof literal === 'string' && literal[0] !== '`' ? addQuotes(literal) : literal;
 };
 
 const indent = (offset: number, level: number) => ' '.repeat(offset + level * 2);


### PR DESCRIPTION
When auto-fixing template strings into object syntax, we drop quotes if we see any. This usually works for css properties like `content` but breaks if we need to preserve the quotes, for example: `gridTemplateAreas`.