### PR TITLE
No suppress XCSS prop lint rule

### DIFF
--- a/.changeset/early-lions-prove.md
+++ b/.changeset/early-lions-prove.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Adds a new supplementary rule for xcss prop — `no-suppress-xcss`.

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -1,12 +1,13 @@
 export const recommended = {
   plugins: ['@compiled'],
   rules: {
+    '@compiled/no-css-prop-without-css-function': 'error',
     '@compiled/no-css-tagged-template-expression': 'error',
     '@compiled/no-exported-css': 'error',
     '@compiled/no-exported-keyframes': 'error',
+    '@compiled/no-invalid-css-map': 'error',
     '@compiled/no-keyframes-tagged-template-expression': 'error',
     '@compiled/no-styled-tagged-template-expression': 'error',
-    '@compiled/no-css-prop-without-css-function': 'error',
-    '@compiled/no-invalid-css-map': 'error',
+    '@compiled/no-suppress-xcss': 'error',
   },
 };

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -8,17 +8,19 @@ import { noExportedKeyframesRule } from './rules/no-exported-keyframes';
 import { noInvalidCssMapRule } from './rules/no-invalid-css-map';
 import { noKeyframesTaggedTemplateExpressionRule } from './rules/no-keyframes-tagged-template-expression';
 import { noStyledTaggedTemplateExpressionRule } from './rules/no-styled-tagged-template-expression';
