### PR TITLE
Extend jsx-pragma eslint rule: detect mixing Compiled with Emotion, and only run if importing Compiled

### DIFF
--- a/.changeset/smooth-shirts-guess.md
+++ b/.changeset/smooth-shirts-guess.md
@@ -1,0 +1,12 @@
+---
+'@compiled/eslint-plugin': minor
+'@compiled/babel-plugin': patch
+'@compiled/react': patch
+---
+
+Add detectConflictWithOtherLibraries and onlyRunIfImportingCompiled config options to jsx-pragma ESLint rule. Both are set to true by default, hence the breaking change.
+
+`detectConflictWithOtherLibraries` raises a linting error if `css` or `jsx` is imported from `@emotion/react` (or `@emotion/core`) in the same file
+as a Compiled import. Set to true by default.
+
+`onlyRunIfImportingCompiled` sets this rule to only suggest adding the JSX pragma if the `css` or `cssMap` functions are imported from `@compiled/react`, as opposed to whenever the `css` attribute is detected at all. Set to false by default.

--- a/packages/eslint-plugin/src/rules/jsx-pragma/README.md
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/README.md
@@ -1,6 +1,6 @@
 # `jsx-pragma`
 
-Ensure that the Compiled JSX pragma is set when using the `css` prop.
+Ensure that the Compiled JSX pragma is set when using the `css` or `xcss` prop.
 
 A JSX pragma is a comment that declares where to import the JSX namespace from. It looks
 like one of the following:
@@ -49,6 +49,15 @@ import { jsx } from '@compiled/react';
 import '@compiled/react';
 
 <div css={{ display: 'block' }} />;
+     ^^^ missing pragma
+```
+
+```js
+// [{ "pragma": "jsxImportSource" }]
+
+import { Box } from '@atlaskit/primitives';
+
+<Box xcss={{ borderStyle: 'solid' }} />;
      ^^^ missing pragma
 ```
 
@@ -108,7 +117,9 @@ Raises a linting error if `css` or `jsx` is imported from `@emotion/react` (or `
 as a Compiled import.
 
 This is important as Emotion can't be used with Compiled in the same file, and ignoring this linting error will
-result in a confusing runtime error. This defaults to `true`.
+result in a confusing runtime error.
+
+This defaults to `true`.
 
 ### `onlyRunIfImportingCompiled: boolean`
 
@@ -116,5 +127,7 @@ By default, the `jsx-pragma` rule suggests adding the Compiled JSX pragma whenev
 used. This may not be ideal if your codebase uses a mix of Compiled and other libraries (e.g. Emotion,
 styled-components). Setting `onlyRunIfImportingCompiled` to true turns off this rule unless `css` or `cssMap`
 are imported from `@compiled/react`.
+
+Note that this option does not affect `xcss`.
 
 This option defaults to `false`.

--- a/packages/eslint-plugin/src/rules/jsx-pragma/README.md
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/README.md
@@ -1,6 +1,23 @@
 # `jsx-pragma`
 
