### PR TITLE
Fix isServerEnvironment check

### DIFF
--- a/.changeset/real-eels-fly.md
+++ b/.changeset/real-eels-fly.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Update isServerEnvironment to support different SSR environment

--- a/packages/react/src/runtime/is-server-environment.ts
+++ b/packages/react/src/runtime/is-server-environment.ts
@@ -4,8 +4,8 @@
  */
 const isJsDomEnvironment = () =>
   window.name === 'nodejs' ||
-  navigator.userAgent.includes('Node.js') ||
-  navigator.userAgent.includes('jsdom');
+  navigator?.userAgent.includes('Node.js') ||
+  navigator?.userAgent.includes('jsdom');
 /**
  * Returns `true` when inside a node environment,
  * else `false`.
@@ -19,7 +19,10 @@ const isJsDomEnvironment = () =>
  * ```
  */
 export const isServerEnvironment = (): boolean => {
-  if (typeof process !== 'undefined' && process.versions != null && process.versions.node != null) {
+  if (
+    typeof window === 'undefined' ||
+    (typeof process !== 'undefined' && process.versions != null && process.versions.node != null)
+  ) {
     return true;
   }
   if (isJsDomEnvironment()) {


### PR DESCRIPTION
Our isServerEnvironment check is no longer working for Atlassian SSR. We need to check for window and also add some null checks.