### PR TITLE
Add `ignoreIfImported` and `excludeReactComponents` options to `no-css-prop-without-css-function` ESLint rule

### DIFF
--- a/.changeset/silly-eels-vanish.md
+++ b/.changeset/silly-eels-vanish.md
@@ -1,0 +1,8 @@
+---
+'@compiled/eslint-plugin': minor
+---
+
+Add two more configuration options to the `no-css-prop-without-css-function` rule:
+
+- `ignoreIfImported` accepts an array of library names. If specified, rule execution will be skipped for all files that import any of the specified libraries (e.g. `@emotion/react`). By default, this is an empty array.
+- `excludeReactComponents` is a boolean that determines whether this rule should skip all React components (as opposed to plain HTML elements). False by default.

--- a/packages/eslint-plugin/src/rules/jsx-pragma/README.md
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/README.md
@@ -106,7 +106,7 @@ import { css } from '@emotion/react';
 
 This rule supports the following options:
 
-### `runtime: 'classic' | 'automatic`
+### `runtime: 'classic' | 'automatic'`
 
 What [JSX runtime](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) to adhere to,
 defaults to automatic.

--- a/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/README.md
+++ b/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/README.md
@@ -82,3 +82,20 @@ const CoolComponent = () => {
   return <MyComponent css={styles} />;
 }
 ```
+
+## Options
+
+This rule supports the following options:
+
+### `ignoreIfImported: string[]`
+
+An array of libraries, each specified as a string (e.g. `['@emotion/core', '@emotion/react']`). If any of these libraries is detected as being imported in the current file, then this ESLint rule does not run.
+
+This is useful if you do not want `no-css-prop-without-css-function` to conflict with files where Emotion's JSX pragma is being used (such as the below example).
+
+```tsx
+/** @jsx jsx */
+import { jsx } from '@emotion/react';
+
+// ...
+```

--- a/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/README.md
+++ b/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/README.md
@@ -99,3 +99,11 @@ import { jsx } from '@emotion/react';
 
 // ...
 ```
+
+This is an empty array by default.
+
+### `excludeReactComponents: boolean`
+
+Whether to exclude `css` attributes of React components from being affected by this ESLint rule. We assume that an element is a React component if it starts with a capital letter.
+
+This is false by default.

