### PR TITLE
Added Babel Plugin 0.19.0 Patch from JFE

### DIFF
--- a/.changeset/young-masks-brush.md
+++ b/.changeset/young-masks-brush.md
@@ -2,4 +2,4 @@
 '@compiled/babel-plugin': minor
 ---
 
-Implemented babel-plugin 0.19.0 patch
+Added error in development/debug mode when using 'innerRef' instead of 'ref'

--- a/.changeset/young-masks-brush.md
+++ b/.changeset/young-masks-brush.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+Implemented babel-plugin 0.19.0 patch

--- a/packages/babel-plugin/src/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/__tests__/index.test.ts
@@ -66,9 +66,7 @@ describe('babel plugin', () => {
       const MyDiv = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           return (
             <CC>

--- a/packages/babel-plugin/src/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/__tests__/index.test.ts
@@ -65,6 +65,11 @@ describe('babel plugin', () => {
       const _ = "._1wyb1fwx{font-size:12px}";
       const MyDiv = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           return (
             <CC>
               <CS>{[_]}</CS>

--- a/packages/babel-plugin/src/__tests__/jsx-automatic.test.ts
+++ b/packages/babel-plugin/src/__tests__/jsx-automatic.test.ts
@@ -74,9 +74,7 @@ describe('jsx automatic', () => {
       const _ = "._syaz13q2{color:blue}";
       forwardRef(({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
         if (__cmplp.innerRef) {
-          throw new Error(
-            "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-          );
+          throw new Error("Please use 'ref' instead of 'innerRef'.");
         }
         return _jsxs(CC, {
           children: [

--- a/packages/babel-plugin/src/__tests__/jsx-automatic.test.ts
+++ b/packages/babel-plugin/src/__tests__/jsx-automatic.test.ts
@@ -73,6 +73,11 @@ describe('jsx automatic', () => {
       import { jsxs as _jsxs } from "react/jsx-runtime";
       const _ = "._syaz13q2{color:blue}";
       forwardRef(({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+        if (__cmplp.innerRef) {
+          throw new Error(
+            "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+          );
+        }
         return _jsxs(CC, {
           children: [
             _jsx(CS, {

--- a/packages/babel-plugin/src/__tests__/module-imports.test.ts
+++ b/packages/babel-plugin/src/__tests__/module-imports.test.ts
@@ -79,9 +79,7 @@ describe('import specifiers', () => {
       const ListItem = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           return (
             <CC>

--- a/packages/babel-plugin/src/__tests__/module-imports.test.ts
+++ b/packages/babel-plugin/src/__tests__/module-imports.test.ts
@@ -78,6 +78,11 @@ describe('import specifiers', () => {
       const _ = "._1wybgktf{font-size:20px}";
       const ListItem = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           return (
             <CC>
               <CS>{[_]}</CS>

--- a/packages/babel-plugin/src/keyframes/__tests__/call-expression.test.ts
+++ b/packages/babel-plugin/src/keyframes/__tests__/call-expression.test.ts
@@ -926,9 +926,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -960,9 +958,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -1002,9 +998,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -1042,9 +1036,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -1076,9 +1068,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -1118,9 +1108,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -1336,9 +1324,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -1370,9 +1356,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -1412,9 +1396,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -1452,9 +1434,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -1486,9 +1466,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>
@@ -1528,9 +1506,7 @@ describe('keyframes', () => {
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
                 if (__cmplp.innerRef) {
-                  throw new Error(
-                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                  );
+                  throw new Error("Please use 'ref' instead of 'innerRef'.");
                 }
                 return (
                   <CC>

--- a/packages/babel-plugin/src/keyframes/__tests__/call-expression.test.ts
+++ b/packages/babel-plugin/src/keyframes/__tests__/call-expression.test.ts
@@ -925,6 +925,11 @@ describe('keyframes', () => {
             const fadeOut = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2, _3, _4]}</CS>
@@ -954,6 +959,11 @@ describe('keyframes', () => {
             const fadeOut = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2]}</CS>
@@ -991,6 +1001,11 @@ describe('keyframes', () => {
             const darken = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2, _3]}</CS>
@@ -1026,6 +1041,11 @@ describe('keyframes', () => {
             const fadeOut = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2, _3, _4]}</CS>
@@ -1055,6 +1075,11 @@ describe('keyframes', () => {
             const fadeOut = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2]}</CS>
@@ -1092,6 +1117,11 @@ describe('keyframes', () => {
             const darken = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2, _3]}</CS>
@@ -1305,6 +1335,11 @@ describe('keyframes', () => {
             const fadeOut = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2, _3, _4]}</CS>
@@ -1334,6 +1369,11 @@ describe('keyframes', () => {
             const fadeOut = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2]}</CS>
@@ -1371,6 +1411,11 @@ describe('keyframes', () => {
             const darken = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2, _3]}</CS>
@@ -1406,6 +1451,11 @@ describe('keyframes', () => {
             const fadeOut = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2, _3, _4]}</CS>
@@ -1435,6 +1485,11 @@ describe('keyframes', () => {
             const fadeOut = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2]}</CS>
@@ -1472,6 +1527,11 @@ describe('keyframes', () => {
             const darken = null;
             const StyledComponent = forwardRef(
               ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+                if (__cmplp.innerRef) {
+                  throw new Error(
+                    "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                  );
+                }
                 return (
                   <CC>
                     <CS>{[_, _2, _3]}</CS>

--- a/packages/babel-plugin/src/keyframes/__tests__/tagged-template-expression.test.ts
+++ b/packages/babel-plugin/src/keyframes/__tests__/tagged-template-expression.test.ts
@@ -813,6 +813,11 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+              if (__cmplp.innerRef) {
+                throw new Error(
+                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                );
+              }
               return (
                 <CC>
                   <CS>{[_, _2, _3, _4]}</CS>
@@ -842,6 +847,11 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+              if (__cmplp.innerRef) {
+                throw new Error(
+                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                );
+              }
               return (
                 <CC>
                   <CS>{[_, _2]}</CS>
@@ -879,6 +889,11 @@ describe('keyframes transforms a tagged template expression', () => {
           const darken = null;
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+              if (__cmplp.innerRef) {
+                throw new Error(
+                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                );
+              }
               return (
                 <CC>
                   <CS>{[_, _2, _3]}</CS>
@@ -914,6 +929,11 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+              if (__cmplp.innerRef) {
+                throw new Error(
+                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                );
+              }
               return (
                 <CC>
                   <CS>{[_, _2, _3, _4]}</CS>
@@ -943,6 +963,11 @@ describe('keyframes transforms a tagged template expression', () => {
           const fadeOut = null;
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+              if (__cmplp.innerRef) {
+                throw new Error(
+                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                );
+              }
               return (
                 <CC>
                   <CS>{[_, _2]}</CS>
@@ -980,6 +1005,11 @@ describe('keyframes transforms a tagged template expression', () => {
           const darken = null;
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+              if (__cmplp.innerRef) {
+                throw new Error(
+                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+                );
+              }
               return (
                 <CC>
                   <CS>{[_, _2, _3]}</CS>

--- a/packages/babel-plugin/src/keyframes/__tests__/tagged-template-expression.test.ts
+++ b/packages/babel-plugin/src/keyframes/__tests__/tagged-template-expression.test.ts
@@ -814,9 +814,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
               if (__cmplp.innerRef) {
-                throw new Error(
-                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                );
+                throw new Error("Please use 'ref' instead of 'innerRef'.");
               }
               return (
                 <CC>
@@ -848,9 +846,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
               if (__cmplp.innerRef) {
-                throw new Error(
-                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                );
+                throw new Error("Please use 'ref' instead of 'innerRef'.");
               }
               return (
                 <CC>
@@ -890,9 +886,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
               if (__cmplp.innerRef) {
-                throw new Error(
-                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                );
+                throw new Error("Please use 'ref' instead of 'innerRef'.");
               }
               return (
                 <CC>
@@ -930,9 +924,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
               if (__cmplp.innerRef) {
-                throw new Error(
-                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                );
+                throw new Error("Please use 'ref' instead of 'innerRef'.");
               }
               return (
                 <CC>
@@ -964,9 +956,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
               if (__cmplp.innerRef) {
-                throw new Error(
-                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                );
+                throw new Error("Please use 'ref' instead of 'innerRef'.");
               }
               return (
                 <CC>
@@ -1006,9 +996,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const StyledComponent = forwardRef(
             ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
               if (__cmplp.innerRef) {
-                throw new Error(
-                  "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-                );
+                throw new Error("Please use 'ref' instead of 'innerRef'.");
               }
               return (
                 <CC>

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.ts
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.ts
@@ -32,9 +32,7 @@ describe('styled component behaviour', () => {
       const ListItem = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           return (
             <CC>
@@ -75,9 +73,7 @@ describe('styled component behaviour', () => {
       const ListItem = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           return (
             <CC>
@@ -355,9 +351,7 @@ describe('styled component behaviour', () => {
       export const BadgeSkeleton = forwardRef(
         ({ as: C = "span", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           const { isLoading, state, ...__cmpldp } = __cmplp;
           return (

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.ts
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.ts
@@ -31,6 +31,11 @@ describe('styled component behaviour', () => {
       const _ = "._1wybgktf{font-size:20px}";
       const ListItem = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           return (
             <CC>
               <CS>{[_]}</CS>
@@ -69,6 +74,11 @@ describe('styled component behaviour', () => {
       const _ = "._1wybgktf{font-size:20px}";
       const ListItem = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           return (
             <CC>
               <CS>{[_]}</CS>
@@ -344,6 +354,11 @@ describe('styled component behaviour', () => {
       const _ = "._bfhkhk3l{background-color:var(--_16ldrz5)}";
       export const BadgeSkeleton = forwardRef(
         ({ as: C = "span", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           const { isLoading, state, ...__cmpldp } = __cmplp;
           return (
             <CC>

--- a/packages/babel-plugin/src/styled/__tests__/call-expression.test.ts
+++ b/packages/babel-plugin/src/styled/__tests__/call-expression.test.ts
@@ -27,9 +27,7 @@ describe('styled object call expression', () => {
       const CompiledComponent = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           return (
             <CC>
@@ -626,9 +624,7 @@ describe('styled object call expression', () => {
       const Component = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           const { isActive, ...__cmpldp } = __cmplp;
           return (
@@ -666,9 +662,7 @@ describe('styled object call expression', () => {
       const Container = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           const { customPadding, ...__cmpldp } = __cmplp;
           return (
@@ -709,9 +703,7 @@ describe('styled object call expression', () => {
       const Container = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           const { morePadding, ...__cmpldp } = __cmplp;
           return (

--- a/packages/babel-plugin/src/styled/__tests__/call-expression.test.ts
+++ b/packages/babel-plugin/src/styled/__tests__/call-expression.test.ts
@@ -26,6 +26,11 @@ describe('styled object call expression', () => {
       });
       const CompiledComponent = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           return (
             <CC>
               <CS>{[_]}</CS>
@@ -620,6 +625,11 @@ describe('styled object call expression', () => {
       const size = 5;
       const Component = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           const { isActive, ...__cmpldp } = __cmplp;
           return (
             <CC>
@@ -655,6 +665,11 @@ describe('styled object call expression', () => {
       "const _ = "._1yt414tu{padding:var(--_1hhnq9y)}";
       const Container = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           const { customPadding, ...__cmpldp } = __cmplp;
           return (
             <CC>
@@ -693,6 +708,11 @@ describe('styled object call expression', () => {
       const _ = "._1yt41v0o{padding:var(--_1dm0vu2)}";
       const Container = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           const { morePadding, ...__cmpldp } = __cmplp;
           return (
             <CC>

--- a/packages/babel-plugin/src/styled/__tests__/tagged-template-expression.test.ts
+++ b/packages/babel-plugin/src/styled/__tests__/tagged-template-expression.test.ts
@@ -30,6 +30,11 @@ describe('styled tagged template expression', () => {
       \`;
       const CompiledComponent = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           return (
             <CC>
               <CS>{[_]}</CS>
@@ -73,6 +78,11 @@ describe('styled tagged template expression', () => {
       \`;
       const CompiledComponent = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           return (
             <CC>
               <CS>{[_]}</CS>
@@ -945,6 +955,11 @@ describe('styled tagged template expression', () => {
       const color2 = "blue";
       const ListItem = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           const { ruleEnabled, ...__cmpldp } = __cmplp;
           return (
             <CC>
@@ -1005,6 +1020,11 @@ describe('styled tagged template expression', () => {
       const color2 = "blue";
       const ListItem = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
+          if (__cmplp.innerRef) {
+            throw new Error(
+              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
+            );
+          }
           const { isActive, ...__cmpldp } = __cmplp;
           return (
             <CC>

--- a/packages/babel-plugin/src/styled/__tests__/tagged-template-expression.test.ts
+++ b/packages/babel-plugin/src/styled/__tests__/tagged-template-expression.test.ts
@@ -31,9 +31,7 @@ describe('styled tagged template expression', () => {
       const CompiledComponent = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           return (
             <CC>
@@ -79,9 +77,7 @@ describe('styled tagged template expression', () => {
       const CompiledComponent = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           return (
             <CC>
@@ -956,9 +952,7 @@ describe('styled tagged template expression', () => {
       const ListItem = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           const { ruleEnabled, ...__cmpldp } = __cmplp;
           return (
@@ -1021,9 +1015,7 @@ describe('styled tagged template expression', () => {
       const ListItem = forwardRef(
         ({ as: C = "div", style: __cmpls, ...__cmplp }, __cmplr) => {
           if (__cmplp.innerRef) {
-            throw new Error(
-              "Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref"
-            );
+            throw new Error("Please use 'ref' instead of 'innerRef'.");
           }
           const { isActive, ...__cmpldp } = __cmplp;
           return (

--- a/packages/babel-plugin/src/utils/build-styled-component.ts
+++ b/packages/babel-plugin/src/utils/build-styled-component.ts
@@ -162,7 +162,7 @@ const styledTemplate = (opts: StyledTemplateOpts, meta: Metadata): t.Node => {
     ${
       isDevelopmentEnv
         ? `if (${PROPS_IDENTIFIER_NAME}.innerRef) {
-          throw new Error("Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref")
+          throw new Error("Please use 'ref' instead of 'innerRef'.")
         }`
         : ''
     }

--- a/packages/babel-plugin/src/utils/build-styled-component.ts
+++ b/packages/babel-plugin/src/utils/build-styled-component.ts
@@ -147,6 +147,10 @@ const styledTemplate = (opts: StyledTemplateOpts, meta: Metadata): t.Node => {
       : '';
 
   const classNames = `${componentClassName}"${unconditionalClassNames.trim()}", ${conditionalClassNames}`;
+  const isDevelopmentEnv =
+    (!process.env.BABEL_ENV && !process.env.NODE_ENV) ||
+    ['development', 'test'].includes(process.env.BABEL_ENV || '') ||
+    ['development', 'test'].includes(process.env.NODE_ENV || '');
 
   return template(
     `
@@ -155,6 +159,13 @@ const styledTemplate = (opts: StyledTemplateOpts, meta: Metadata): t.Node => {
     style: ${STYLE_IDENTIFIER_NAME},
     ...${PROPS_IDENTIFIER_NAME}
   }, ${REF_IDENTIFIER_NAME}) => {
+    ${
+      isDevelopmentEnv
+        ? `if (${PROPS_IDENTIFIER_NAME}.innerRef) {
+          throw new Error("Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref")
+        }`
+        : ''
+    }
     ${
       hasInvalidDomProps
         ? `const {${invalidDomProps.join(

--- a/packages/parcel-transformer/src/__tests__/transformer.parceltest.ts
+++ b/packages/parcel-transformer/src/__tests__/transformer.parceltest.ts
@@ -204,6 +204,7 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
   expect(extractedComponent).toMatchInlineSnapshot(`
     "var Button = (0, _react.forwardRef)(function(_ref, __cmplr) {
         var _ref$as = _ref.as, C = _ref$as === void 0 ? "button" : _ref$as, __cmpls = _ref.style, __cmplp = _objectWithoutProperties(_ref, _excluded);
+        if (__cmplp.innerRef) throw new Error("Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref");
         return /*#__PURE__*/ (0, _jsxRuntime.jsx)(C, _objectSpread(_objectSpread({}, __cmplp), {}, {
             style: __cmpls,
             ref: __cmplr,

--- a/packages/parcel-transformer/src/__tests__/transformer.parceltest.ts
+++ b/packages/parcel-transformer/src/__tests__/transformer.parceltest.ts
@@ -204,7 +204,7 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
   expect(extractedComponent).toMatchInlineSnapshot(`
     "var Button = (0, _react.forwardRef)(function(_ref, __cmplr) {
         var _ref$as = _ref.as, C = _ref$as === void 0 ? "button" : _ref$as, __cmpls = _ref.style, __cmplp = _objectWithoutProperties(_ref, _excluded);
-        if (__cmplp.innerRef) throw new Error("Please use 'ref' instead of 'innerRef'. For more details, visit go/compiled-innerref");
+        if (__cmplp.innerRef) throw new Error("Please use 'ref' instead of 'innerRef'.");
         return /*#__PURE__*/ (0, _jsxRuntime.jsx)(C, _objectSpread(_objectSpread({}, __cmplp), {}, {
             style: __cmpls,
             ref: __cmplr,


### PR DESCRIPTION
- A patch was added to JFE to inform **_developers_** to _**not**_ use innerRef as it causes issues with Compiled.
- Manually added the patch due to the origin being a JavaScript file and destination being a TypeScript file.
- Updated snapshots for unit tests
