### PR TITLE
Fix xcss prop not being compatible with Emotion

### DIFF
--- a/.changeset/nasty-seas-ring.md
+++ b/.changeset/nasty-seas-ring.md
@@ -1,0 +1,8 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+Fix xcss being incompatible with codebases that use Emotion and Compiled:
+
+- Add `processXcss` option to `@compiled/babel-plugin`. If `processXcss` is set to false, `xcss` usages will be ignored, and will not be processed as Compiled. (Note that `xcss` is currently implemented in Atlassian Design System using Emotion.) Defaults to `true`.
+- `css` usages in a file will no longer be processed as Compiled if `xcss` is used in the same file, so long as there is not a `@compiled/react` import specified in that file.

--- a/.changeset/nasty-seas-ring.md
+++ b/.changeset/nasty-seas-ring.md
@@ -1,5 +1,5 @@
 ---
-'@compiled/babel-plugin': minor
+'@compiled/babel-plugin': patch
 ---
 
 Fix xcss being incompatible with codebases that use Emotion and Compiled:

--- a/packages/babel-plugin/src/types.ts
+++ b/packages/babel-plugin/src/types.ts
@@ -75,6 +75,14 @@ export interface PluginOptions {
    * Default to `undefined`
    */
   classNameCompressionMap?: { [index: string]: string };
+
+  /**
+   * Whether Compiled should process usages of xcss in the codebase.
+   * Disable this if xcss is not implemented in your codebase using Compiled's xcss functionality.
+   *
+   * Default to `true`
+   */
+  processXcss?: boolean;
 }
 
 export interface State extends PluginPass {
@@ -100,6 +108,8 @@ export interface State extends PluginPass {
     styled?: string;
     cssMap?: string;
   };
+
+  usesXcss?: boolean;
 
   importedCompiledImports?: {
     css?: string;

--- a/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
+++ b/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
@@ -199,6 +199,11 @@ describe('xcss prop transformation', () => {
     `
     );
 
+    // Ideally this shouldn't import @compiled/react/runtime at all because those
+    // are unused, and xcss runs at runtime here.
+    //
+    // Tree-shaking should get rid of these, but not adding these imports in the first
+    // place is something we could do in a future PR perhaps.
     expect(result).toMatchInlineSnapshot(`
       "import * as React from "react";
       import { ax, ix, CC, CS } from "@compiled/react/runtime";
@@ -216,6 +221,7 @@ describe('xcss prop transformation', () => {
     const result = transform(
       `
       import { cssMap } from '@compiled/react';
+      import Button from '@atlaskit/button';
 
       const stylesOne = cssMap({ text: { color: 'red' } })
       const stylesTwo = cssMap({ text: { color: 'blue' } })
@@ -234,6 +240,7 @@ describe('xcss prop transformation', () => {
     expect(result).toMatchInlineSnapshot(`
       "import * as React from "react";
       import { ax, ix, CC, CS } from "@compiled/react/runtime";
+      import Button from "@atlaskit/button";
       const _2 = "._syaz13q2{color:blue}";
       const _ = "._syaz5scu{color:red}";
       const stylesOne = {
@@ -264,6 +271,7 @@ describe('xcss prop transformation', () => {
     const result = transform(
       `
       import { Box, xcss } from '@atlaskit/primitives';
+      import Button from '@atlaskit/button';
       import { cssMap } from '@compiled/react';
 
       const styles = cssMap({ text: { color: 'red' } })
@@ -279,10 +287,12 @@ describe('xcss prop transformation', () => {
     `
     );
 
+    // Here, xcss runs at runtime
     expect(result).toMatchInlineSnapshot(`
       "import * as React from "react";
       import { ax, ix, CC, CS } from "@compiled/react/runtime";
       import { Box, xcss } from "@atlaskit/primitives";
+      import Button from "@atlaskit/button";
       const _ = "._syaz5scu{color:red}";
       const styles = {
         text: "_syaz5scu",
@@ -299,6 +309,187 @@ describe('xcss prop transformation', () => {
               <CS>{[_]}</CS>
               {<Button xcss={styles.text} />}
             </CC>
+          </>
+        );
+      }
+      "
+    `);
+  });
+
+  it('should not transform xcss if processXcss = false', () => {
+    const result = transform(
+      `
+      <Component xcss={{ color: 'red' }} />
+    `,
+      { processXcss: false }
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "<Component
+        xcss={{
+          color: "red",
+        }}
+      />;
+      "
+    `);
+  });
+});
+
+// Note: we don't support explicitly *importing* Compiled
+// in the same file as Emotion - this is something we lint against
+// through the jsx-pragma rule.
+//
+// We only choose to worry about cases where we don't have
+// two different CSS-in-JS libraries being explicitly imported,
+// i.e. xcss prop, where @compiled/react isn't imported but
+// @compiled/babel-plugin will still process the xcss usages.
+describe('xcss prop interacting with other libraries', () => {
+  it("xcss prop in primitive component shouldn't affect css prop from Emotion", () => {
+    const result = transform(
+      `
+      /** @jsx jsx */
+      import { css, jsx } from '@emotion/react';
+      import { Box, xcss } from '@atlaskit/primitives';
+      import Button from '@atlaskit/button';
+
+      export function Mixed() {
+        return (
+          <>
+            <Box xcss={xcss({ color: 'red' })} />
+            <div css={{ color: 'pink' }} />
+          </>
+        );
+      }
+    `
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "import { ax, ix, CC, CS } from "@compiled/react/runtime";
+      import { css, jsx } from "@emotion/react";
+      import { Box, xcss } from "@atlaskit/primitives";
+      import Button from "@atlaskit/button";
+      export function Mixed() {
+        return (
+          <>
+            <Box
+              xcss={xcss({
+                color: "red",
+              })}
+            />
+            <div
+              css={{
+                color: "pink",
+              }}
+            />
+          </>
+        );
+      }
+      "
+    `);
+  });
+
+  it("xcss prop shouldn't affect css prop from Emotion", () => {
+    const result = transform(
+      `
+      /** @jsx jsx */
+      import { css, jsx } from '@emotion/react';
+      import { Box } from '@atlaskit/primitives';
+
+      export function Mixed() {
+        return (
+          <>
+            <Box xcss={{ color: 'red' }} />
+            <div css={{ color: 'pink' }} />
+          </>
+        );
+      }
+    `
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "import { ax, ix, CC, CS } from "@compiled/react/runtime";
+      import { css, jsx } from "@emotion/react";
+      import { Box } from "@atlaskit/primitives";
+      const _ = "._syaz5scu{color:red}";
+      export function Mixed() {
+        return (
+          <>
+            <CC>
+              <CS>{[_]}</CS>
+              {<Box xcss={"_syaz5scu"} />}
+            </CC>
+            <div
+              css={{
+                color: "pink",
+              }}
+            />
+          </>
+        );
+      }
+      "
+    `);
+  });
+
+  it("xcss prop shouldn't affect styled prop from styled-components", () => {
+    const result = transform(
+      `
+      import { cssMap } from '@compiled/react';
+      import styled from 'styled-components';
+      import Button from '@atlaskit/button';
+
+      const stylesOne = cssMap({ text: { color: 'red' } });
+      const stylesTwo = cssMap({ text: { color: 'blue' } });
+
+      const Component = styled.div\`
+        color: green;
+      \`;
+
+      export function Mixed() {
+        return (
+          <>
+            <div css={{ color: 'pink' }} />
+            <Button xcss={stylesOne.text} />
+            <Button xcss={stylesTwo.text} />
+            <Component>hello world</Component>
+          </>
+        );
+      }
+    `
+    );
+
+    expect(result).toMatchInlineSnapshot(`
+      "import * as React from "react";
+      import { ax, ix, CC, CS } from "@compiled/react/runtime";
+      import styled from "styled-components";
+      import Button from "@atlaskit/button";
+      const _3 = "._syaz13q2{color:blue}";
+      const _2 = "._syaz5scu{color:red}";
+      const _ = "._syaz32ev{color:pink}";
+      const stylesOne = {
+        text: "_syaz5scu",
+      };
+      const stylesTwo = {
+        text: "_syaz13q2",
+      };
+      const Component = styled.div\`
+        color: green;
+      \`;
+      export function Mixed() {
+        return (
+          <>
+            <CC>
+              <CS>{[_]}</CS>
+              {<div className={ax(["_syaz32ev"])} />}
+            </CC>
+            <CC>
+              <CS>{[_2]}</CS>
+              {<Button xcss={stylesOne.text} />}
+            </CC>
+            <CC>
+              <CS>{[_3]}</CS>
+              {<Button xcss={stylesTwo.text} />}
+            </CC>
+            <Component>hello world</Component>
           </>
         );
       }


### PR DESCRIPTION
Fix xcss prop PR causing incompatibilities when both Emotion and Compiled are used in the same file and not the same component:

- `css` usages in a file will no longer be processed as Compiled if `xcss` is used in the same file, so long as there is not a `@compiled/react` import specified in that file.
- Add `processXcss` option to `@compiled/babel-plugin`. If `processXcss` is set to false, `xcss` usages will be ignored, and will not be processed as Compiled. Defaults to `true`.
  - This is because `xcss` is still currently implemented in Atlassian Design System using Emotion

---

*Note:*

Ideally we shouldn't allow Compiled to run on the `css` prop without use of the `css` function call and `import { css } from '@compiled/react'`. I'll make a proper writeup about this idea soon.

The current PR is just to unblock my other work, so this idea is outside the scope of this PR.