+import { noSuppressXCSS } from './rules/no-suppress-xcss';
 
 export const rules = {
   'jsx-pragma': jsxPragmaRule,
+  'no-css-prop-without-css-function': noCssPropWithoutCssFunctionRule,
   'no-css-tagged-template-expression': noCssTaggedTemplateExpressionRule,
+  'no-emotion-css': noEmotionCssRule,
   'no-exported-css': noExportedCssRule,
   'no-exported-keyframes': noExportedKeyframesRule,
-  'no-emotion-css': noEmotionCssRule,
+  'no-invalid-css-map': noInvalidCssMapRule,
   'no-keyframes-tagged-template-expression': noKeyframesTaggedTemplateExpressionRule,
   'no-styled-tagged-template-expression': noStyledTaggedTemplateExpressionRule,
-  'no-css-prop-without-css-function': noCssPropWithoutCssFunctionRule,
-  'no-invalid-css-map': noInvalidCssMapRule,
+  'no-suppress-xcss': noSuppressXCSS,
 };
 
 export const configs = {

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/README.md
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/README.md
@@ -1,6 +1,8 @@
 # `no-suppress-xcss`
 
-Disallows supressing type violations when using the xcss prop.
+Disallows supressing type violations when using the xcss prop. Supressing type violations will cause incidents and unexpected behaviour when code changes in the future.
+
+Components that use xcss prop have explicitly declared what styles they should and should not accept, consumers must adhere to this API.
 
 👎 Examples of **incorrect** code for this rule:
 

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/README.md
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/README.md
@@ -1,0 +1,16 @@
+# `no-suppress-xcss`
+
+Disallows supressing type violations when using the xcss prop.
+
+👎 Examples of **incorrect** code for this rule:
+
+```js
+// @ts-expect-error
+<Button xcss={{ fill: 'var(--ds-text)' }} />
+```
+
+👍 Examples of **correct** code for this rule:
+
+```js
+<Button xcss={{ color: 'var(--ds-text)' }} />
+```

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/__tests__/rule.test.ts
@@ -2,6 +2,101 @@ import { typeScriptTester as tester } from '../../../test-utils';
 import { noSuppressXCSS } from '../index';
 
 tester.run('no-styled-tagged-template-expression', noSuppressXCSS, {
-  valid: [],
-  invalid: [],
+  valid: [
+    `
+      <Component xcss={{ fill: 'red' }} />
+    `,
+    `
+      <Component innerXcss={{ fill: 'red' }} />
+    `,
+    `
+      // @ts-expect-error
+      function Foo() {
+        // @ts-ignore
+        return (
+          <>
+            <Component xcss={{ fill: 'red' }} />
+          </>
+        );
+      }
+    `,
+  ],
+  invalid: [
+    {
+      code: `
+      // @ts-expect-error
+      <Component xcss={{ fill: 'red' }} />
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      code: `
+      // @ts-expect-error
+      <Component innerXcss={{ fill: 'red' }} />
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      code: `
+      // @ts-ignore
+      <Component xcss={{ fill: 'red' }} />
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      code: `
+
+      <Component
+        // @ts-expect-error
+        innerXcss={{ fill: 'red' }}
+      />
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      code: `
+
+      <Component
+        // @ts-ignore
+        xcss={{ fill: 'red' }}
+      />
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      code: `
+      // @ts-ignore
+      <Component innerXcss={{ fill: 'red' }} />
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      only: true,
+      code: `
+      function Foo() {
+        return (
+          <>
+            {/* @ts-ignore */}
+            <Component xcss={{ fill: 'red' }} />
+          </>
+        );
+      }
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      only: true,
+      code: `
+      function Foo() {
+        return (
+          <>
+            {/* @ts-expect-error */}
+            <Component xcss={{ fill: 'red' }} />
+          </>
+        );
+      }
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+  ],
 });

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/__tests__/rule.test.ts
@@ -35,6 +35,28 @@ tester.run('no-styled-tagged-template-expression', noSuppressXCSS, {
     },
     {
       code: `
+      <Component
+        xcss={{
+          // @ts-ignore
+          fill: 'red'
+        }}
+      />
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      code: `
+      <Component
+        xcss={{
+          // @ts-nocheck
+          fill: 'red'
+        }}
+      />
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      code: `
       // @ts-expect-error
       <Component xcss={{ fill: 'red' }} />
     `,
@@ -69,6 +91,16 @@ tester.run('no-styled-tagged-template-expression', noSuppressXCSS, {
 
       <Component
         // @ts-ignore
+        xcss={{ fill: 'red' }}
+      />
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      code: `
+
+      <Component
+        // @ts-nocheck
         xcss={{ fill: 'red' }}
       />
     `,

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/__tests__/rule.test.ts
@@ -24,6 +24,17 @@ tester.run('no-styled-tagged-template-expression', noSuppressXCSS, {
   invalid: [
     {
       code: `
+      <Component
+        xcss={{
+          // @ts-expect-error
+          fill: 'red'
+        }}
+      />
+    `,
+      errors: [{ messageId: 'no-suppress-xcss' }],
+    },
+    {
+      code: `
       // @ts-expect-error
       <Component xcss={{ fill: 'red' }} />
     `,
@@ -71,7 +82,6 @@ tester.run('no-styled-tagged-template-expression', noSuppressXCSS, {
       errors: [{ messageId: 'no-suppress-xcss' }],
     },
     {
-      only: true,
       code: `
       function Foo() {
         return (
@@ -85,7 +95,6 @@ tester.run('no-styled-tagged-template-expression', noSuppressXCSS, {
       errors: [{ messageId: 'no-suppress-xcss' }],
     },
     {
-      only: true,
       code: `
       function Foo() {
         return (

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/__tests__/rule.test.ts
@@ -1,0 +1,7 @@
+import { typeScriptTester as tester } from '../../../test-utils';
+import { noSuppressXCSS } from '../index';
+
+tester.run('no-styled-tagged-template-expression', noSuppressXCSS, {
+  valid: [],
+  invalid: [],
+});

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/index.ts
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/index.ts
@@ -8,10 +8,41 @@ export const noSuppressXCSS: Rule.RuleModule = {
         'The xcss prop is predicated on adhering to the type contract. Supressing it breaks this contract and thus is not allowed.',
       url: 'https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/no-supress-xcss',
     },
-    messages: {},
+    messages: {
+      'no-suppress-xcss': 'bad!',
+    },
     type: 'problem',
   },
-  create() {
-    return {};
+  create(context) {
+    return {
+      'JSXAttribute[name.name=/[xX]css$/]': (node: Rule.Node) => {
+        if (!node.loc) {
+          return;
+        }
+
+        const comments = context.sourceCode.getAllComments();
+
+        for (let i = 0; i < comments.length; i++) {
+          const comment = comments[i];
+          if (!comment.loc) {
+            continue;
+          }
+
+          const commentLine = comment.loc.start.line;
+          const nodeLine = node.loc.start.line;
+          const isCommentOnPreviousLine = nodeLine - 1 === commentLine;
+
+          if (
+            isCommentOnPreviousLine &&
+            ['@ts-expect-error', '@ts-ignore'].some((tag) => comment.value.includes(tag))
+          ) {
+            context.report({
+              node,
+              messageId: 'no-suppress-xcss',
+            });
+          }
+        }
+      },
+    };
   },
 };

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/index.ts
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/index.ts
@@ -1,5 +1,43 @@
 import type { Rule } from 'eslint';
 
+function nodeIsTypeSuppressed(context: Rule.RuleContext, node: Rule.Node) {
+  if (!node.loc) {
+    return;
+  }
+
+  const comments = context.sourceCode.getAllComments();
+
+  for (let i = 0; i < comments.length; i++) {
+    const comment = comments[i];
+    if (!comment.loc) {
+      continue;
+    }
+
+    const commentLine = comment.loc.start.line;
+    const nodeLine = node.loc.start.line;
+    const isCommentOnPreviousLine = nodeLine - 1 === commentLine;
+
+    if (
+      isCommentOnPreviousLine &&
+      ['@ts-expect-error', '@ts-ignore'].some((tag) => comment.value.includes(tag))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function getParentJSXAttribute(node: Rule.Node) {
+  let parent: Rule.Node | null = node.parent;
+
+  while (parent && parent.type !== 'JSXAttribute') {
+    parent = parent.parent;
+  }
+
+  return parent;
+}
+
 export const noSuppressXCSS: Rule.RuleModule = {
   meta: {
     docs: {
@@ -14,33 +52,26 @@ export const noSuppressXCSS: Rule.RuleModule = {
     type: 'problem',
   },
   create(context) {
+    const violations = new WeakSet<Rule.Node>();
+
     return {
-      'JSXAttribute[name.name=/[xX]css$/]': (node: Rule.Node) => {
-        if (!node.loc) {
-          return;
+      'JSXAttribute[name.name=/[xX]css$/] Property': (node: Rule.Node) => {
+        const parent = getParentJSXAttribute(node);
+
+        if (!violations.has(parent) && nodeIsTypeSuppressed(context, node)) {
+          context.report({
+            node: node,
+            messageId: 'no-suppress-xcss',
+          });
         }
-
-        const comments = context.sourceCode.getAllComments();
-
-        for (let i = 0; i < comments.length; i++) {
-          const comment = comments[i];
-          if (!comment.loc) {
-            continue;
-          }
-
-          const commentLine = comment.loc.start.line;
-          const nodeLine = node.loc.start.line;
-          const isCommentOnPreviousLine = nodeLine - 1 === commentLine;
-
-          if (
-            isCommentOnPreviousLine &&
-            ['@ts-expect-error', '@ts-ignore'].some((tag) => comment.value.includes(tag))
-          ) {
-            context.report({
-              node,
-              messageId: 'no-suppress-xcss',
-            });
-          }
+      },
+      'JSXAttribute[name.name=/[xX]css$/]': (node: Rule.Node) => {
+        if (node.type === 'JSXAttribute' && nodeIsTypeSuppressed(context, node)) {
+          violations.add(node);
+          context.report({
+            node: node.name,
+            messageId: 'no-suppress-xcss',
+          });
         }
       },
     };

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/index.ts
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/index.ts
@@ -1,0 +1,17 @@
+import type { Rule } from 'eslint';
+
+export const noSuppressXCSS: Rule.RuleModule = {
+  meta: {
+    docs: {
+      recommended: true,
+      description:
+        'The xcss prop is predicated on adhering to the type contract. Supressing it breaks this contract and thus is not allowed.',
+      url: 'https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/no-supress-xcss',
+    },
+    messages: {},
+    type: 'problem',
+  },
+  create() {
+    return {};
+  },
+};

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/index.ts
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/index.ts
@@ -7,8 +7,7 @@ function nodeIsTypeSuppressed(context: Rule.RuleContext, node: Rule.Node) {
 
   const comments = context.sourceCode.getAllComments();
 
-  for (let i = 0; i < comments.length; i++) {
-    const comment = comments[i];
+  for (const comment of comments) {
     if (!comment.loc) {
       continue;
     }
@@ -19,7 +18,7 @@ function nodeIsTypeSuppressed(context: Rule.RuleContext, node: Rule.Node) {
 
     if (
       isCommentOnPreviousLine &&
-      ['@ts-expect-error', '@ts-ignore'].some((tag) => comment.value.includes(tag))
+      ['@ts-expect-error', '@ts-ignore', '@ts-nocheck'].some((tag) => comment.value.includes(tag))
     ) {
       return true;
     }
@@ -47,7 +46,8 @@ export const noSuppressXCSS: Rule.RuleModule = {
       url: 'https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/no-supress-xcss',
     },
     messages: {
-      'no-suppress-xcss': 'bad!',
+      'no-suppress-xcss':
+        'Supressing type violations inside xcss risks incidents and unintended behaviour when code changes — only declare allowed values',
     },
     type: 'problem',
   },

--- a/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
@@ -165,8 +165,14 @@ describe('xcss prop', () => {
     ).toBeObject();
     expectTypeOf(
       <CSSPropComponent
-        // @ts-expect-error — Types of property 'backgroundColor' are incompatible.
-        xcss={{ color: 'red', '&:hover': { color: 'red', backgroundColor: 'red' } }}
+        xcss={{
+          color: 'red',
+          '&:hover': {
+            color: 'red',
+            // @ts-expect-error — Types of property 'backgroundColor' are incompatible.
+            backgroundColor: 'red',
+          },
+        }}
       />
     ).toBeObject();
   });
@@ -188,8 +194,13 @@ describe('xcss prop', () => {
     ).toBeObject();
     expectTypeOf(
       <CSSPropComponent
-        // @ts-expect-error — Type '{ screen: { color: string; backgroundColor: string; }; }' is not assignable to type 'undefined'.
-        xcss={{ color: 'red', '@media': { screen: { color: 'red', backgroundColor: 'red' } } }}
+        xcss={{
+          color: 'red',
+          // @ts-expect-error — Type '{ screen: { color: string; backgroundColor: string; }; }' is not assignable to type 'undefined'.
+          '@media': {
+            screen: { color: 'red', backgroundColor: 'red' },
+          },
+        }}
       />
     ).toBeObject();
   });


### PR DESCRIPTION
This pull request adds a new lint rule `no-suppress-xcss` that marks any ts-ignore / ts-expect-errors on the preceding line as violations when used in conjunction with xcss prop.

I will be putting up small PRs over the week to complete all the lint rules we need for the xcss prop feature. The lint rules are defined here: https://github.com/atlassian-labs/compiled/pull/1533