### PR TITLE
Update jsx-pragma rule to ensure it exists when using xcss prop

### DIFF
--- a/.changeset/flat-forks-live.md
+++ b/.changeset/flat-forks-live.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Update jsx-pragma lint rule to enforce the pragma is in scope when passing the `className` prop on host elements an output of xcss prop.

--- a/packages/babel-plugin/src/babel-plugin.ts
+++ b/packages/babel-plugin/src/babel-plugin.ts
@@ -91,7 +91,7 @@ export default declare<State>((api) => {
             }
           }
 
-          if (!state.compiledImports && /(x|X)css={/.exec(file.code)) {
+          if (!state.compiledImports && /(x|X)css={/.test(file.code)) {
             // xcss prop was found turn on Compiled
             state.compiledImports = {};
           }

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
@@ -7,6 +7,20 @@ tester.run('jsx-pragma', jsxPragmaRule, {
       /** @jsxImportSource @compiled/react */
       <div css={{ display: 'block' }} />
     `,
+    `
+      <AnotherComponent className={xcss} />
+    `,
+    `
+      <div className={anythingElse} />
+    `,
+    `
+      /** @jsxImportSource @compiled/react */
+      <div className={xcss} />
+    `,
+    `
+      /** @jsxImportSource @compiled/react */
+      <div className={innerXcss} />
+    `,
     {
       code: `
       /** @jsxImportSource @compiled/react */
@@ -24,6 +38,18 @@ tester.run('jsx-pragma', jsxPragmaRule, {
     },
   ],
   invalid: [
+    {
+      code: `
+        <div className={xcss} />
+      `,
+      errors: [{ messageId: 'missingPragmaXCSS' }],
+    },
+    {
+      code: `
+      <div className={innerXcss} />
+    `,
+      errors: [{ messageId: 'missingPragmaXCSS' }],
+    },
     {
       code: `<div css={{ display: 'block' }} />`,
       output: `/** @jsx jsx */

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
@@ -40,13 +40,21 @@ tester.run('jsx-pragma', jsxPragmaRule, {
   invalid: [
     {
       code: `
-        <div className={xcss} />
+      <div className={xcss} />
+      `,
+      output: `
+      /** @jsxImportSource @compiled/react */
+<div className={xcss} />
       `,
       errors: [{ messageId: 'missingPragmaXCSS' }],
     },
     {
       code: `
       <div className={innerXcss} />
+    `,
+      output: `
+      /** @jsxImportSource @compiled/react */
+<div className={innerXcss} />
     `,
       errors: [{ messageId: 'missingPragmaXCSS' }],
     },

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
@@ -27,6 +27,50 @@ const findReactDeclarationWithDefaultImport = (
   return undefined;
 };
 
+function createFixer(context: Rule.RuleContext, source: SourceCode, options: Options) {
+  return function* fix(fixer: Rule.RuleFixer) {
+    const pragma = options.runtime === 'classic' ? '@jsx jsx' : '@jsxImportSource @compiled/react';
+    const reactImport = findReactDeclarationWithDefaultImport(source);
+    if (reactImport) {
+      const [declaration, defaultImport] = reactImport;
+      const [defaultImportVariable] = context.getDeclaredVariables(defaultImport);
+
+      if (defaultImportVariable && defaultImportVariable.references.length === 0) {
+        if (declaration.specifiers.length === 1) {
+          // Only the default specifier exists and it isn't used - remove the whole declaration!
+          yield fixer.remove(declaration);
+        } else {
+          // Multiple specifiers exist but the default one isn't used - remove the default specifier!
+          yield fixer.replaceText(declaration, removeImportFromDeclaration(declaration, []));
+        }
+      }
+    }
+
+    yield fixer.insertTextBefore(source.ast.body[0], `/** ${pragma} */\n`);
+
+    const compiledImports = findCompiledImportDeclarations(context);
+
+    if (options.runtime === 'classic' && !findDeclarationWithImport(compiledImports, 'jsx')) {
+      // jsx import is missing time to add one
+      if (compiledImports.length === 0) {
+        // No import exists, add a new one!
+        yield fixer.insertTextBefore(
+          source.ast.body[0],
+          "import { jsx } from '@compiled/react';\n"
+        );
+      } else {
+        // An import exists with no JSX! Let's add one to the first found.
+        const [firstCompiledImport] = compiledImports;
+
+        yield fixer.replaceText(
+          firstCompiledImport,
+          addImportToDeclaration(firstCompiledImport, ['jsx'])
+        );
+      }
+    }
+  };
+}
+
 export const jsxPragmaRule: Rule.RuleModule = {
   meta: {
     docs: {
@@ -137,6 +181,7 @@ export const jsxPragmaRule: Rule.RuleModule = {
           context.report({
             node,
             messageId: 'missingPragmaXCSS',
+            fix: createFixer(context, source, options),
           });
         }
       },
@@ -146,61 +191,13 @@ export const jsxPragmaRule: Rule.RuleModule = {
           return;
         }
 
-        const pragma =
-          options.runtime === 'classic' ? '@jsx jsx' : '@jsxImportSource @compiled/react';
-
         context.report({
           messageId: 'missingPragma',
           data: {
             pragma: options.runtime === 'classic' ? 'jsx' : 'jsxImportSource',
           },
           node,
-          *fix(fixer) {
-            const reactImport = findReactDeclarationWithDefaultImport(source);
-            if (reactImport) {
-              const [declaration, defaultImport] = reactImport;
-              const [defaultImportVariable] = context.getDeclaredVariables(defaultImport);
-
-              if (defaultImportVariable && defaultImportVariable.references.length === 0) {
-                if (declaration.specifiers.length === 1) {
-                  // Only the default specifier exists and it isn't used - remove the whole declaration!
-                  yield fixer.remove(declaration);
-                } else {
-                  // Multiple specifiers exist but the default one isn't used - remove the default specifier!
-                  yield fixer.replaceText(
-                    declaration,
-                    removeImportFromDeclaration(declaration, [])
-                  );
-                }
-              }
-            }
-
-            yield fixer.insertTextBefore(source.ast.body[0], `/** ${pragma} */\n`);
-
-            const compiledImports = findCompiledImportDeclarations(context);
-
-            if (
-              options.runtime === 'classic' &&
-              !findDeclarationWithImport(compiledImports, 'jsx')
-            ) {
-              // jsx import is missing time to add one
-              if (compiledImports.length === 0) {
-                // No import exists, add a new one!
-                yield fixer.insertTextBefore(
-                  source.ast.body[0],
-                  "import { jsx } from '@compiled/react';\n"
-                );
-              } else {
-                // An import exists with no JSX! Let's add one to the first found.
-                const [firstCompiledImport] = compiledImports;
-
-                yield fixer.replaceText(
-                  firstCompiledImport,
-                  addImportToDeclaration(firstCompiledImport, ['jsx'])
-                );
-              }
-            }
-          },
+          fix: createFixer(context, source, options),
         });
       },
     };

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
@@ -176,7 +176,7 @@ export const jsxPragmaRule: Rule.RuleModule = {
         if (
           node.value?.type === 'JSXExpressionContainer' &&
           node.value.expression.type === 'Identifier' &&
-          /[Xx]css$/.exec(node.value.expression.name)
+          /[Xx]css$/.test(node.value.expression.name)
         ) {
           context.report({
             node,

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
@@ -34,6 +34,7 @@ export const jsxPragmaRule: Rule.RuleModule = {
     },
     fixable: 'code',
     messages: {
+      missingPragmaXCSS: 'Applying xcss prop to className requires the jsx pragma in scope.',
       missingPragma: 'To use the `css` prop you must set the {{ pragma }} pragma.',
       preferJsxImportSource:
         'Use of the jsxImportSource pragma (automatic runtime) is preferred over the jsx pragma (classic runtime).',
@@ -117,6 +118,25 @@ export const jsxPragmaRule: Rule.RuleModule = {
                 );
               }
             },
+          });
+        }
+      },
+
+      'JSXOpeningElement[name.name=/^[a-z]+$/] > JSXAttribute[name.name=/^className$/]': (
+        node: Rule.Node
+      ) => {
+        if (node.type !== 'JSXAttribute' || jsxPragma || jsxImportSourcePragma) {
+          return;
+        }
+
+        if (
+          node.value?.type === 'JSXExpressionContainer' &&
+          node.value.expression.type === 'Identifier' &&
+          /[Xx]css$/.exec(node.value.expression.name)
+        ) {
+          context.report({
+            node,
+            messageId: 'missingPragmaXCSS',
           });
         }
       },

--- a/packages/eslint-plugin/src/rules/local-cx-xcss/index.ts
+++ b/packages/eslint-plugin/src/rules/local-cx-xcss/index.ts
@@ -38,7 +38,7 @@ export const localCXXCSSRule: Rule.RuleModule = {
           const parentJSXAttribute = getParentJSXAttribute(node);
           const propName = parentJSXAttribute?.name.name.toString();
 
-          if (propName && /[xX]css$/.exec(propName)) {
+          if (propName && /[xX]css$/.test(propName)) {
             return;
           }
 


### PR DESCRIPTION
This pull request updates the jsx pragma rule to mark violations when passing a `className` prop an `xcss` or named xcss prop value. To resolve your define the jsx pragma. This rule exists as a DX improvement otherwise it will be confusing how to resolve the type error when passing `className` the xcss typed object.

I will be putting up small PRs over the week to complete all the lint rules we need for the xcss prop feature. The lint rules are defined here: https://github.com/atlassian-labs/compiled/pull/1533

Violation:

```jsx
<div className={xcss} />
```

Success:

```jsx
/* @jsxImportSource @compiled/react */
<div className={xcss} />
```

**TODO**

- [x] Refactor to have an autofixer (re-use already existing logic!)