--- a/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/__tests__/rule.test.ts
@@ -157,6 +157,12 @@ tester.run(
         `,
         options: [{ ignoreIfImported: ['@emotion/react'] }],
       },
+      {
+        code: outdent`
+          <CustomComponent css={{ color: 'blue' }} />
+        `,
+        options: [{ excludeReactComponents: true }],
+      },
     ],
 
     invalid: [

--- a/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-css-prop-without-css-function/__tests__/rule.test.ts
@@ -130,6 +130,33 @@ tester.run(
         );
       }
       `,
+      {
+        code: outdent`
+          /** @jsx jsx */
+          import { jsx } from '@emotion/react';
+
+          <div css={{ color: 'blue' }} />
+        `,
+        options: [{ ignoreIfImported: ['@emotion/react'] }],
+      },
+      {
+        code: outdent`
+          /** @jsx jsx */
+          import { jsx } from '@emotion/core';
+
+          <div css={{ color: 'blue' }} />
+        `,
+        options: [{ ignoreIfImported: ['styled-components', '@emotion/core'] }],
+      },
+      {
+        code: outdent`
+          import { css } from '@compiled/react';
+          import { jsx } from '@emotion/react';
+
+          <div css={{ color: 'blue' }} />
+        `,
+        options: [{ ignoreIfImported: ['@emotion/react'] }],
+      },
     ],
 
     invalid: [
@@ -450,6 +477,24 @@ tester.run(
 
           <MyComponent css={styles} />;
         `,
+      },
+      {
+        errors: [
+          {
+            messageId: 'noCssFunction',
+          },
+        ],
+        code: outdent`
+          import { css } from '@compiled/react';
+
+          <div css={{ color: 'blue' }} />
+        `,
+        output: outdent`
+          import { css } from '@compiled/react';
+
+          <div css={css({ color: 'blue' })} />
+        `,
+        options: [{ ignoreIfImported: ['@emotion/react'] }],
       },
     ],
   }

--- a/packages/eslint-plugin/src/utils/ast.ts
+++ b/packages/eslint-plugin/src/utils/ast.ts
@@ -4,6 +4,14 @@ import type { ImportDeclaration, ImportSpecifier } from 'estree';
 
 import { COMPILED_IMPORT } from './constants';
 
+// WARNING
+// context.getSourceCode() is deprecated, but we still use it here because
+// the newer alternative, context.sourceCode, is not supported below
+// ESLint 8.40.
+//
+// We can replace this with context.sourceCode once we are certain that
+// all Compiled users are using ESLint 8.40+.
+
 /**
  * Given a rule, return all imports from the libraries defined in `source`
  * in the file. If `source` is not specified, return all import statements
@@ -30,21 +38,26 @@ export const findLibraryImportDeclarations = (
 };
 
 /**
- * Re-implementation of findCompiledImportDeclarations for typescript-eslint.
+ * Re-implementation of findLibraryImportDeclarations for typescript-eslint.
  *
- * Given a rule, return any `@compiled/react` import declarations in the source code.
+ * Given a rule, return all imports from the libraries defined in `source`
+ * in the file. If `source` is not specified, return all import statements
+ * from `@compiled/react`.
  *
  * @param context Rule context
  * @returns a list of import declarations
  */
-export const findTSCompiledImportDeclarations = (
-  context: TSESLint.RuleContext<string, readonly unknown[]>
+export const findTSLibraryImportDeclarations = (
+  context: TSESLint.RuleContext<string, readonly unknown[]>,
+  sources = [COMPILED_IMPORT]
 ): TSESTree.ImportDeclaration[] => {
   return context
     .getSourceCode()
     .ast.body.filter(
       (node): node is TSESTree.ImportDeclaration =>
-        node.type === 'ImportDeclaration' && node.source.value === COMPILED_IMPORT
+        node.type === 'ImportDeclaration' &&
+        typeof node.source.value === 'string' &&
+        sources.includes(node.source.value)
     );
 };
 

--- a/packages/eslint-plugin/src/utils/ast.ts
+++ b/packages/eslint-plugin/src/utils/ast.ts
@@ -61,16 +61,20 @@ export const findTSLibraryImportDeclarations = (
     );
 };
 
+const isDOMElementName = (elementName: string): boolean =>
+  elementName.charAt(0) !== elementName.charAt(0).toUpperCase() &&
+  elementName.charAt(0) === elementName.charAt(0).toLowerCase();
+
 /**
  * Returns whether the element is a DOM element, which is all lowercase...
  * as opposed to a React component, which is capitalized.
  *
- * @param elementName
+ * @param jsxElement the JSX element to check
  * @returns whether the element is a DOM element (true) or a React component (false)
  */
-export const isDOMElement = (elementName: string): boolean =>
-  elementName.charAt(0) !== elementName.charAt(0).toUpperCase() &&
-  elementName.charAt(0) === elementName.charAt(0).toLowerCase();
+export const isNodeDOMElement = (jsxElement: TSESTree.JSXOpeningElement): boolean => {
+  return jsxElement.name.type === 'JSXIdentifier' && isDOMElementName(jsxElement.name.name);
+};
 
 /**
  * Traverses up the AST until it reaches a JSXOpeningElement. Used in conjunction with


### PR DESCRIPTION
There are some edge cases that `no-css-prop-without-css-function` didn't handle well when used in a repository with both Emotion and Compiled. This PR provides some more configuration options that get around these edge cases:

### Files that use Emotion

This is perfectly normal Emotion syntax:

```tsx
/** @jsx jsx */
import { jsx } from '@emotion/react';

<div css={{ color: 'blue' }} />
```

We don't want to add Compiled to a file that already has Emotion in it. `ignoreIfImported` provides a way to exclude files that use Emotion, for example we can exclude any file that imports something from `@emotion/react` and `@emotion/core`.

### Using `css` on atlaskit components

```tsx
import Button from '@atlaskit/button';

<Button css={{ color: 'blue' }} />
```

`@atlaskit` components still use Emotion (as of writing :eyes:), so converting `css={{ color: 'blue' }}` to `css={css({ color: 'blue' })}` and importing `import { css } from '@compiled/react'` can cause type errors.

`excludeReactComponents` lets us get around this issue.