### PR TITLE
Remove `ax` from runtime 

### DIFF
--- a/packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-source-code.test.ts
+++ b/packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-source-code.test.ts
@@ -90,7 +90,7 @@ describe('babel-plugin-strip-runtime using source code', () => {
 
           const Component = () =>
             /*#__PURE__*/ _jsx('div', {
-              className: ax(['_1wyb1fwx _syaz13q2']),
+              className: '_1wyb1fwx _syaz13q2',
               children: 'hello world',
             });
           "
@@ -153,7 +153,7 @@ describe('babel-plugin-strip-runtime using source code', () => {
             /*#__PURE__*/ React.createElement(
               'div',
               {
-                className: ax(['_1wyb1fwx _syaz13q2']),
+                className: '_1wyb1fwx _syaz13q2',
               },
               'hello world'
             );
@@ -219,7 +219,7 @@ describe('babel-plugin-strip-runtime using source code', () => {
 
           const Component = () =>
             _jsx('div', {
-              className: ax(['_1wyb1fwx _syaz13q2']),
+              className: '_1wyb1fwx _syaz13q2',
               children: 'hello world',
             });
           "
@@ -285,7 +285,7 @@ describe('babel-plugin-strip-runtime using source code', () => {
             /*#__PURE__*/ React.createElement(
               'div',
               {
-                className: ax(['_1wyb1fwx _syaz13q2']),
+                className: '_1wyb1fwx _syaz13q2',
               },
               'hello world'
             );

--- a/packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-transpiled-code.test.ts
+++ b/packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-transpiled-code.test.ts
@@ -97,7 +97,7 @@ describe('babel-plugin-strip-runtime using transpiled code', () => {
       expect(actual.split('var Component = ')[1]).toMatchInlineSnapshot(`
         "() =>
           (0, _jsxRuntime.jsx)('div', {
-            className: (0, _runtime.ax)(['_1wyb1fwx _syaz13q2']),
+            className: '_1wyb1fwx _syaz13q2',
             children: 'hello world',
           });
         "
@@ -116,7 +116,7 @@ describe('babel-plugin-strip-runtime using transpiled code', () => {
 
         var Component = () =>
           _jsx('div', {
-            className: ax(['_1wyb1fwx _syaz13q2']),
+            className: '_1wyb1fwx _syaz13q2',
             children: 'hello world',
           });
         "
@@ -154,7 +154,7 @@ describe('babel-plugin-strip-runtime using transpiled code', () => {
           React.createElement(
             'div',
             {
-              className: (0, _runtime.ax)(['_1wyb1fwx _syaz13q2']),
+              className: '_1wyb1fwx _syaz13q2',
             },
             'hello world'
           );
@@ -174,7 +174,7 @@ describe('babel-plugin-strip-runtime using transpiled code', () => {
           React.createElement(
             'div',
             {
-              className: ax(['_1wyb1fwx _syaz13q2']),
+              className: '_1wyb1fwx _syaz13q2',
             },
             'hello world'
           );

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -29,6 +29,7 @@
     "@babel/traverse": "^7.17.10",
     "@babel/types": "^7.17.10",
     "@compiled/css": "^0.8.6",
+    "@compiled/react": "^0.11.2",
     "@compiled/utils": "^0.6.16",
     "@emotion/is-prop-valid": "^1.2.0",
     "resolve": "^1.22.0"

--- a/packages/babel-plugin/src/__tests__/css-builder.test.ts
+++ b/packages/babel-plugin/src/__tests__/css-builder.test.ts
@@ -40,7 +40,7 @@ describe('css builder', () => {
         <CS>{[_, _2]}</CS>
         {
           <div
-            className={ax([\\"_bfhk8ruw _syaz1aj3\\"])}
+            className=\\"_bfhk8ruw _syaz1aj3\\"
             style={{
               \\"--_agotg1\\": ix(getBackgroundColor(customBackgroundColor)),
               \\"--_1ylxx6h\\": ix(color),

--- a/packages/babel-plugin/src/__tests__/expression-evaluation.test.ts
+++ b/packages/babel-plugin/src/__tests__/expression-evaluation.test.ts
@@ -356,7 +356,7 @@ describe('import specifiers', () => {
 
     expect(actual).toIncludeMultiple([
       '._vwz41rme{line-height:var(--_12w6gfj)',
-      'ax(["_vwz41rme"])',
+      '"_vwz41rme"',
       '"--_12w6gfj": ix(getLineHeight())',
     ]);
   });
@@ -371,7 +371,7 @@ describe('import specifiers', () => {
         <div css={{ marginTop: spacing * 2 }} />
       `);
 
-      expect(actual).toIncludeMultiple(['._19pkexct{margin-top:16px}', 'ax(["_19pkexct"])']);
+      expect(actual).toIncludeMultiple(['._19pkexct{margin-top:16px}', '"_19pkexct"']);
     });
 
     it('statically evaluates calculated value with nested binary', () => {
@@ -383,7 +383,7 @@ describe('import specifiers', () => {
         <div css={{ marginTop: spacing * 2 / 2 }} />
       `);
 
-      expect(actual).toIncludeMultiple(['._19pkftgi{margin-top:8px}', 'ax(["_19pkftgi"])']);
+      expect(actual).toIncludeMultiple(['._19pkftgi{margin-top:8px}', '"_19pkftgi"']);
     });
 
     it('statically evaluates calculated value with multiple identifiers', () => {
@@ -397,7 +397,7 @@ describe('import specifiers', () => {
         <div css={{ marginTop: one + two - three }} />
       `);
 
-      expect(actual).toIncludeMultiple(['._19pkidpf{margin-top:0}', 'ax(["_19pkidpf"])']);
+      expect(actual).toIncludeMultiple(['._19pkidpf{margin-top:0}', '"_19pkidpf"']);
     });
 
     it('statically evaluates calculated value within calc utility', () => {
@@ -409,10 +409,7 @@ describe('import specifiers', () => {
         <div css={{ width: \`calc(100% - \${spacing * 2}px)\` }} />
       `);
 
-      expect(actual).toIncludeMultiple([
-        '._1bsbj0q6{width:calc(100% - 16px)}',
-        'ax(["_1bsbj0q6"])',
-      ]);
+      expect(actual).toIncludeMultiple(['._1bsbj0q6{width:calc(100% - 16px)}', '"_1bsbj0q6"']);
     });
 
     it('statically evaluates calculated value with string literal containing numeric value', () => {
@@ -424,7 +421,7 @@ describe('import specifiers', () => {
         <div css={{ marginTop: stringSpacing * 2 }} />
       `);
 
-      expect(actual).toIncludeMultiple(['._19pkexct{margin-top:16px}', 'ax(["_19pkexct"])']);
+      expect(actual).toIncludeMultiple(['._19pkexct{margin-top:16px}', '"_19pkexct"']);
     });
 
     it('statically evaluates calculated value with unary expression', () => {
@@ -436,7 +433,7 @@ describe('import specifiers', () => {
         <div css={{ marginTop: -getSpacing() * 2 }} />
       `);
 
-      expect(actual).toIncludeMultiple(['._19pk4h84{margin-top:-16px}', 'ax(["_19pk4h84"])']);
+      expect(actual).toIncludeMultiple(['._19pk4h84{margin-top:-16px}', '"_19pk4h84"']);
     });
 
     it('falls back to dynamic evaluation when non static value used', () => {
@@ -451,7 +448,7 @@ describe('import specifiers', () => {
       expect(actual).toIncludeMultiple([
         '._19pk19vg{margin-top:var(--_lb6tu)}',
         '"--_lb6tu": ix(getSpacing() * 2)',
-        'ax(["_19pk19vg"])',
+        '"_19pk19vg"',
       ]);
     });
 
@@ -469,7 +466,7 @@ describe('import specifiers', () => {
         }
       );
 
-      expect(actual).toIncludeMultiple(['._syaz5scu{color:red}', 'ax(["_syaz5scu"])']);
+      expect(actual).toIncludeMultiple(['._syaz5scu{color:red}', '"_syaz5scu"']);
     });
 
     it('statically evaluates a TS const expression in a resolved binding', () => {

--- a/packages/babel-plugin/src/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/__tests__/index.test.ts
@@ -107,7 +107,7 @@ describe('babel plugin', () => {
         return (
           <CC>
             <CS>{[_]}</CS>
-            {<div className={ax([\\"_1wyb1fwx\\"])}>hello</div>}
+            {<div className=\\"_1wyb1fwx\\">hello</div>}
           </CC>
         );
       };
@@ -139,7 +139,7 @@ describe('babel plugin', () => {
         return (
           <CC>
             <CS>{[_]}</CS>
-            {<div className={ax([\\"_1wyb1fwx\\"])}>hello</div>}
+            {<div className=\\"_1wyb1fwx\\">hello</div>}
           </CC>
         );
       };
@@ -187,7 +187,7 @@ describe('babel plugin', () => {
       <CompiledRoot>
         <CC>
           <CS>{[_]}</CS>
-          {<div className={ax([\\"_1e0c1ule\\"])} />}
+          {<div className=\\"_1e0c1ule\\" />}
         </CC>
       </CompiledRoot>;
       "

--- a/packages/babel-plugin/src/__tests__/jsx-automatic.test.ts
+++ b/packages/babel-plugin/src/__tests__/jsx-automatic.test.ts
@@ -22,7 +22,7 @@ describe('jsx automatic', () => {
             children: [_],
           }),
           _jsx(\\"div\\", {
-            className: ax([\\"_syaz13q2\\"]),
+            className: \\"_syaz13q2\\",
           }),
         ],
       });

--- a/packages/babel-plugin/src/__tests__/rule-hoisting.test.ts
+++ b/packages/babel-plugin/src/__tests__/rule-hoisting.test.ts
@@ -23,11 +23,11 @@ describe('rule hoisting', () => {
         <>
           <CC>
             <CS>{[_]}</CS>
-            {<div className={ax([\\"_1wyb1fwx\\"])}>hello world</div>}
+            {<div className=\\"_1wyb1fwx\\">hello world</div>}
           </CC>
           <CC>
             <CS>{[_2]}</CS>
-            {<div className={ax([\\"_1wyb1tcg\\"])}>hello world</div>}
+            {<div className=\\"_1wyb1tcg\\">hello world</div>}
           </CC>
         </>
       );
@@ -56,11 +56,11 @@ describe('rule hoisting', () => {
         <>
           <CC>
             <CS>{[_]}</CS>
-            {<div className={ax([\\"_1wyb1fwx\\"])}>hello world</div>}
+            {<div className=\\"_1wyb1fwx\\">hello world</div>}
           </CC>
           <CC>
             <CS>{[_]}</CS>
-            {<div className={ax([\\"_1wyb1fwx\\"])}>hello world</div>}
+            {<div className=\\"_1wyb1fwx\\">hello world</div>}
           </CC>
         </>
       );

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.ts
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.ts
@@ -152,7 +152,7 @@ describe('css prop behaviour', () => {
       <div css={{ fontSize: 20 }} {...props} />
     `);
 
-    expect(actual).toInclude('<div{...props}className={ax(["_1wybgktf"])}/>');
+    expect(actual).toInclude('<div{...props}className="_1wybgktf"/>');
   });
 
   it('should pass through static props', () => {
@@ -162,7 +162,7 @@ describe('css prop behaviour', () => {
       <div css={{ fontSize: 20 }} role="menu" />
     `);
 
-    expect(actual).toInclude('<div role="menu"className={ax(["_1wybgktf"])}/>');
+    expect(actual).toInclude('<div role="menu"className="_1wybgktf"/>');
   });
 
   it('should concat explicit use of class name prop from an identifier on an element', () => {
@@ -182,15 +182,15 @@ describe('css prop behaviour', () => {
       import '@compiled/react';
 
       const base = { color: 'black' };
-      const top = \` color: red; \`;
+      const top = \` marginTop: 10px; \`;
 
       <div css={[base, top]}>hello world</div>
     `);
 
     expect(actual).toIncludeMultiple([
-      '._syaz5scu{color:red}',
       '._syaz11x8{color:black}',
-      '<div className={ax(["_syaz11x8","_syaz5scu"])}>hello world</div>',
+      '._16f719bv{marginTop:10px}',
+      '<div className="_syaz11x8 _16f719bv">hello world</div>',
     ]);
   });
 
@@ -209,7 +209,7 @@ describe('css prop behaviour', () => {
       '._1wyb1fwx{font-size:12px}',
       '._syaz11x8{color:black}',
       '._1e0c1o8l{display:inline-block}',
-      '<div className={ax(["_1e0c1o8l _syaz11x8","_1wyb1fwx _1bsb12am"])}>hello world</div>',
+      '<div className="_1e0c1o8l _syaz11x8 _1wyb1fwx _1bsb12am">hello world</div>',
     ]);
   });
 
@@ -222,7 +222,7 @@ describe('css prop behaviour', () => {
 
     expect(actual).toInclude(`{color:blue}`);
     expect(actual).toInclude(
-      `<div style={{display:'block'}}className={ax([\"_syaz13q2\"])}>hello world</div>`
+      `<div style={{display:'block'}}className=\"_syaz13q2\">hello world</div>`
     );
   });
 
@@ -452,7 +452,7 @@ describe('css prop behaviour', () => {
       'const _2="._y44vk4ag{animation:fadeOut 2s ease-in-out}"',
       'const _="@keyframes fadeOut{0%{opacity:1}50%{opacity:0.5}to{opacity:0}}"',
       '<CS>{[_,_2]}</CS>',
-      'className={ax(["_y44vk4ag"])}',
+      'className="_y44vk4ag"',
     ]);
   });
 
@@ -732,5 +732,20 @@ describe('css prop behaviour', () => {
     `);
 
     expect(actual).toIncludeMultiple(["css={{color:'red'}}", 'css={null}', "css={{color:'blue'}}"]);
+  });
+
+  it('should deduplicate atomic declarations', () => {
+    const actual = transform(`
+      import '@compiled/react';
+
+      <div css={[{ fontSize: 20, color: 'red', marginTop: '20px' }, { fontSize: 30, color: 'black' }]} />
+    `);
+
+    expect(actual).toIncludeMultiple([
+      '._1wyb1ul9{font-size:30px}',
+      '._syaz11x8{color:black}',
+      '._19pkgktf{margin-top:20px}',
+      '<div className="_1wyb1ul9 _syaz11x8 _19pkgktf"/>',
+    ]);
   });
 });

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.ts
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.ts
@@ -734,7 +734,7 @@ describe('css prop behaviour', () => {
     expect(actual).toIncludeMultiple(["css={{color:'red'}}", 'css={null}', "css={{color:'blue'}}"]);
   });
 
-  it('should deduplicate atomic declarations', () => {
+  it('should ensure atomic declarations of a single group exist', () => {
     const actual = transform(`
       import '@compiled/react';
 
@@ -747,5 +747,15 @@ describe('css prop behaviour', () => {
       '._19pkgktf{margin-top:20px}',
       '<div className="_1wyb1ul9 _syaz11x8 _19pkgktf"/>',
     ]);
+  });
+
+  it('should add `ax` if `UserDefinedComponent`', () => {
+    const actual = transform(`
+      import '@compiled/react';
+
+      <Div css={{ color: 'red' }} />
+    `);
+
+    expect(actual).toInclude('ax(["_syaz5scu"])');
   });
 });

--- a/packages/babel-plugin/src/css-prop/__tests__/jsx-pragma.test.ts
+++ b/packages/babel-plugin/src/css-prop/__tests__/jsx-pragma.test.ts
@@ -13,7 +13,7 @@ describe('local jsx namespace', () => {
       const _ = \\"._syaz5scu{color:red}\\";
       <CC>
         <CS>{[_]}</CS>
-        {<div className={ax([\\"_syaz5scu\\"])}>hello</div>}
+        {<div className=\\"_syaz5scu\\">hello</div>}
       </CC>;
       "
     `);
@@ -34,7 +34,7 @@ describe('local jsx namespace', () => {
       const _ = \\"._syaz5scu{color:red}\\";
       <CC>
         <CS>{[_]}</CS>
-        {<div className={ax([\\"_syaz5scu\\"])}>hello</div>}
+        {<div className=\\"_syaz5scu\\">hello</div>}
       </CC>;
       "
     `);

--- a/packages/babel-plugin/src/keyframes/__tests__/call-expression.test.ts
+++ b/packages/babel-plugin/src/keyframes/__tests__/call-expression.test.ts
@@ -86,7 +86,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2, _3, _4]}</CS>
-              {<div className={ax([\\"_5sagymdr _j7hqb4f3 _1pgl1ytf\\"])} />}
+              {<div className=\\"_5sagymdr _j7hqb4f3 _1pgl1ytf\\" />}
             </CC>;
             "
           `);
@@ -104,7 +104,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
-              {<div className={ax([\\"_y44vjvcp\\"])} />}
+              {<div className=\\"_y44vjvcp\\" />}
             </CC>;
             "
           `);
@@ -126,7 +126,7 @@ describe('keyframes', () => {
             const darken = null;
             <CC>
               <CS>{[_, _2, _3]}</CS>
-              {<div className={ax([\\"_y44vwtez\\"])} />}
+              {<div className=\\"_y44vwtez\\" />}
             </CC>;
             "
           `);
@@ -168,7 +168,7 @@ describe('keyframes', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hq1bo5\\"])} />}
+            {<div className=\\"_j7hq1bo5\\" />}
           </CC>;
           "
         `);
@@ -198,7 +198,7 @@ describe('keyframes', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hqocb1\\"])} />}
+            {<div className=\\"_j7hqocb1\\" />}
           </CC>;
           "
         `);
@@ -240,7 +240,7 @@ describe('keyframes', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hqgafb\\"])} />}
+            {<div className=\\"_j7hqgafb\\" />}
           </CC>;
           "
         `);
@@ -297,7 +297,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
-              {<div className={ax([\\"_j7hq1kkh\\"])} />}
+              {<div className=\\"_j7hq1kkh\\" />}
             </CC>;
             "
           `);
@@ -363,7 +363,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
-              {<div className={ax([\\"_j7hq1kkh\\"])} />}
+              {<div className=\\"_j7hq1kkh\\" />}
             </CC>;
             "
           `);
@@ -400,7 +400,7 @@ describe('keyframes', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hq1rje\\"])} />}
+            {<div className=\\"_j7hq1rje\\" />}
           </CC>;
           "
         `);
@@ -446,7 +446,7 @@ describe('keyframes', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hq1bo5\\"])} />}
+            {<div className=\\"_j7hq1bo5\\" />}
           </CC>;
           "
         `);
@@ -485,7 +485,7 @@ describe('keyframes', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hqjcah\\"])} />}
+            {<div className=\\"_j7hqjcah\\" />}
           </CC>;
           "
         `);
@@ -533,7 +533,7 @@ describe('keyframes', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hqjcah\\"])} />}
+            {<div className=\\"_j7hqjcah\\" />}
           </CC>;
           "
         `);
@@ -579,7 +579,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
-              {<div className={ax([\\"_j7hqwahf\\"])} />}
+              {<div className=\\"_j7hqwahf\\" />}
             </CC>;
             "
           `);
@@ -629,7 +629,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
-              {<div className={ax([\\"_j7hqgafb\\"])} />}
+              {<div className=\\"_j7hqgafb\\" />}
             </CC>;
             "
           `);
@@ -664,7 +664,7 @@ describe('keyframes', () => {
             const enlargeFont = null;
             <CC>
               <CS>{[_, _2]}</CS>
-              {<div className={ax([\\"_j7hq1mki\\"])} />}
+              {<div className=\\"_j7hq1mki\\" />}
             </CC>;
             "
           `);
@@ -700,7 +700,7 @@ describe('keyframes', () => {
             const enlargeFont = null;
             <CC>
               <CS>{[_, _2]}</CS>
-              {<div className={ax([\\"_j7hq67nm\\"])} />}
+              {<div className=\\"_j7hq67nm\\" />}
             </CC>;
             "
           `);
@@ -740,7 +740,7 @@ describe('keyframes', () => {
               <CS>{[_, _2]}</CS>
               {
                 <div
-                  className={ax([\\"_j7hq1vu4\\"])}
+                  className=\\"_j7hq1vu4\\"
                   style={{
                     \\"--_1b1u9h2\\": ix(runtime.colors.blue),
                     \\"--_19i50d6\\": ix(getOpacity(0)),
@@ -802,7 +802,7 @@ describe('keyframes', () => {
                 <CS>{[_, _2, _3, _4]}</CS>
                 {
                   <div
-                    className={ax([\\"_j7hq1lmr _bfhk1220 _syaz115e\\"])}
+                    className=\\"_j7hq1lmr _bfhk1220 _syaz115e\\"
                     style={{
                       \\"--_113bsv7\\": ix(runtime[0].from),
                       \\"--_k85g0d\\": ix(runtime[0].to),
@@ -837,7 +837,7 @@ describe('keyframes', () => {
                   <CS>{[_, _2, _3, _4]}</CS>
                   {
                     <div
-                      className={ax([\\"_j7hq1lmr _bfhk1220 _syaz115e\\"])}
+                      className=\\"_j7hq1lmr _bfhk1220 _syaz115e\\"
                       style={{
                         \\"--_113bsv7\\": ix(runtime[0].from),
                         \\"--_k85g0d\\": ix(runtime[0].to),
@@ -852,7 +852,7 @@ describe('keyframes', () => {
                   <CS>{[_, _2, _3, _5]}</CS>
                   {
                     <div
-                      className={ax([\\"_j7hq1lmr _bfhk1220 _syazjq9z\\"])}
+                      className=\\"_j7hq1lmr _bfhk1220 _syazjq9z\\"
                       style={{
                         \\"--_113bsv7\\": ix(runtime[1].from),
                         \\"--_k85g0d\\": ix(runtime[1].to),
@@ -886,7 +886,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2, _3, _4]}</CS>
-              {<div className={ax([\\"_5sagymdr _j7hqb4f3 _1pgl1ytf\\"])} />}
+              {<div className=\\"_5sagymdr _j7hqb4f3 _1pgl1ytf\\" />}
             </CC>;
             "
           `);
@@ -904,7 +904,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
-              {<div className={ax([\\"_y44vjvcp\\"])} />}
+              {<div className=\\"_y44vjvcp\\" />}
             </CC>;
             "
           `);
@@ -926,7 +926,7 @@ describe('keyframes', () => {
             const darken = null;
             <CC>
               <CS>{[_, _2, _3]}</CS>
-              {<div className={ax([\\"_y44vwtez\\"])} />}
+              {<div className=\\"_y44vwtez\\" />}
             </CC>;
             "
           `);
@@ -1202,7 +1202,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2, _3, _4]}</CS>
-              {<div className={ax([\\"_5sagymdr _j7hq1c6j _1pgl1ytf\\"])} />}
+              {<div className=\\"_5sagymdr _j7hq1c6j _1pgl1ytf\\" />}
             </CC>;
             "
           `);
@@ -1220,7 +1220,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
-              {<div className={ax([\\"_y44v1go4\\"])} />}
+              {<div className=\\"_y44v1go4\\" />}
             </CC>;
             "
           `);
@@ -1242,7 +1242,7 @@ describe('keyframes', () => {
             const darken = null;
             <CC>
               <CS>{[_, _2, _3]}</CS>
-              {<div className={ax([\\"_y44vheiy\\"])} />}
+              {<div className=\\"_y44vheiy\\" />}
             </CC>;
             "
           `);
@@ -1266,7 +1266,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2, _3, _4]}</CS>
-              {<div className={ax([\\"_5sagymdr _j7hq1c6j _1pgl1ytf\\"])} />}
+              {<div className=\\"_5sagymdr _j7hq1c6j _1pgl1ytf\\" />}
             </CC>;
             "
           `);
@@ -1284,7 +1284,7 @@ describe('keyframes', () => {
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
-              {<div className={ax([\\"_y44v1go4\\"])} />}
+              {<div className=\\"_y44v1go4\\" />}
             </CC>;
             "
           `);
@@ -1306,7 +1306,7 @@ describe('keyframes', () => {
             const darken = null;
             <CC>
               <CS>{[_, _2, _3]}</CS>
-              {<div className={ax([\\"_y44vheiy\\"])} />}
+              {<div className=\\"_y44vheiy\\" />}
             </CC>;
             "
           `);

--- a/packages/babel-plugin/src/keyframes/__tests__/tagged-template-expression.test.ts
+++ b/packages/babel-plugin/src/keyframes/__tests__/tagged-template-expression.test.ts
@@ -85,7 +85,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2, _3, _4]}</CS>
-            {<div className={ax([\\"_5sagymdr _j7hqa2t1 _1pgl1ytf\\"])} />}
+            {<div className=\\"_5sagymdr _j7hqa2t1 _1pgl1ytf\\" />}
           </CC>;
           "
         `);
@@ -103,7 +103,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_y44v1e4p\\"])} />}
+            {<div className=\\"_y44v1e4p\\" />}
           </CC>;
           "
         `);
@@ -125,7 +125,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const darken = null;
           <CC>
             <CS>{[_, _2, _3]}</CS>
-            {<div className={ax([\\"_y44vt6c7\\"])} />}
+            {<div className=\\"_y44vt6c7\\" />}
           </CC>;
           "
         `);
@@ -149,7 +149,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2, _3, _4]}</CS>
-            {<div className={ax([\\"_5sagymdr _j7hqa2t1 _1pgl1ytf\\"])} />}
+            {<div className=\\"_5sagymdr _j7hqa2t1 _1pgl1ytf\\" />}
           </CC>;
           "
         `);
@@ -167,7 +167,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_y44v1e4p\\"])} />}
+            {<div className=\\"_y44v1e4p\\" />}
           </CC>;
           "
         `);
@@ -189,7 +189,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const darken = null;
           <CC>
             <CS>{[_, _2, _3]}</CS>
-            {<div className={ax([\\"_y44vt6c7\\"])} />}
+            {<div className=\\"_y44vt6c7\\" />}
           </CC>;
           "
         `);
@@ -231,7 +231,7 @@ describe('keyframes transforms a tagged template expression', () => {
         const fadeOut = null;
         <CC>
           <CS>{[_, _2]}</CS>
-          {<div className={ax([\\"_j7hqkl5x\\"])} />}
+          {<div className=\\"_j7hqkl5x\\" />}
         </CC>;
         "
       `);
@@ -273,7 +273,7 @@ describe('keyframes transforms a tagged template expression', () => {
         const fadeOut = null;
         <CC>
           <CS>{[_, _2]}</CS>
-          {<div className={ax([\\"_j7hq6mn5\\"])} />}
+          {<div className=\\"_j7hq6mn5\\" />}
         </CC>;
         "
       `);
@@ -330,7 +330,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hqzznm\\"])} />}
+            {<div className=\\"_j7hqzznm\\" />}
           </CC>;
           "
         `);
@@ -396,7 +396,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hqzznm\\"])} />}
+            {<div className=\\"_j7hqzznm\\" />}
           </CC>;
           "
         `);
@@ -433,7 +433,7 @@ describe('keyframes transforms a tagged template expression', () => {
         const fadeOut = null;
         <CC>
           <CS>{[_, _2]}</CS>
-          {<div className={ax([\\"_j7hqi8pm\\"])} />}
+          {<div className=\\"_j7hqi8pm\\" />}
         </CC>;
         "
       `);
@@ -479,7 +479,7 @@ describe('keyframes transforms a tagged template expression', () => {
         const fadeOut = null;
         <CC>
           <CS>{[_, _2]}</CS>
-          {<div className={ax([\\"_j7hqkl5x\\"])} />}
+          {<div className=\\"_j7hqkl5x\\" />}
         </CC>;
         "
       `);
@@ -525,7 +525,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hqy222\\"])} />}
+            {<div className=\\"_j7hqy222\\" />}
           </CC>;
           "
         `);
@@ -575,7 +575,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hqdjmv\\"])} />}
+            {<div className=\\"_j7hqdjmv\\" />}
           </CC>;
           "
         `);
@@ -610,7 +610,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const enlargeFont = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hqrsut\\"])} />}
+            {<div className=\\"_j7hqrsut\\" />}
           </CC>;
           "
         `);
@@ -646,7 +646,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const enlargeFont = null;
           <CC>
             <CS>{[_, _2]}</CS>
-            {<div className={ax([\\"_j7hq1emf\\"])} />}
+            {<div className=\\"_j7hq1emf\\" />}
           </CC>;
           "
         `);
@@ -686,7 +686,7 @@ describe('keyframes transforms a tagged template expression', () => {
             <CS>{[_, _2]}</CS>
             {
               <div
-                className={ax([\\"_j7hq17yp\\"])}
+                className=\\"_j7hq17yp\\"
                 style={{
                   \\"--_1b1u9h2\\": ix(runtime.colors.blue),
                   \\"--_19i50d6\\": ix(getOpacity(0)),
@@ -748,7 +748,7 @@ describe('keyframes transforms a tagged template expression', () => {
               <CS>{[_, _2, _3, _4]}</CS>
               {
                 <div
-                  className={ax([\\"_j7hq1vlm _bfhk1220 _syaz115e\\"])}
+                  className=\\"_j7hq1vlm _bfhk1220 _syaz115e\\"
                   style={{
                     \\"--_1tdwvvr\\": ix(runtime[0].from),
                     \\"--_151ky4\\": ix(runtime[0].to),
@@ -783,7 +783,7 @@ describe('keyframes transforms a tagged template expression', () => {
                 <CS>{[_, _2, _3, _4]}</CS>
                 {
                   <div
-                    className={ax([\\"_j7hq1vlm _bfhk1220 _syaz115e\\"])}
+                    className=\\"_j7hq1vlm _bfhk1220 _syaz115e\\"
                     style={{
                       \\"--_1tdwvvr\\": ix(runtime[0].from),
                       \\"--_151ky4\\": ix(runtime[0].to),
@@ -798,7 +798,7 @@ describe('keyframes transforms a tagged template expression', () => {
                 <CS>{[_, _2, _3, _5]}</CS>
                 {
                   <div
-                    className={ax([\\"_j7hq1vlm _bfhk1220 _syazjq9z\\"])}
+                    className=\\"_j7hq1vlm _bfhk1220 _syazjq9z\\"
                     style={{
                       \\"--_1tdwvvr\\": ix(runtime[1].from),
                       \\"--_151ky4\\": ix(runtime[1].to),

--- a/packages/babel-plugin/tsconfig.json
+++ b/packages/babel-plugin/tsconfig.json
@@ -5,5 +5,10 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "references": [{ "path": "../benchmark" }, { "path": "../css" }, { "path": "../utils" }]
+  "references": [
+    { "path": "../benchmark" },
+    { "path": "../css" },
+    { "path": "../utils" },
+    { "path": "../react" }
+  ]
 }

--- a/packages/parcel-transformer/src/__tests__/transformer.parceltest.ts
+++ b/packages/parcel-transformer/src/__tests__/transformer.parceltest.ts
@@ -62,9 +62,7 @@ it('transforms assets with babel plugin', async () => {
                         ]
                     }),
                     /*#__PURE__*/ (0, _jsxRuntime.jsx)(\\"div\\", {
-                        className: (0, _runtime.ax)([
-                            \\"_1wyb12am _syaz5scu\\"
-                        ]),
+                        className: \\"_1wyb12am _syaz5scu\\",
                         children: \\"hello from parcel\\"
                     })
                 ]
@@ -106,9 +104,7 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
         /*#__PURE__*/ return _jsxRuntime.jsxs(_jsxRuntime.Fragment, {
             children: [
                 /*#__PURE__*/ _jsxRuntime.jsx(\\"div\\", {
-                    className: _runtime.ax([
-                        \\"_1wyb12am _syaz5scu\\"
-                    ]),
+                    className: \\"_1wyb12am _syaz5scu\\",
                     children: \\"CSS prop\\"
                 }),
                 /*#__PURE__*/ _jsxRuntime.jsx(_babelComponentFixtureDefault.default, {
@@ -197,9 +193,7 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
     function BabelComponent(_ref2) {
         var children = _ref2.children;
         return (0, _jsxRuntime.jsx)(\\"div\\", {
-            className: (0, _runtime.ax)([
-                \\"_19pk1ul9\\"
-            ]),
+            className: \\"_19pk1ul9\\",
             children: /*#__PURE__*/ (0, _jsxRuntime.jsx)(Button, {
                 children: children
             })


### PR DESCRIPTION
This PR is the first attempt to remove `ax` from runtime. It will remove `ax` if the below conditions are met:
- Use CSS props 
- Does not receive className
- Atomic CSS rules are statically defined

Example
```
<div css={{ color: 'red' }} />
```