### PR TITLE
Fix transparent and currentcolor not being treated as a color

### DIFF
--- a/.changeset/khaki-coats-attend.md
+++ b/.changeset/khaki-coats-attend.md
@@ -1,0 +1,5 @@
+---
+'@compiled/css': patch
+---
+
+Fix transparent and currentcolor not being treated as a color

--- a/packages/css/src/plugins/expand-shorthands/__tests__/utils.test.ts
+++ b/packages/css/src/plugins/expand-shorthands/__tests__/utils.test.ts
@@ -119,4 +119,12 @@ describe('expand utils', () => {
 
     expect(actual).toBe(true);
   });
+
+  it('should return true for special color words', () => {
+    const value = parse('transparent');
+
+    const actual = isColor(value.nodes[0]);
+
+    expect(actual).toBe(true);
+  });
 });

--- a/packages/css/src/plugins/expand-shorthands/utils.ts
+++ b/packages/css/src/plugins/expand-shorthands/utils.ts
@@ -12,7 +12,10 @@ export const globalValues = ['inherit', 'initial', 'unset', 'revert', 'revert-la
  * @param node
  */
 export const isColor = (node: Node): boolean => {
-  return (node.type === 'word' || node.type === 'func') && node.isColor;
+  if ((node.type === 'word' || node.type === 'func') && node.isColor) return true;
+
+  // https://drafts.csswg.org/css-color/#named-colors two special words aren't included in `isColor`
+  return node.type === 'word' && ['transparent', 'currentcolor'].includes(node.value);
 };
 
 const widthUnits = new Set([


### PR DESCRIPTION
We found a bug where the `outline` property was not working, as the colour `word` was not picked up correctly. It turns out this is because `transparent` isn't a named colour. We could support this case so we manually add this to our util.

Broken:

```
const Button = styled.button({
  outline: '2px solid transparent',
});
```

Works:

```
const Button = styled.button({
  outlineWidth: '2px',
  outlineStyle: 'solid',
  outlineColor: 'transparent',
});
```