### PR TITLE
Refactor no-css-prop-without-css-function, fix edge case

### DIFF
--- a/.changeset/orange-dragons-train.md
+++ b/.changeset/orange-dragons-train.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Fix edge case where no-css-prop-without-css-function crashes

--- a/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/__tests__/rule.test.ts
@@ -116,6 +116,20 @@ tester.run(
       const otherStyles = css({ background: 'blue' });
       const Component = (props) => <MyComponent css={[props.myBoolean() && styles, otherStyles]} />;
       `,
+      outdent`
+      import { css } from '@compiled/react';
+
+      const FloatingContainer = (css) => {
+        const floatingContainerStyles = css({ color: 'pink' });
+        const cssStyles = [floatingContainerStyles, css({ color: 'blue' })];
+
+        return (
+          <div ref={ref} css={cssStyles} {...rest}>
+            {children}
+          </div>
+        );
+      }
+      `,
     ],
 
     invalid: [


### PR DESCRIPTION
In a situation like this:

```tsx
import { css } from '@compiled/react';
const FloatingContainer = (css) => {
  const floatingContainerStyles = css({ color: 'pink' });
  const cssStyles = [floatingContainerStyles, css({ color: 'blue' })];
  return (
    <div ref={ref} css={cssStyles} {...rest}>
      {children}
    </div>
  );
}
```

the `no-css-prop-without-css-function` eslint rule crashes.

This results from an incorrect assumption that traversing downwards from `css={cssStyles}` into the definition of `cssStyles` and `floatingContainerStyles`, and then traversing upwards (via `node.parent.parent.parent...`), will always get back to where you started.

In fact, after traversing downwards to `floatingContainerStyles`, traversing upwards goes through the variable declaration `const cssStyles = [floatingContainerStyles, css({ color: 'blue' })];`, not the `<div ref={ref} css={cssStyles} {...rest}>` element that we traversed down through 😦 

This PR fixes this by keeping track of the original node we started at (`baseNode`). Since there is a lot of shared state to keep track of here, the functions are also refactored into a class.