### PR TITLE
Replace sourceCode with getSourceCode

### DIFF
--- a/.changeset/plenty-cats-buy.md
+++ b/.changeset/plenty-cats-buy.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Replace context.sourceCode with context.getSourceCode(), to restore compatibility with ESLint v7 and <v8.40.0

--- a/packages/eslint-plugin/src/rules/no-invalid-css-map/index.ts
+++ b/packages/eslint-plugin/src/rules/no-invalid-css-map/index.ts
@@ -39,7 +39,7 @@ const reportIfNotTopLevelScope = (node: CallExpression, context: Rule.RuleContex
 };
 
 const createCssMapRule = (context: Rule.RuleContext): Rule.RuleListener => {
-  const { text } = context.sourceCode;
+  const { text } = context.getSourceCode();
   if (!text.includes(COMPILED_IMPORT)) {
     return {};
   }

--- a/packages/eslint-plugin/src/utils/create-no-exported-rule/check-if-compiled-export.ts
+++ b/packages/eslint-plugin/src/utils/create-no-exported-rule/check-if-compiled-export.ts
@@ -13,7 +13,7 @@ type Stack = {
 };
 
 const getStack = (context: RuleContext, node: Node) => {
-  const { scopeManager } = context.sourceCode;
+  const { scopeManager } = context.getSourceCode();
   const stack: Omit<Stack, 'scope'> = {
     nodes: [],
     root: node,


### PR DESCRIPTION
Even though `getSourceCode()` is deprecated in ESLint, support for the alternative `sourceCode` was [not added until v8.40.0](packages/eslint-plugin/src/test-utils.ts) (released May 2023). We revert back to the older syntax for compatibility with ESLint v7 and older versions of v8.