### PR TITLE
Add example type test

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,22 @@ module.exports = {
         'import/export': 'off',
         // We will let TypeScript handle this for tsx? files, and ignore it on jsx? files to enable linting without
         // building packages
-        'import/no-extraneous-dependencies': 'error',
+        'import/no-extraneous-dependencies': [
+          'error',
+          {
+            devDependencies: [
+              '**/__tests__/**',
+              '**/test/**',
+              '**/stories/**',
+              '**/__fixtures__/**',
+              '**/fixtures/**',
+              '**/__perf__/**',
+              '**/*.test.tsx?',
+              '**/index.js',
+              '**/test-utils.ts',
+            ],
+          },
+        ],
         'import/no-unresolved': 'off',
         'import/order': [
           'error',

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "eslint-plugin-json-files": "^2.2.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "expect-type": "^0.17.3",
     "flow-bin": "^0.183.0",
     "flowgen": "^1.21.0",
     "husky": "^4.3.8",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "eslint-plugin-json-files": "^2.2.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "expect-type": "^0.17.3",
     "flow-bin": "^0.183.0",
     "flowgen": "^1.21.0",
     "husky": "^4.3.8",

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "devDependencies": {
+  "dependencies": {
     "benchmark": "^2.1.4"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,6 +79,7 @@
     "@testing-library/react": "^12.1.5",
     "@types/jsdom": "^16.2.15",
     "@types/react-dom": "^17.0.20",
+    "expect-type": "^0.17.3",
     "jsdom": "^19.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/react/src/css/__tests__/types.test.ts
+++ b/packages/react/src/css/__tests__/types.test.ts
@@ -1,0 +1,12 @@
+/** @jsxImportSource @compiled/react */
+import { css } from '@compiled/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { expectTypeOf } from 'expect-type';
+
+describe('css func tests', () => {
+  it('should type violate when given invalid types', () => {
+    const style = css({ color: 'red' });
+
+    expectTypeOf(style).not.toMatchTypeOf<string>();
+  });
+});

--- a/packages/react/src/css/__tests__/types.test.ts
+++ b/packages/react/src/css/__tests__/types.test.ts
@@ -1,6 +1,5 @@
 /** @jsxImportSource @compiled/react */
 import { css } from '@compiled/react';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { expectTypeOf } from 'expect-type';
 
 describe('css func tests', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8568,6 +8568,11 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+expect-type@^0.17.3:
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.17.3.tgz#30623b0c66f6483e89b31272848776db662778e6"
+  integrity sha512-K0ZdZJ97jiAtaOwhEHHz/f0N6Xbj5reRz5g6+5BO7+OvqQ7PMQz0/c8bFSJs1zPotNJL5HJaC6t6lGPEAtGyOw==
+
 expect@^24.1.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"


### PR DESCRIPTION
This pull request installs the `expect-type` package and writes a simple test. It's a portable library with no boiler plate to have it configured.

It does not throw errors at runtime (meaning: all tests with only type assertions will always pass). It leans on the TypeScript compiler to raise errors at compile time. That means we need to make sure we're type checking tests else the tests won't actually do anything. 

We do throw the build if there are type errors in tests currently, so happy days!

```
➜  compiled git:(expect-type-assertions) yarn build
yarn run v1.22.19
$ yarn build:babel-fixture && yarn build:browser && yarn build:cjs && yarn build:esm && yarn flow-types build && yarn postbuild
$ yarn workspace @compiled/babel-component-fixture build && yarn workspace @compiled/babel-component-extracted-fixture build
$ TEST_PKG_VERSION='0.0.0' babel ./src --out-dir=./dist
Successfully compiled 1 file with Babel (1405ms).
$ TEST_PKG_VERSION='0.0.0' babel ./src --out-dir=./dist
Successfully compiled 1 file with Babel (1387ms).
$ ttsc --build packages/tsconfig.browser.json
packages/react/src/css/__tests__/types.test.ts:10:39 - error TS2344: Type 'string' does not satisfy the constraint '{ [x: number]: "Expected: string, Actual: never"; [iterator]: "Expected: function, Actual: never"; replace: "Expected: function, Actual: never"; fixed: "Expected: function, Actual: never"; ... 853 more ...; valueOf: "Expected: function, Actual: never"; }'.

10     expectTypeOf(style).toMatchTypeOf<string>();
                                         ~~~~~~


Found 1 error.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```