### PR TITLE
XCSS prop no js lint

### DIFF
--- a/.changeset/wild-berries-add.md
+++ b/.changeset/wild-berries-add.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Adds new supplementary lint rule for xcss prop `no-js-xcss`.

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -6,6 +6,7 @@ export const recommended = {
     '@compiled/no-exported-css': 'error',
     '@compiled/no-exported-keyframes': 'error',
     '@compiled/no-invalid-css-map': 'error',
+    '@compiled/no-js-xcss': 'error',
     '@compiled/no-keyframes-tagged-template-expression': 'error',
     '@compiled/no-styled-tagged-template-expression': 'error',
     '@compiled/no-suppress-xcss': 'error',

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -6,6 +6,7 @@ import { noEmotionCssRule } from './rules/no-emotion-css';
 import { noExportedCssRule } from './rules/no-exported-css';
 import { noExportedKeyframesRule } from './rules/no-exported-keyframes';
 import { noInvalidCssMapRule } from './rules/no-invalid-css-map';
+import { noJavaScriptXCSSRule } from './rules/no-js-xcss';
 import { noKeyframesTaggedTemplateExpressionRule } from './rules/no-keyframes-tagged-template-expression';
 import { noStyledTaggedTemplateExpressionRule } from './rules/no-styled-tagged-template-expression';
 import { noSuppressXCSS } from './rules/no-suppress-xcss';
@@ -18,6 +19,7 @@ export const rules = {
   'no-exported-css': noExportedCssRule,
   'no-exported-keyframes': noExportedKeyframesRule,
   'no-invalid-css-map': noInvalidCssMapRule,
+  'no-js-xcss': noJavaScriptXCSSRule,
   'no-keyframes-tagged-template-expression': noKeyframesTaggedTemplateExpressionRule,
   'no-styled-tagged-template-expression': noStyledTaggedTemplateExpressionRule,
   'no-suppress-xcss': noSuppressXCSS,

--- a/packages/eslint-plugin/src/rules/no-js-xcss/README.md
+++ b/packages/eslint-plugin/src/rules/no-js-xcss/README.md
@@ -1,0 +1,19 @@
+# `no-js-xcss`
+
+Disallows using xcss prop inside JavaScript files.
+
+Components that use xcss prop have explicitly declared what styles via the type system they should and should not accept, consumers must adhere to this API. Without TypeScript it's impossible to ensure this is met.
+
+👎 Examples of **incorrect** code for this rule:
+
+```js
+// my-component.jsx
+<Button xcss={{ fill: 'var(--ds-text)' }} />
+```
+
+👍 Examples of **correct** code for this rule:
+
+```js
+// my-component.tsx
+<Button xcss={{ color: 'var(--ds-text)' }} />
+```

--- a/packages/eslint-plugin/src/rules/no-js-xcss/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-js-xcss/__tests__/rule.test.ts
@@ -1,7 +1,7 @@
 import { typeScriptTester as tester } from '../../../test-utils';
-import { noSuppressXCSS } from '../index';
+import { noJavaScriptXCSSRule } from '../index';
 
-tester.run('no-styled-tagged-template-expression', noSuppressXCSS, {
+tester.run('no-styled-tagged-template-expression', noJavaScriptXCSSRule, {
   valid: [
     {
       filename: 'my-component.tsx',

--- a/packages/eslint-plugin/src/rules/no-js-xcss/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-js-xcss/__tests__/rule.test.ts
@@ -1,7 +1,7 @@
 import { typeScriptTester as tester } from '../../../test-utils';
 import { noJavaScriptXCSSRule } from '../index';
 
-tester.run('no-styled-tagged-template-expression', noJavaScriptXCSSRule, {
+tester.run('no-js-xcss', noJavaScriptXCSSRule, {
   valid: [
     {
       filename: 'my-component.tsx',

--- a/packages/eslint-plugin/src/rules/no-js-xcss/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-js-xcss/__tests__/rule.test.ts
@@ -1,0 +1,29 @@
+import { typeScriptTester as tester } from '../../../test-utils';
+import { noSuppressXCSS } from '../index';
+
+tester.run('no-styled-tagged-template-expression', noSuppressXCSS, {
+  valid: [
+    {
+      filename: 'my-component.tsx',
+      code: `
+      <Component xcss={{ fill: 'red' }} />
+    `,
+    },
+  ],
+  invalid: [
+    {
+      filename: 'my-component.js',
+      code: `
+      <Component xcss={{ fill: 'red' }} />
+    `,
+      errors: [{ messageId: 'no-js-xcss' }],
+    },
+    {
+      filename: 'my-component.jsx',
+      code: `
+      <Component xcss={{ fill: 'red' }} />
+    `,
+      errors: [{ messageId: 'no-js-xcss' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin/src/rules/no-js-xcss/index.ts
+++ b/packages/eslint-plugin/src/rules/no-js-xcss/index.ts
@@ -1,6 +1,6 @@
 import type { Rule } from 'eslint';
 
-export const noSuppressXCSS: Rule.RuleModule = {
+export const noJavaScriptXCSSRule: Rule.RuleModule = {
   meta: {
     docs: {
       recommended: true,

--- a/packages/eslint-plugin/src/rules/no-js-xcss/index.ts
+++ b/packages/eslint-plugin/src/rules/no-js-xcss/index.ts
@@ -1,0 +1,32 @@
+import type { Rule } from 'eslint';
+
+export const noSuppressXCSS: Rule.RuleModule = {
+  meta: {
+    docs: {
+      recommended: true,
+      description:
+        'The xcss prop is predicated on adhering to the type contract. Using it without TypeScript breaks this contract and thus is not allowed.',
+      url: 'https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/no-js-xcss',
+    },
+    messages: {
+      'no-js-xcss':
+        'Using xcss in JavaScript risks incidents and unintended behaviour when code changes — only use inside TypeScript files',
+    },
+    type: 'problem',
+  },
+  create(context) {
+    const violations = new WeakSet<Rule.Node>();
+
+    return {
+      'JSXAttribute[name.name=/[xX]css$/]': (node: Rule.Node) => {
+        if (node.type === 'JSXAttribute' && !context.filename.endsWith('.tsx')) {
+          violations.add(node);
+          context.report({
+            node: node.name,
+            messageId: 'no-js-xcss',
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin/src/rules/no-js-xcss/index.ts
+++ b/packages/eslint-plugin/src/rules/no-js-xcss/index.ts
@@ -15,12 +15,9 @@ export const noJavaScriptXCSSRule: Rule.RuleModule = {
     type: 'problem',
   },
   create(context) {
-    const violations = new WeakSet<Rule.Node>();
-
     return {
       'JSXAttribute[name.name=/[xX]css$/]': (node: Rule.Node) => {
         if (node.type === 'JSXAttribute' && !context.filename.endsWith('.tsx')) {
-          violations.add(node);
           context.report({
             node: node.name,
             messageId: 'no-js-xcss',


### PR DESCRIPTION
This pull request adds a new lint rule `no-js-xcss` that marks non tsx files as violations when using xcss prop.

I will be putting up small PRs over the week to complete all the lint rules we need for the xcss prop feature. The lint rules are defined here: https://github.com/atlassian-labs/compiled/pull/1533