-Enforce a jsx pragma is set when using the `css` prop.
+Ensure that the Compiled JSX pragma is set when using the `css` prop.
+
+A JSX pragma is a comment that declares where to import the JSX namespace from. It looks
+like one of the following:
+
+```js
+/** @jsx jsx */
+import { jsx } from '@compiled/react';
+```
+
+```js
+/** @jsxImportSource @compiled/react */
+import { jsx } from '@compiled/react';
+```
+
+For all Compiled usages, one of these should be used. See the
+[Emotion documentation](https://emotion.sh/docs/css-prop#jsx-pragma) for more details
+on how JSX pragmas work.
 
 ---
 
@@ -35,6 +52,17 @@ import '@compiled/react';
      ^^^ missing pragma
 ```
 
+```js
+// [{ "detectConflictWithOtherLibraries": true }]
+
+/** @jsx jsx */
+import { css } from '@compiled/react';
+import { jsx } from '@emotion/react';
+
+<div css={css({ display: 'block' })} />;
+          ^^^ cannot mix Compiled and Emotion
+```
+
 👍 Examples of **correct** code for this rule:
 
 ```js
@@ -52,6 +80,19 @@ import { jsx } from '@compiled/react';
 <div css={{ display: 'block' }} />
 ```
 
+```js
+// [{ "onlyRunIfImportingCompiled": true }]
+
+import { css } from '@emotion/react';
+<div css={css({ display: 'block' })} />;
+```
+
+```js
+// [{ "onlyRunIfImportingCompiled": true }]
+
+<div css={{ display: 'block' }} />
+```
+
 ## Options
 
 This rule supports the following options:
@@ -60,3 +101,20 @@ This rule supports the following options:
 
 What [JSX runtime](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) to adhere to,
 defaults to automatic.
+
+### `detectConflictWithOtherLibraries: boolean`
+
+Raises a linting error if `css` or `jsx` is imported from `@emotion/react` (or `@emotion/core`) in the same file
+as a Compiled import.
+
+This is important as Emotion can't be used with Compiled in the same file, and ignoring this linting error will
+result in a confusing runtime error. This defaults to `true`.
+
+### `onlyRunIfImportingCompiled: boolean`
+
+By default, the `jsx-pragma` rule suggests adding the Compiled JSX pragma whenever the `css` attribute is being
+used. This may not be ideal if your codebase uses a mix of Compiled and other libraries (e.g. Emotion,
+styled-components). Setting `onlyRunIfImportingCompiled` to true turns off this rule unless `css` or `cssMap`
+are imported from `@compiled/react`.
+
+This option defaults to `false`.

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
@@ -67,16 +67,8 @@ tester.run('jsx-pragma', jsxPragmaRule, {
     {
       name: "when onlyRunIfImportingCompiled is true and Emotion css is used, don't override with Compiled (with Emotion css and jsx)",
       code: `
+        /** @jsx jsx */
         import { css, jsx } from '@emotion/react';
-        <div css={css({ display: 'block' })} />
-      `,
-      options: [{ onlyRunIfImportingCompiled: true }],
-    },
-    {
-      name: "when onlyRunIfImportingCompiled is true, Emotion css is used and Compiled styled is used, don't add jsx",
-      code: `
-        import { css } from '@emotion/react';
-        import { styled } from '@compiled/react';
         <div css={css({ display: 'block' })} />
       `,
       options: [{ onlyRunIfImportingCompiled: true }],
@@ -366,6 +358,33 @@ import * as React from 'react';
       ],
     },
     {
+      name: 'should error if Emotion css and Compiled styled are used',
+      code: `
+        import { css } from '@emotion/react';
+        import { styled } from '@compiled/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      errors: [
+        {
+          messageId: 'emotionAndCompiledConflict',
+        },
+      ],
+    },
+    {
+      name: 'should error if Emotion css and Compiled styled are used (onlyRunIfImportingCompiled = true)',
+      code: `
+        import { css } from '@emotion/react';
+        import { styled } from '@compiled/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
+      errors: [
+        {
+          messageId: 'emotionAndCompiledConflict',
+        },
+      ],
+    },
+    {
       name: 'should error when both Emotion and Compiled css APIs are being used',
       code: `
         /** @jsx jsx */
@@ -416,6 +435,40 @@ import * as React from 'react';
       ],
     },
     {
+      name: 'should error when both Emotion jsx API and Compiled css API are being used (with JSX pragma)',
+      code: `
+        /** @jsx jsx */
+        import * as React from 'react';
+        import { jsx } from '@emotion/react';
+        import { css } from '@compiled/react';
+
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
+      errors: [
+        {
+          messageId: 'emotionAndCompiledConflict',
+        },
+      ],
+    },
+    {
+      name: 'should error when both Emotion css API and Compiled jsx API are being used (with JSX pragma)',
+      code: `
+        /** @jsx jsx */
+        import * as React from 'react';
+        import { jsx } from '@compiled/react';
+        import { css } from '@emotion/react';
+
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true, runtime: 'classic' }],
+      errors: [
+        {
+          messageId: 'emotionAndCompiledConflict',
+        },
+      ],
+    },
+    {
       name: 'should error when both Emotion and Compiled css APIs are being used (with @emotion/core)',
       code: `
         /** @jsx jsxEmotion */
@@ -433,7 +486,7 @@ import * as React from 'react';
       ],
     },
     {
-      name: 'should error when both Emotion and Compiled css APIs are being used (onlyRunIfImportingCompiled on)',
+      name: 'should error when both Emotion and Compiled css APIs are being used (onlyRunIfImportingCompiled = true)',
       code: `
         import * as React from 'react';
         import { css } from '@emotion/react';

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
@@ -7,57 +7,82 @@ tester.run('jsx-pragma', jsxPragmaRule, {
       /** @jsxImportSource @compiled/react */
       <div css={{ display: 'block' }} />
     `,
-    `
-      <AnotherComponent className={xcss} />
-    `,
-    `
-      <div className={anythingElse} />
-    `,
-    `
-      /** @jsxImportSource @compiled/react */
-      <div className={xcss} />
-    `,
-    `
-      /** @jsxImportSource @compiled/react */
-      <div className={innerXcss} />
-    `,
     {
       code: `
-      /** @jsxImportSource @compiled/react */
-      <div css={{ display: 'block' }} />
-    `,
+        /** @jsxImportSource @compiled/react */
+        <div css={{ display: 'block' }} />
+      `,
       options: [{ runtime: 'automatic' }],
     },
     {
       code: `
-      /** @jsx jsx */
-      import { jsx } from '@compiled/react';
-      <div css={{ display: 'block' }} />
-    `,
+        /** @jsx jsx */
+        import { jsx } from '@compiled/react';
+        <div css={{ display: 'block' }} />
+      `,
       options: [{ runtime: 'classic' }],
+    },
+    {
+      name: "don't error when @jsxImportSource and Compiled css API are being used",
+      code: `
+        /** @jsxImportSource @compiled/react */
+        import { css } from '@compiled/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ runtime: 'automatic' }],
+    },
+    {
+      code: `
+        /** @jsx jsx */
+        import { css, jsx } from '@compiled/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ runtime: 'classic' }],
+    },
+    {
+      name: "when onlyRunIfImportingCompiled is true and Compiled is not imported, don't override with Compiled",
+      code: `<div css={{ display: 'block' }} />`,
+      options: [{ onlyRunIfImportingCompiled: true }],
+    },
+    {
+      name: "when onlyRunIfImportingCompiled is true and Emotion jsx is used, don't override with Compiled",
+      code: `
+        /** @jsx jsx */
+        import { jsx } from '@emotion/react';
+        <>
+          <div css={{ display: 'block' }} />
+          <div css={[ someStyles ]} />
+        </>
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
+    },
+    {
+      name: "when onlyRunIfImportingCompiled is true and Emotion css is used, don't override with Compiled (with Emotion css function)",
+      code: `
+        import { css } from '@emotion/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
+    },
+    {
+      name: "when onlyRunIfImportingCompiled is true and Emotion css is used, don't override with Compiled (with Emotion css and jsx)",
+      code: `
+        import { css, jsx } from '@emotion/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
+    },
+    {
+      name: "when onlyRunIfImportingCompiled is true, Emotion css is used and Compiled styled is used, don't add jsx",
+      code: `
+        import { css } from '@emotion/react';
+        import { styled } from '@compiled/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
     },
   ],
   invalid: [
-    {
-      code: `
-      <div className={xcss} />
-      `,
-      output: `
-      /** @jsxImportSource @compiled/react */
-<div className={xcss} />
-      `,
-      errors: [{ messageId: 'missingPragmaXCSS' }],
-    },
-    {
-      code: `
-      <div className={innerXcss} />
-    `,
-      output: `
-      /** @jsxImportSource @compiled/react */
-<div className={innerXcss} />
-    `,
-      errors: [{ messageId: 'missingPragmaXCSS' }],
-    },
     {
       code: `<div css={{ display: 'block' }} />`,
       output: `/** @jsx jsx */
@@ -337,6 +362,89 @@ import * as React from 'react';
       errors: [
         {
           messageId: 'missingPragma',
+        },
+      ],
+    },
+    {
+      name: 'should error when both Emotion and Compiled css APIs are being used',
+      code: `
+        /** @jsx jsx */
+        import * as React from 'react';
+        import { css, jsx } from '@emotion/react';
+        import { css as cssCompiled } from '@compiled/react';
+
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
+      errors: [
+        {
+          messageId: 'emotionAndCompiledConflict',
+        },
+      ],
+    },
+    {
+      name: 'should error when both Emotion and Compiled css APIs are being used (alt)',
+      code: `
+        /** @jsx jsxEmotion */
+        import * as React from 'react';
+        import { css, jsx as jsxEmotion } from '@emotion/react';
+        import { css as cssCompiled } from '@compiled/react';
+
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
+      errors: [
+        {
+          messageId: 'emotionAndCompiledConflict',
+        },
+      ],
+    },
+    {
+      name: 'should error when both Emotion jsx API and Compiled css API are being used',
+      code: `
+        import * as React from 'react';
+        import { jsx } from '@emotion/react';
+        import { css } from '@compiled/react';
+
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
+      errors: [
+        {
+          messageId: 'emotionAndCompiledConflict',
+        },
+      ],
+    },
+    {
+      name: 'should error when both Emotion and Compiled css APIs are being used (with @emotion/core)',
+      code: `
+        /** @jsx jsxEmotion */
+        import * as React from 'react';
+        import { jsx } from '@emotion/core';
+        import { css as cssCompiled } from '@compiled/react';
+
+        <div css={{ display: 'block' }} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
+      errors: [
+        {
+          messageId: 'emotionAndCompiledConflict',
+        },
+      ],
+    },
+    {
+      name: 'should error when both Emotion and Compiled css APIs are being used (onlyRunIfImportingCompiled on)',
+      code: `
+        import * as React from 'react';
+        import { css } from '@emotion/react';
+        import { css as cssCompiled } from '@compiled/react';
+
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ onlyRunIfImportingCompiled: true }],
+      errors: [
+        {
+          messageId: 'emotionAndCompiledConflict',
         },
       ],
     },

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
@@ -7,6 +7,20 @@ tester.run('jsx-pragma', jsxPragmaRule, {
       /** @jsxImportSource @compiled/react */
       <div css={{ display: 'block' }} />
     `,
+    `
+      <AnotherComponent className={xcss} />
+    `,
+    `
+      <div className={anythingElse} />
+    `,
+    `
+      /** @jsxImportSource @compiled/react */
+      <div className={xcss} />
+    `,
+    `
+      /** @jsxImportSource @compiled/react */
+      <div className={innerXcss} />
+    `,
     {
       code: `
         /** @jsxImportSource @compiled/react */
@@ -75,6 +89,26 @@ tester.run('jsx-pragma', jsxPragmaRule, {
     },
   ],
   invalid: [
+    {
+      code: `
+      <div className={xcss} />
+      `,
+      output: `
+      /** @jsxImportSource @compiled/react */
+<div className={xcss} />
+      `,
+      errors: [{ messageId: 'missingPragmaXCSS' }],
+    },
+    {
+      code: `
+      <div className={innerXcss} />
+    `,
+      output: `
+      /** @jsxImportSource @compiled/react */
+<div className={innerXcss} />
+    `,
+      errors: [{ messageId: 'missingPragmaXCSS' }],
+    },
     {
       code: `<div css={{ display: 'block' }} />`,
       output: `/** @jsx jsx */

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
@@ -1,11 +1,64 @@
 import type { Rule, SourceCode } from 'eslint';
 import type { ImportDeclaration, ImportDefaultSpecifier, ImportNamespaceSpecifier } from 'estree';
 
-import { findCompiledImportDeclarations, findDeclarationWithImport } from '../../utils/ast';
+import {
+  findDeclarationWithImport,
+  findLibraryImportDeclarations,
+  usesCompiledCssAPI,
+} from '../../utils/ast';
 import { addImportToDeclaration, removeImportFromDeclaration } from '../../utils/ast-to-string';
+import { findJsxImportSourcePragma, findJsxPragma } from '../../utils/jsx';
 
 type Options = {
+  detectConflictWithOtherLibraries: boolean;
+  onlyRunIfImportingCompiled: boolean;
   runtime: 'classic' | 'automatic';
+};
+
+type OtherLibraries = '@emotion/core' | '@emotion/react';
+
+/**
+ * Given a query and an object, finds whether the query appears in the object's keys.
+ *
+ * Gets around pesky type-checking false positives.
+ *
+ * @param query
+ * @param myObject
+ * @returns whether query is in the object's keys
+ */
+function inObjectKeys<T extends string>(query: any, myObject: Record<T, any>): query is T {
+  return Object.keys(myObject).includes(query);
+}
+
+const getOtherLibraryImports = (context: Rule.RuleContext): OtherLibraries[] => {
+  const PROBLEMATIC_IMPORT_SPECIFIERS: readonly string[] = ['css', 'jsx'];
+
+  const detectedLibraries: Record<OtherLibraries, number> = {
+    '@emotion/core': 0,
+    '@emotion/react': 0,
+  };
+  const otherLibraryImports = findLibraryImportDeclarations(
+    context,
+    Object.keys(detectedLibraries)
+  );
+
+  for (const importDecl of otherLibraryImports) {
+    for (const specifier of importDecl.specifiers) {
+      if (
+        specifier.type === 'ImportSpecifier' &&
+        PROBLEMATIC_IMPORT_SPECIFIERS.includes(specifier.imported.name)
+      ) {
+        const sourceLibrary = importDecl.source.value;
+        if (inObjectKeys(sourceLibrary, detectedLibraries)) {
+          detectedLibraries[sourceLibrary]++;
+        }
+      }
+    }
+  }
+
+  return (Object.keys(detectedLibraries) as OtherLibraries[]).filter(
+    (name) => detectedLibraries[name as OtherLibraries] > 0
+  );
 };
 
 const findReactDeclarationWithDefaultImport = (
@@ -28,6 +81,8 @@ const findReactDeclarationWithDefaultImport = (
 };
 
 function createFixer(context: Rule.RuleContext, source: SourceCode, options: Options) {
+  const compiledImports = findLibraryImportDeclarations(context);
+
   return function* fix(fixer: Rule.RuleFixer) {
     const pragma = options.runtime === 'classic' ? '@jsx jsx' : '@jsxImportSource @compiled/react';
     const reactImport = findReactDeclarationWithDefaultImport(source);
@@ -47,8 +102,6 @@ function createFixer(context: Rule.RuleContext, source: SourceCode, options: Opt
     }
 
     yield fixer.insertTextBefore(source.ast.body[0], `/** ${pragma} */\n`);
-
-    const compiledImports = findCompiledImportDeclarations(context);
 
     if (options.runtime === 'classic' && !findDeclarationWithImport(compiledImports, 'jsx')) {
       // jsx import is missing time to add one
@@ -84,6 +137,10 @@ export const jsxPragmaRule: Rule.RuleModule = {
         'Use of the jsxImportSource pragma (automatic runtime) is preferred over the jsx pragma (classic runtime).',
       preferJsx:
         'Use of the jsx pragma (classic runtime) is preferred over the jsx pragma (automatic runtime).',
+
+      // TODO: test whether Compiled's styled works with Emotion's css
+      emotionAndCompiledConflict:
+        "You can't have css or jsx be imported from both Emotion and Compiled in the same file - this will cause type-checking and runtime errors. Consider changing all of your Emotion imports from `@emotion/react` to `@compiled/react`.",
     },
     schema: [
       {
@@ -93,20 +150,34 @@ export const jsxPragmaRule: Rule.RuleModule = {
             type: 'string',
             pattern: '^(classic|automatic)$',
           },
+          detectConflictWithOtherLibraries: {
+            type: 'boolean',
+          },
+          onlyRunIfImportingCompiled: {
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
       },
     ],
     type: 'problem',
   },
+
   create(context) {
-    const options: Options = context.options[0] || { runtime: 'automatic' };
+    const optionsRaw = context.options[0] || {};
+    const options: Options = {
+      detectConflictWithOtherLibraries: optionsRaw.detectConflictWithOtherLibraries ?? true,
+      onlyRunIfImportingCompiled: optionsRaw.onlyRunIfImportingCompiled ?? false,
+      runtime: optionsRaw.runtime ?? 'automatic',
+    };
+
     const source = context.getSourceCode();
     const comments = source.getAllComments();
-    const jsxPragma = comments.find((n) => n.value.indexOf('@jsx jsx') > -1);
-    const jsxImportSourcePragma = comments.find(
-      (n) => n.value.indexOf('@jsxImportSource @compiled/react') > -1
-    );
+
+    const compiledImports = findLibraryImportDeclarations(context);
+    const otherLibraryImports = getOtherLibraryImports(context);
+    const jsxPragma = findJsxPragma(comments, compiledImports);
+    const jsxImportSourcePragma = findJsxImportSourcePragma(comments);
 
     return {
       Program() {
@@ -117,7 +188,6 @@ export const jsxPragmaRule: Rule.RuleModule = {
             *fix(fixer) {
               yield fixer.replaceText(jsxPragma as any, '/** @jsxImportSource @compiled/react */');
 
-              const compiledImports = findCompiledImportDeclarations(context);
               const jsxImport = findDeclarationWithImport(compiledImports, 'jsx');
               if (!jsxImport) {
                 return;
@@ -144,7 +214,7 @@ export const jsxPragmaRule: Rule.RuleModule = {
             *fix(fixer) {
               yield fixer.replaceText(jsxImportSourcePragma as any, '/** @jsx jsx */');
 
-              const compiledImports = findCompiledImportDeclarations(context);
+              const compiledImports = findLibraryImportDeclarations(context);
               const jsxImport = findDeclarationWithImport(compiledImports, 'jsx');
               if (jsxImport) {
                 return;
@@ -186,17 +256,30 @@ export const jsxPragmaRule: Rule.RuleModule = {
         }
       },
 
-      JSXAttribute(node: any) {
-        if (jsxPragma || jsxImportSourcePragma || node.name.name !== 'css') {
+      'JSXAttribute[name.name=/^css$/]': (node: Rule.Node) => {
+        if (node.type !== 'JSXAttribute' || jsxPragma || jsxImportSourcePragma) {
+          return;
+        }
+
+        if (options.onlyRunIfImportingCompiled && !usesCompiledCssAPI(compiledImports)) {
+          return;
+        }
+
+        if (options.detectConflictWithOtherLibraries && otherLibraryImports.length) {
+          context.report({
+            node,
+            messageId: 'emotionAndCompiledConflict',
+          });
+
           return;
         }
 
         context.report({
+          node,
           messageId: 'missingPragma',
           data: {
             pragma: options.runtime === 'classic' ? 'jsx' : 'jsxImportSource',
           },
-          node,
           fix: createFixer(context, source, options),
         });
       },

--- a/packages/eslint-plugin/src/utils/ast.ts
+++ b/packages/eslint-plugin/src/utils/ast.ts
@@ -96,21 +96,21 @@ export const findDeclarationWithImport = (
   );
 };
 
-const COMPILED_CSS_IMPORTS: readonly string[] = ['css', 'cssMap'];
+const COMPILED_IMPORTS: readonly string[] = ['css', 'cssMap', 'styled', 'jsx'];
 
 /**
- * Given an array of import statements, return whether there are any css and cssMap imports
+ * Given an array of import statements, return whether there are any Compiled imports
  * from `@compiled/react`.
  *
  * @param source an array of import declarations
- * @returns whether any Compiled css APIs are being imported from @compiled/react (css, cssMap)
+ * @returns whether any Compiled APIs are being imported from @compiled/react
  */
-export const usesCompiledCssAPI = (imports: ImportDeclaration[]): boolean => {
+export const usesCompiledAPI = (imports: ImportDeclaration[]): boolean => {
   for (const importDeclaration of imports) {
     for (const specifier of importDeclaration.specifiers) {
       if (
         specifier.type === 'ImportSpecifier' &&
-        COMPILED_CSS_IMPORTS.includes(specifier.imported.name)
+        COMPILED_IMPORTS.includes(specifier.imported.name)
       ) {
         return true;
       }

--- a/packages/eslint-plugin/src/utils/create-no-exported-rule/is-styled-component.ts
+++ b/packages/eslint-plugin/src/utils/create-no-exported-rule/is-styled-component.ts
@@ -1,7 +1,7 @@
 import type { Rule } from 'eslint';
 import type { MemberExpression, Identifier } from 'estree';
 
-import { findCompiledImportDeclarations } from '../ast';
+import { findLibraryImportDeclarations } from '../ast';
 
 type Node = Rule.Node;
 type RuleContext = Rule.RuleContext;
@@ -48,7 +48,7 @@ const findNode = (nodes: Node[]): MemberExpression | Identifier | undefined => {
  * @returns
  */
 const getStyledImportSpecifierName = (context: RuleContext): string | undefined => {
-  const compiledImports = findCompiledImportDeclarations(context);
+  const compiledImports = findLibraryImportDeclarations(context);
 
   return compiledImports[0].specifiers.find(
     (spec) => spec.type === 'ImportSpecifier' && spec.imported.name === 'styled'

--- a/packages/eslint-plugin/src/utils/jsx.ts
+++ b/packages/eslint-plugin/src/utils/jsx.ts
@@ -1,0 +1,43 @@
+import type { Comment, ImportDeclaration } from 'estree';
+
+/**
+ * Return the "@ jsx jsx" JSX pragma (i.e. a comment that has special
+ * meaning to the TypeScript compiler), if it exists AND if jsx is
+ * imported from "@compiled/react".
+ */
+export const findJsxPragma = (
+  comments: Comment[],
+  compiledImports: ImportDeclaration[]
+): Comment | undefined => {
+  let jsxPragma: Comment | undefined = undefined;
+  // It is surprisingly possible to specify the JSX pragma with a
+  // value other than "jsx", e.g. "@ jsx myCustomJsxFunction", as long
+  // as that is imported somehow (e.g. import { myCustomJsxFunction } from 'xyz').
+  let jsxPragmaName = '';
+
+  for (const comment of comments) {
+    const match = /@jsx (\w+)/.exec(comment.value);
+    if (match) {
+      jsxPragma = comment;
+      jsxPragmaName = match[1];
+    }
+  }
+
+  if (!jsxPragma) return undefined;
+
+  for (const importDecl of compiledImports) {
+    for (const specifier of importDecl.specifiers) {
+      const jsxPragmaUsesCompiled =
+        specifier.type === 'ImportSpecifier' &&
+        specifier.imported.name === 'jsx' &&
+        specifier.local.name === jsxPragmaName;
+
+      if (jsxPragmaUsesCompiled) return jsxPragma;
+    }
+  }
+
+  return undefined;
+};
+
+export const findJsxImportSourcePragma = (comments: Comment[]): Comment | undefined =>
+  comments.find((n) => n.value.indexOf('@jsxImportSource @compiled/react') > -1);


### PR DESCRIPTION
Add two config options to the `jsx-pragma` eslint rule:

* `detectConflictWithOtherLibraries` (**true** by default): lint error if importing any Emotion libraries in the same file as Compiled imports. Compiled styled/css/jsx/etc is not compatible with Emotion's css/jsx
* `onlyRunIfImportingCompiled` (false by default): don't give a lint error for the `css` attribute if there are no Compiled imports in the file. This allows for Emotion's `css` API and Compiled's `css` API to be used in the same repo (albeit not the same file). This doesn't apply to `xcss`.

- [x] Check if `detectConflictWithOtherLibraries` and `onlyRunIfImportingCompiled` need to include `xcss`
  - should be no if I understand [this PR](https://github.com/atlassian-labs/compiled/pull/1533/files#diff-b40b66ef02522d9d4bab5d1e1406b62df730ada7d15aef81918b72bd748e99ad) correctly?
- [x] Check if using Compiled styled and Emotion css works in the same file
    - Answer: no! As long as `@compiled/react` is in scope, funny things happen when mixing with Emotion haha
- [x] Check documentation
- [x] Create changeset