### PR TITLE
Fix XCSS prop collecting more styles than expected

### DIFF
--- a/packages/babel-plugin/src/babel-plugin.ts
+++ b/packages/babel-plugin/src/babel-plugin.ts
@@ -91,11 +91,7 @@ export default declare<State>((api) => {
             }
           }
 
-          if (
-            !state.opts.requireCompiledInScopeForXCSSProp &&
-            !state.compiledImports &&
-            /(x|X)css={/.exec(file.code)
-          ) {
+          if (!state.compiledImports && /(x|X)css={/.exec(file.code)) {
             // xcss prop was found turn on Compiled
             state.compiledImports = {};
           }

--- a/packages/babel-plugin/src/types.ts
+++ b/packages/babel-plugin/src/types.ts
@@ -28,16 +28,6 @@ export interface PluginOptions {
   importReact?: boolean;
 
   /**
-   * By default the `xcss` prop works by just using it. To aid repositories
-   * migrating to Compiled `xcss` prop, you can use this config to have it
-   * only be enabled when Compiled has been activated either by jsx pragma
-   * or other Compiled APIs.
-   *
-   * Defaults to `false`.
-   */
-  requireCompiledInScopeForXCSSProp?: boolean;
-
-  /**
    * Security nonce that will be applied to inline style elements if defined.
    */
   nonce?: string;

--- a/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
+++ b/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
@@ -144,24 +144,6 @@ describe('xcss prop transformation', () => {
     `);
   });
 
-  it('should ignore xcss prop when compiled must be in scope', () => {
-    const result = transform(
-      `
-      <Component xcss={{ color: 'red' }} />
-    `,
-      { requireCompiledInScopeForXCSSProp: true }
-    );
-
-    expect(result).toMatchInlineSnapshot(`
-      "<Component
-        xcss={{
-          color: "red",
-        }}
-      />;
-      "
-    `);
-  });
-
   it('should transform xcss prop when compiled is in scope', () => {
     const result = transform(
       `
@@ -172,8 +154,7 @@ describe('xcss prop transformation', () => {
       });
 
       <Component xcss={styles.primary} />
-    `,
-      { requireCompiledInScopeForXCSSProp: true }
+    `
     );
 
     expect(result).toMatchInlineSnapshot(`
@@ -227,6 +208,52 @@ describe('xcss prop transformation', () => {
           color: "red",
         })}
       />;
+      "
+    `);
+  });
+
+  it('should ignore primitive components mixed with compiled components', () => {
+    const result = transform(
+      `
+      import { Box, xcss } from '@atlaskit/primitives';
+      import { cssMap } from '@compiled/react';
+
+      const styles = cssMap({ text: { color: 'red' } })
+
+      export function Mixed() {
+        return (
+          <>
+            <Box xcss={xcss({ color: 'red' })} />
+            <Button xcss={styles.text} />
+          </>
+        );
+      }
+    `
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "import * as React from "react";
+      import { ax, ix, CC, CS } from "@compiled/react/runtime";
+      import { Box, xcss } from "@atlaskit/primitives";
+      const _ = "._syaz5scu{color:red}";
+      const styles = {
+        text: "_syaz5scu",
+      };
+      export function Mixed() {
+        return (
+          <>
+            <Box
+              xcss={xcss({
+                color: "red",
+              })}
+            />
+            <CC>
+              <CS>{[_]}</CS>
+              {<Button xcss={styles.text} />}
+            </CC>
+          </>
+        );
+      }
       "
     `);
   });

--- a/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
+++ b/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
@@ -208,4 +208,26 @@ describe('xcss prop transformation', () => {
       "
     `);
   });
+
+  it('should ignore primitive components using runtime xcss prop', () => {
+    const result = transform(
+      `
+      import { Box, xcss } from '@atlaskit/primitives';
+
+      <Box xcss={xcss({ color: 'red' })} />
+    `
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "import * as React from "react";
+      import { ax, ix, CC, CS } from "@compiled/react/runtime";
+      import { Box, xcss } from "@atlaskit/primitives";
+      <Box
+        xcss={xcss({
+          color: "red",
+        })}
+      />;
+      "
+    `);
+  });
 });

--- a/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
+++ b/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
@@ -212,6 +212,54 @@ describe('xcss prop transformation', () => {
     `);
   });
 
+  it('should only add styles to xcss call sites that use them', () => {
+    const result = transform(
+      `
+      import { cssMap } from '@compiled/react';
+
+      const stylesOne = cssMap({ text: { color: 'red' } })
+      const stylesTwo = cssMap({ text: { color: 'blue' } })
+
+      export function Mixed() {
+        return (
+          <>
+            <Button xcss={stylesOne.text} />
+            <Button xcss={stylesTwo.text} />
+          </>
+        );
+      }
+    `
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "import * as React from "react";
+      import { ax, ix, CC, CS } from "@compiled/react/runtime";
+      const _2 = "._syaz13q2{color:blue}";
+      const _ = "._syaz5scu{color:red}";
+      const stylesOne = {
+        text: "_syaz5scu",
+      };
+      const stylesTwo = {
+        text: "_syaz13q2",
+      };
+      export function Mixed() {
+        return (
+          <>
+            <CC>
+              <CS>{[_]}</CS>
+              {<Button xcss={stylesOne.text} />}
+            </CC>
+            <CC>
+              <CS>{[_2]}</CS>
+              {<Button xcss={stylesTwo.text} />}
+            </CC>
+          </>
+        );
+      }
+      "
+    `);
+  });
+
   it('should ignore primitive components mixed with compiled components', () => {
     const result = transform(
       `

--- a/packages/babel-plugin/src/xcss-prop/index.ts
+++ b/packages/babel-plugin/src/xcss-prop/index.ts
@@ -92,6 +92,12 @@ export const visitXcssPropPath = (path: NodePath<t.JSXOpeningElement>, meta: Met
     path.parentPath.replaceWith(compiledTemplate(jsxElementNode, sheets, meta));
   } else {
     const sheets = collectPassStyles(meta);
+    if (sheets.length === 0) {
+      // No sheets were extracted — bail out from the transform.
+      // This covers the legacy use case of runtime xcss prop.
+      return;
+    }
+
     path.parentPath.replaceWith(compiledTemplate(jsxElementNode, sheets, meta));
   }
 };

--- a/packages/babel-plugin/src/xcss-prop/index.ts
+++ b/packages/babel-plugin/src/xcss-prop/index.ts
@@ -29,11 +29,27 @@ function staticObjectInvariant(expression: t.ObjectExpression, meta: Metadata) {
   );
 }
 
-function collectPassStyles(meta: Metadata): string[] {
+function collectPathMemberExpressionIdentifiers(propPath: NodePath<t.JSXAttribute>): string[] {
+  const identifiers: string[] = [];
+
+  propPath.traverse({
+    MemberExpression(node) {
+      if (node.node.object.type === 'Identifier') {
+        identifiers.push(node.node.object.name);
+      }
+    },
+  });
+
+  return identifiers;
+}
+
+function collectPassStyles(meta: Metadata, identifiers: string[]): string[] {
   const styles: string[] = [];
 
   for (const key in meta.state.cssMap) {
-    styles.push(...meta.state.cssMap[key]);
+    if (identifiers.includes(key)) {
+      styles.push(...meta.state.cssMap[key]);
+    }
   }
 
   return styles;
@@ -48,7 +64,7 @@ export const visitXcssPropPath = (path: NodePath<t.JSXOpeningElement>, meta: Met
   meta.state.transformCache.set(path, true);
   const jsxElementNode = path.parentPath.node as t.JSXElement;
 
-  const prop = path.get('attributes').find((attr): attr is NodePath<t.JSXAttribute> => {
+  const propPath = path.get('attributes').find((attr): attr is NodePath<t.JSXAttribute> => {
     if (t.isJSXAttribute(attr.node) && `${attr.node.name.name}`.toLowerCase().endsWith('xcss')) {
       return true;
     }
@@ -56,8 +72,8 @@ export const visitXcssPropPath = (path: NodePath<t.JSXOpeningElement>, meta: Met
     return false;
   });
 
-  const container = getJsxAttributeExpressionContainer(prop);
-  if (!prop || !container || container.expression.type === 'JSXEmptyExpression') {
+  const container = getJsxAttributeExpressionContainer(propPath);
+  if (!propPath || !container || container.expression.type === 'JSXEmptyExpression') {
     // Nothing to do — bail out!
     return;
   }
@@ -84,14 +100,19 @@ export const visitXcssPropPath = (path: NodePath<t.JSXOpeningElement>, meta: Met
       default:
         throw buildCodeFrameError(
           'Unexpected count of class names please raise an issue on Github',
-          prop.node,
+          propPath.node,
           meta.parentPath
         );
     }
 
     path.parentPath.replaceWith(compiledTemplate(jsxElementNode, sheets, meta));
   } else {
-    const sheets = collectPassStyles(meta);
+    // We make the assumption that xcss prop only takes member expressions such as:
+    // 1. Dot notation, such as "styles.text"
+    // 2. Bracket notation, such as "styles[appearance]"
+    const identifiers = collectPathMemberExpressionIdentifiers(propPath);
+    const sheets = collectPassStyles(meta, identifiers);
+
     if (sheets.length === 0) {
       // No sheets were extracted — bail out from the transform.
       // This covers the legacy use case of runtime xcss prop.


### PR DESCRIPTION
This pull request fixes a bug where xcss prop would collect all styles in the module instead of the ones used. In doing that we also unblock being able to use the legacy xcss prop in the same module as the new xcss prop.

- fixes collection bug
- removes migration option as it's not needed anymore