### PR TITLE
Fix xcss eslint rules not compatible with eslint v7

### DIFF
--- a/.changeset/eighty-chefs-remain.md
+++ b/.changeset/eighty-chefs-remain.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Fix xcss eslint rules not compatible with eslint v7

--- a/packages/eslint-plugin/src/rules/no-js-xcss/index.ts
+++ b/packages/eslint-plugin/src/rules/no-js-xcss/index.ts
@@ -17,7 +17,7 @@ export const noJavaScriptXCSSRule: Rule.RuleModule = {
   create(context) {
     return {
       'JSXAttribute[name.name=/[xX]css$/]': (node: Rule.Node) => {
-        if (node.type === 'JSXAttribute' && !context.filename.endsWith('.tsx')) {
+        if (node.type === 'JSXAttribute' && !context.getFilename().endsWith('.tsx')) {
           context.report({
             node: node.name,
             messageId: 'no-js-xcss',

--- a/packages/eslint-plugin/src/rules/no-suppress-xcss/index.ts
+++ b/packages/eslint-plugin/src/rules/no-suppress-xcss/index.ts
@@ -5,7 +5,7 @@ function nodeIsTypeSuppressed(context: Rule.RuleContext, node: Rule.Node) {
     return;
   }
 
-  const comments = context.sourceCode.getAllComments();
+  const comments = context.getSourceCode().getAllComments();
 
   for (const comment of comments) {
     if (!comment.loc) {


### PR DESCRIPTION
Fix xcss eslint rules not being compatible with eslint v7.

`filename` and `sourceCode` were added somewhere in eslint v8.40 as a replacement for the now-deprecated `getFIleName()` and `getSourceCode()`. Not everyone is using eslint v8.40 and above 🫠

cc @kylorhall-atlassian