### PR TITLE
eslint plugin: Allow function parameters/imported values in edge case

### DIFF
--- a/.changeset/yellow-tools-sniff.md
+++ b/.changeset/yellow-tools-sniff.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': minor
+---
+
+Allow function parameters and imported values for variables on left side of an `&&` (AND) expression

--- a/.changeset/yellow-tools-sniff.md
+++ b/.changeset/yellow-tools-sniff.md
@@ -1,5 +1,5 @@
 ---
-'@compiled/eslint-plugin': minor
+'@compiled/eslint-plugin': patch
 ---
 
 Allow function parameters and imported values for variables on left side of an `&&` (AND) expression

--- a/.changeset/yellow-tools-sniff.md
+++ b/.changeset/yellow-tools-sniff.md
@@ -2,4 +2,4 @@
 '@compiled/eslint-plugin': patch
 ---
 
-Allow function parameters and imported values for variables on left side of an `&&` (AND) expression
+Allow function parameters and imported values for left side of any logical expression in `css` attribute (A && B, A || B, A ?? B)

--- a/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/__tests__/rule.test.ts
@@ -53,6 +53,25 @@ tester.run(
 
         <div css={styles} />;
       `,
+      // an AND expression containing a boolean (or something that we can treat
+      // as truthy or falsy) and some styles
+      outdent`
+      import React from 'react';
+      import { css } from '@compiled/react';
+      import { MyComponent } from './external-file';
+
+      const styles = css({ color: 'yellow' });
+      const Component = ({ myBoolean }) => <MyComponent css={myBoolean && styles} />;
+      `,
+      outdent`
+      import React from 'react';
+      import { css } from '@compiled/react';
+      import { MyComponent } from './external-file';
+
+      const styles = css({ color: 'yellow' });
+      const otherStyles = css({ background: 'blue' });
+      const Component = ({ myBoolean }) => <MyComponent css={[myBoolean && styles, otherStyles]} />;
+      `,
     ],
 
     invalid: [
@@ -277,6 +296,22 @@ tester.run(
           const CoolComponent = ({ styles = { color: blue } }) => {
             return <MyComponent css={styles} />;
           }
+        `,
+      },
+      {
+        errors: [
+          {
+            messageId: 'functionParameterInvalidCssUsage',
+          },
+        ],
+        code: outdent`
+        import React from 'react';
+        import { css } from '@compiled/react';
+
+        import { MyComponent } from './external-file';
+
+        const myBoolean = true;
+        const Component = ({ styles }) => <MyComponent css={myBoolean && styles} />;
         `,
       },
       {

--- a/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/__tests__/rule.test.ts
@@ -53,8 +53,7 @@ tester.run(
 
         <div css={styles} />;
       `,
-      // an AND expression containing a boolean (or something that we can treat
-      // as truthy or falsy) and some styles
+      // Logical expressions in the css attribute
       outdent`
       import React from 'react';
       import { css } from '@compiled/react';
@@ -71,6 +70,51 @@ tester.run(
       const styles = css({ color: 'yellow' });
       const otherStyles = css({ background: 'blue' });
       const Component = ({ myBoolean }) => <MyComponent css={[myBoolean && styles, otherStyles]} />;
+      `,
+      outdent`
+      import React from 'react';
+      import { css } from '@compiled/react';
+      import { MyComponent } from './external-file';
+
+      const styles = css({ color: 'yellow' });
+      const otherStyles = css({ background: 'blue' });
+      const Component = ({ myBoolean }) => <MyComponent css={[myBoolean || styles, otherStyles]} />;
+      `,
+      outdent`
+      import React from 'react';
+      import { css } from '@compiled/react';
+      import { MyComponent } from './external-file';
+
+      const styles = css({ color: 'yellow' });
+      const otherStyles = css({ background: 'blue' });
+      const Component = ({ myBoolean }) => <MyComponent css={[myBoolean ?? styles, otherStyles]} />;
+      `,
+      outdent`
+      import React from 'react';
+      import { css } from '@compiled/react';
+      import { MyComponent } from './external-file';
+
+      const styles = css({ color: 'yellow' });
+      const otherStyles = css({ background: 'blue' });
+      const Component = (props) => <MyComponent css={[props.myBoolean && styles, otherStyles]} />;
+      `,
+      outdent`
+      import React from 'react';
+      import { css } from '@compiled/react';
+      import { MyComponent } from './external-file';
+
+      const styles = css({ color: 'yellow' });
+      const otherStyles = css({ background: 'blue' });
+      const Component = ({ myBoolean }) => <MyComponent css={[myBoolean() && styles, otherStyles]} />;
+      `,
+      outdent`
+      import React from 'react';
+      import { css } from '@compiled/react';
+      import { MyComponent } from './external-file';
+
+      const styles = css({ color: 'yellow' });
+      const otherStyles = css({ background: 'blue' });
+      const Component = (props) => <MyComponent css={[props.myBoolean() && styles, otherStyles]} />;
       `,
     ],
 

--- a/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/index.ts
+++ b/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/index.ts
@@ -40,6 +40,18 @@ const handleIdentifier = (node: TSESTree.Identifier, references: Reference[], co
     const isImported = reference?.resolved?.defs.find((def) => def.type === 'ImportBinding');
     const isFunctionParameter = reference?.resolved?.defs.find((def) => def.type === 'Parameter');
 
+    // We assume that anything that is not on the right side of an AND logical expression
+    // (e.g. the A in css={A && B}) is only used as a boolean (or de-facto booleans) for
+    // short-circuiting, and do not form part of the final styling for our component.
+    const isNotRightSideOfAndExpression =
+      node.parent?.type === 'LogicalExpression' &&
+      node.parent.operator === '&&' &&
+      node !== node.parent.right;
+
+    if (isNotRightSideOfAndExpression) {
+      return;
+    }
+
     const jsxElement = traverseUpToJSXOpeningElement(node);
 
     // css property on DOM elements are always fine, e.g.

--- a/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/index.ts
+++ b/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/index.ts
@@ -40,18 +40,6 @@ const handleIdentifier = (node: TSESTree.Identifier, references: Reference[], co
     const isImported = reference?.resolved?.defs.find((def) => def.type === 'ImportBinding');
     const isFunctionParameter = reference?.resolved?.defs.find((def) => def.type === 'Parameter');
 
-    // We assume that anything that is on the left side of an AND logical expression
-    // (e.g. the A in css={A && B}) is only used as a boolean (or de-facto booleans) for
-    // short-circuiting, and do not form part of the final styling for our component.
-    const isLeftSideOfAndExpression =
-      node.parent?.type === 'LogicalExpression' &&
-      node.parent.operator === '&&' &&
-      node === node.parent.left;
-
-    if (isLeftSideOfAndExpression) {
-      return;
-    }
-
     const jsxElement = traverseUpToJSXOpeningElement(node);
 
     // css property on DOM elements are always fine, e.g.
@@ -140,8 +128,6 @@ const findStyleNodes = (node: CSSValue, references: Reference[], context: Contex
       }
     });
   } else if (node.type === 'LogicalExpression') {
-    // Traverse both values in the logical expression
-    findStyleNodes(node.left, references, context);
     findStyleNodes(node.right, references, context);
   } else if (node.type === 'ConditionalExpression') {
     // Traverse both return values in the conditional expression

--- a/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/index.ts
+++ b/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/index.ts
@@ -40,15 +40,15 @@ const handleIdentifier = (node: TSESTree.Identifier, references: Reference[], co
     const isImported = reference?.resolved?.defs.find((def) => def.type === 'ImportBinding');
     const isFunctionParameter = reference?.resolved?.defs.find((def) => def.type === 'Parameter');
 
-    // We assume that anything that is not on the right side of an AND logical expression
+    // We assume that anything that is on the left side of an AND logical expression
     // (e.g. the A in css={A && B}) is only used as a boolean (or de-facto booleans) for
     // short-circuiting, and do not form part of the final styling for our component.
-    const isNotRightSideOfAndExpression =
+    const isLeftSideOfAndExpression =
       node.parent?.type === 'LogicalExpression' &&
       node.parent.operator === '&&' &&
-      node !== node.parent.right;
+      node === node.parent.left;
 
-    if (isNotRightSideOfAndExpression) {
+    if (isLeftSideOfAndExpression) {
       return;
     }
 


### PR DESCRIPTION
Follow up PR to #1491 

There is a case where we should allow function parameters and imported values in the `css` attribute: when the variable is the left hand side of an AND (`&&`) expression. Consider an example like this:

```jsx
import { css } from '@compiled/react';

const styles = css(...);
const otherStyles = css(...);
const Component = ({ myBoolean }) => <MyComponent css={[myBoolean && styles, otherStyles]} />;

<Component myBoolean />
```

Compiled handles this perfectly fine because `styles` and `otherStyles` are statically evaluable, but #1491 erroneously marks `myBoolean` as problematic. This PR fixes this.