### PR TITLE
remove runtime side effects

### DIFF
--- a/.changeset/thirty-days-tie.md
+++ b/.changeset/thirty-days-tie.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Remove `@compiled/react` runtime side-effect to ensure no error if the module is reloaded.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,11 +17,7 @@
   },
   "license": "Apache-2.0",
   "author": "Michael Dougall",
-  "sideEffects": [
-    "./dist/browser/runtime/index.js",
-    "./dist/cjs/runtime/index.js",
-    "./dist/esm/runtime/index.js"
-  ],
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": [

--- a/packages/react/src/runtime/index.ts
+++ b/packages/react/src/runtime/index.ts
@@ -3,14 +3,3 @@ export { default as CC } from './style-cache';
 export { default as ax } from './ax';
 export { default as ac, clearCache as clearAcCache } from './ac';
 export { default as ix } from './css-custom-property';
-
-// Ensure only one `@compiled/runtime` exist in the bundle.
-// This is because `ac` and `style-cache` need to access a singlton.
-if (typeof window !== 'undefined') {
-  if (typeof window.__COMPILED_IMPORTED__ !== 'undefined') {
-    throw new Error(
-      'Multiple instances of Compiled Runtime have been found on the page. A likely cause is that muliple versions of `@compiled/react` exist in JS bundle.'
-    );
-  }
-  window.__COMPILED_IMPORTED__ = true;
-}


### PR DESCRIPTION
We added a runtime side-effect to ensure only one copy of `@compiled/react` exists in the bundle at [PR](https://github.com/atlassian-labs/compiled/pull/1437). 

However, the side-effect relies on the assumption that modules are cached once loaded. This assumption is incorrect in many cases. It will throw a runtime error if `@compiled/react/runtime` is loaded twice. 

I think the risk outweighs the benefits of this side-effect. I will remove this side-effect in this PR and explore other ways of ensuring only one `@compiled/react` in the bundle.

