### PR TITLE
Fix react runtime ax function returning incorrect result for selectors

### DIFF
--- a/.changeset/two-avocados-kick.md
+++ b/.changeset/two-avocados-kick.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Fix react runtime ax function returning incorrect result for selectors

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime.js",
-      "limit": "166B",
+      "limit": "189B",
       "import": "{ ax }",
       "ignore": [
         "react"

--- a/packages/react/src/runtime/__tests__/ax.test.ts
+++ b/packages/react/src/runtime/__tests__/ax.test.ts
@@ -25,10 +25,22 @@ describe('ax', () => {
     expect(result).toEqual('_aaaacccc');
   });
 
-  it('should ensure the last atomic declaration of a multi group wins', () => {
-    const result = ax(['_aaaabbbb _aaaacccc', 'foo']);
+  it('should ensure the last atomic declaration of many single groups wins', () => {
+    const result = ax(['_aaaabbbb', '_aaaacccc', '_aaaadddd', '_aaaaeeee']);
 
-    expect(result).toEqual('_aaaacccc foo');
+    expect(result).toEqual('_aaaaeeee');
+  });
+
+  it('should ensure the last atomic declaration of a multi group wins', () => {
+    const result = ax(['_aaaabbbb _aaaacccc']);
+
+    expect(result).toEqual('_aaaacccc');
+  });
+
+  it('should ensure the last atomic declaration of many multi groups wins', () => {
+    const result = ax(['_aaaabbbb _aaaacccc _aaaadddd _aaaaeeee']);
+
+    expect(result).toEqual('_aaaaeeee');
   });
 
   it('should not remove any atomic declarations if there are no duplicate groups', () => {
@@ -48,5 +60,11 @@ describe('ax', () => {
     const result = ax(['hello_there', 'hello_world']);
 
     expect(result).toEqual('hello_there hello_world');
+  });
+
+  it('should ignore non atomic declarations when atomic declarations exist', () => {
+    const result = ax(['hello_there', 'hello_world', '_aaaabbbb']);
+
+    expect(result).toEqual('hello_there hello_world _aaaabbbb');
   });
 });

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -28,8 +28,8 @@ const ATOMIC_GROUP_LENGTH = 5;
  * @param classes
  */
 export default function ax(classNames: (string | undefined | false)[]): string | undefined {
-  if (classNames.length <= 1) {
-    // short circuit if theres no custom class names.
+  if (classNames.length <= 1 && (!classNames[0] || classNames[0].indexOf(' ') === -1)) {
+    // short circuit if there's no custom class names.
     return classNames[0] || undefined;
   }
 


### PR DESCRIPTION
![Screenshot 2023-01-17 at 09 52 32](https://user-images.githubusercontent.com/5213366/212797811-aa97345e-4378-4fde-8609-827bbd055684.png)
A simple bug in the `ax` logic which was breaking styles when we have a selector style declaration. This manifests by not removing classnames that should be overridden, causing a race condition on the correct style.

This is because the early exit in the `ax` function did not account for multiple css classnames in the same string.