### PR TITLE
Bugfix generate compression map correctly

### DIFF
--- a/.changeset/rich-dragons-wait.md
+++ b/.changeset/rich-dragons-wait.md
@@ -1,0 +1,5 @@
+---
+'@compiled/css': patch
+---
+
+Hotfix: if a compressed class name is in both stylesheet and old compression map, keep it in the new compression map.

--- a/packages/css/src/__tests__/generate-compression-map.test.ts
+++ b/packages/css/src/__tests__/generate-compression-map.test.ts
@@ -1,6 +1,8 @@
 import { generateCompressionMap as generate } from '../generate-compression-map';
 
 describe('generate compression map', () => {
+  beforeEach(() => {});
+
   const baseCSS = `
     ._154i14e6{top:33px}
     ._14tk72c6>div:not([role=group])>a{padding-left:18.6px}
@@ -126,15 +128,15 @@ describe('generate compression map', () => {
   });
 
   it('should generate class names with the old compression map', () => {
+    const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
     const oldCompressionMap: { [index: string]: string } = {
       '17gjpfqs': 'a',
       '1vdp1hna': 'b',
       '14fy1hna': 'c',
     };
     const result = generate(baseCSS, { oldClassNameCompressionMap: oldCompressionMap });
-    for (const property in oldCompressionMap) {
-      expect(result).toHaveProperty(property, oldCompressionMap[property]);
-    }
+    expect(result).toMatchObject(oldCompressionMap);
+    consoleWarnMock.mockRestore();
   });
 
   it('should generate class names with prefix', () => {
@@ -220,5 +222,23 @@ describe('generate compression map', () => {
       '1vdp1hna': '_na',
       '17gjpfqs': '_oa',
     });
+  });
+  it('should keep previous compressed names', () => {
+    const oldCompressionMap: { [index: string]: string } = {
+      '154i14e6': 'a',
+      hnu8tcjq: 'b',
+      '121jagmp': 'c',
+    };
+
+    let inputCSS = baseCSS;
+
+    Object.entries(oldCompressionMap).forEach(([key, value]) => {
+      inputCSS = inputCSS.replace('_' + key, value);
+    });
+
+    const result = generate(inputCSS, {
+      oldClassNameCompressionMap: oldCompressionMap,
+    });
+    expect(result).toMatchObject(oldCompressionMap);
   });
 });


### PR DESCRIPTION
If a compressed class name is in both stylesheet and old compression map, keep it in the new compression map. Let me give an example.

If the stylesheet looks like
```
.a { color: red }
._aaaabbbb { color: green }
```
oldCompressionMap:
```
{ "aaaacccc": "a" }
```
We should keep `{ "aaaacccc": "a" }` in the returned compression map.