### PR TITLE
Created ESLint rule to disallow/discourage usage of empty styled.div() calls

### DIFF
--- a/.changeset/shy-years-wash.md
+++ b/.changeset/shy-years-wash.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': minor
+---
+
+Created ESLint rule to disallow usage of empty styled.element() function calls/empty object arguments

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -11,5 +11,6 @@ export const recommended = {
     '@compiled/no-keyframes-tagged-template-expression': 'error',
     '@compiled/no-styled-tagged-template-expression': 'error',
     '@compiled/no-suppress-xcss': 'error',
+    '@compiled/no-empty-styled-expression': 'warning',
   },
 };

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -11,6 +11,6 @@ export const recommended = {
     '@compiled/no-keyframes-tagged-template-expression': 'error',
     '@compiled/no-styled-tagged-template-expression': 'error',
     '@compiled/no-suppress-xcss': 'error',
-    '@compiled/no-empty-styled-expression': 'warning',
+    '@compiled/no-empty-styled-expression': 'error',
   },
 };

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
@@ -11,27 +11,13 @@ Passing an empty object or no object at all causes Compiled to build extra `div/
 👎 Examples of **incorrect** code for this rule:
 
 ```
-const Wrapper = styled.div();
-
-function Button() {
-  return <Wrapper>
-    <MyComponent>Hello</MyComponent>
-    <MyOtherComponent>world</MyOtherComponent>
-  </Wrapper>;
-}
+const EmptyStyledExpression = styled.div();
 ```
 
 and
 
 ```
-const Wrapper = styled.div({});
-
-function Button() {
-  return <Wrapper>
-    <MyComponent>Hello</MyComponent>
-    <MyOtherComponent>world</MyOtherComponent>
-  </Wrapper>;
-}
+const EmptyStyledExpressionArgument = styled.div({});
 ```
 
 👍 Examples of **correct** code for this rule:
@@ -43,16 +29,9 @@ const Wrapper = styled.div({
     backgroundColor: 'green',
   },
 });
-
-function Button() {
-  return <Wrapper>
-    <MyComponent>Hello</MyComponent>
-    <MyOtherComponent>world</MyOtherComponent>
-  </Wrapper>;
-}
 ```
 
-🔀 Work Arounds and Recommendations
+🔀 Recommendations
 
 1. Write your code in a way that doesn't require a Wrapper
 2. Use the empty React fragment: `<> <YourComponentHere></YourComponentHere> </>`

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
@@ -2,7 +2,7 @@
 
 Discourages any `styled` expression to be used when passing empty arguments in `@compiled/react`.
 
-Passing an empty object or no object at all causes Compiled to build extra `div` elements as opposed to simply using a `div`. This leads to reduced performance and is greatly discouraged. If a wrapper is necessary, opt to use a `div` or wrap it in the empty React fragment `<> <YourComponentHere></YourComponentHere> </>`.
+Passing an empty object or no object at all causes Compiled to build extra `div/span` elements, as opposed to simply using a `div`. This leads to reduced performance and is greatly discouraged. If a wrapper is necessary, opt to use a `div` or wrap it in the empty React fragment `<> <YourComponentHere></YourComponentHere> </>`.
 
 ---
 

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
@@ -31,9 +31,9 @@ const Wrapper = styled.div({
 });
 ```
 
-# 🔀 Recommendations
+## 🔀 Recommendations
 
-## Use elements directly
+### Use elements directly
 
 ```diff
 - const Wrapper = styled.div({});
@@ -44,7 +44,7 @@ const Wrapper = styled.div({
   }
 ```
 
-## Use a React fragment
+### Use a React fragment
 
 ```diff
 - const Wrapper = styled.div({});

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
@@ -12,12 +12,10 @@ Passing an empty object or no object at all causes Compiled to build extra `div/
 
 ```javascript
 const EmptyStyledExpression = styled.div();
-```
 
-and
-
-```javascript
 const EmptyStyledExpressionArgument = styled.div({});
+
+const EmptyStyledExpressionArgument = styled.div([]);
 ```
 
 👍 Examples of **correct** code for this rule:

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
@@ -1,6 +1,6 @@
 # `no-empty-styled-expression`
 
-Discourages any `styled` expression to be used when passing empty arguments in `@compiled/react`.
+Disallows/discourages any `styled` expression to be used when passing empty arguments in `@compiled/react`.
 
 Passing an empty object or no object at all causes Compiled to build extra `div/span` elements, as opposed to simply using a `div`. This leads to reduced performance and is greatly discouraged. If a wrapper is necessary, opt to use a `div` or wrap it in the empty React fragment `<> <YourComponentHere></YourComponentHere> </>`.
 
@@ -10,19 +10,19 @@ Passing an empty object or no object at all causes Compiled to build extra `div/
 
 👎 Examples of **incorrect** code for this rule:
 
-```
+```javascript
 const EmptyStyledExpression = styled.div();
 ```
 
 and
 
-```
+```javascript
 const EmptyStyledExpressionArgument = styled.div({});
 ```
 
 👍 Examples of **correct** code for this rule:
 
-```
+```javascript
 const Wrapper = styled.div({
   backgroundColor: 'red',
   MyComponent: {
@@ -44,8 +44,9 @@ const Wrapper = styled.div({
   }
 ```
 
+## Use a React fragment
+
 ```diff
-Use a React fragment
 - const Wrapper = styled.div({});
 
    function App() {

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
@@ -1,0 +1,59 @@
+# `no-empty-styled-expression`
+
+Discourages any `styled` expression to be used when passing empty arguments in `@compiled/react`.
+
+Passing an empty object or no object at all causes Compiled to build extra `div` elements as opposed to simply using a `div`. This leads to reduced performance and is greatly discouraged. If a wrapper is necessary, opt to use a `div` or wrap it in the empty React fragment `<> <YourComponentHere></YourComponentHere> </>`.
+
+---
+
+## Rule details
+
+👎 Examples of **incorrect** code for this rule:
+
+```
+const Wrapper = styled.div();
+
+function Button() {
+  return <Wrapper>
+    <MyComponent>Hello</MyComponent>
+    <MyOtherComponent>world</MyOtherComponent>
+  </Wrapper>;
+}
+```
+
+and
+
+```
+const Wrapper = styled.div({});
+
+function Button() {
+  return <Wrapper>
+    <MyComponent>Hello</MyComponent>
+    <MyOtherComponent>world</MyOtherComponent>
+  </Wrapper>;
+}
+```
+
+👍 Examples of **correct** code for this rule:
+
+```
+const Wrapper = styled.div({
+  backgroundColor: 'red',
+  MyComponent: {
+    backgroundColor: 'green',
+  },
+});
+
+function Button() {
+  return <Wrapper>
+    <MyComponent>Hello</MyComponent>
+    <MyOtherComponent>world</MyOtherComponent>
+  </Wrapper>;
+}
+```
+
+🔀 Work Arounds and Recommendations
+
+1. Write your code in a way that doesn't require a Wrapper
+2. Use the empty React fragment: `<> <YourComponentHere></YourComponentHere> </>`
+3. Use a `<div>`

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/README.md
@@ -31,8 +31,25 @@ const Wrapper = styled.div({
 });
 ```
 
-🔀 Recommendations
+# 🔀 Recommendations
 
-1. Write your code in a way that doesn't require a Wrapper
-2. Use the empty React fragment: `<> <YourComponentHere></YourComponentHere> </>`
-3. Use a `<div>`
+## Use elements directly
+
+```diff
+- const Wrapper = styled.div({});
+
+   function App() {
+-    return <Wrapper>hello world</Wrapper>;
++    return <div>hello world</div>;
+  }
+```
+
+```diff
+Use a React fragment
+- const Wrapper = styled.div({});
+
+   function App() {
+-    return <Wrapper>hello world</Wrapper>;
++    return <>hello world</>;
+  }
+```

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -1,0 +1,2 @@
+// How can I test a rule that emits a warning/error message, but makes no changes in the code?
+// Is there an Assert for ESLint?

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -38,7 +38,7 @@ tester.run('no-styled-tagged-template-expression', noStyledEmptyExpressionRule, 
         `,
     },
     {
-      name: 'styled.div({}) is passed no arguments',
+      name: 'styled.div() is passed no arguments',
       code: `
             import { styled } from '@compiled/react';
 
@@ -54,7 +54,7 @@ tester.run('no-styled-tagged-template-expression', noStyledEmptyExpressionRule, 
         `,
     },
     {
-      name: 'styled.span({}) is passed no arguments',
+      name: 'styled.span() is passed no arguments',
       code: `
             import { styled } from '@compiled/react';
 

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -71,5 +71,13 @@ tester.run('no-styled-tagged-template-expression', noEmptyStyledExpressionRule, 
             styled.span();
         `,
     },
+    {
+      name: 'styled.div() passed empty array as argument',
+      code: `
+            import { styled } from '@compiled/react';
+
+            styled.div([]);
+        `,
+    },
   ]),
 });

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -14,18 +14,28 @@ const createInvalidTestCases = (tests: InvalidTestCase[]) =>
 tester.run('no-styled-tagged-template-expression', noEmptyStyledExpressionRule, {
   valid: [
     `
-      import { styled } from 'styled';
+        import { styled } from 'styled';
 
-      styled.div({
-        color: blue
-      });
+        styled.div({
+            color: blue
+        });
     `,
     `
-      import { styled } from 'styled';
+        import { styled } from 'styled';
 
-      styled.span({
-        color: blue
-      });
+        styled.span({
+            color: blue
+        });
+    `,
+    `
+        import { styled } from '@compiled/react';
+
+        styled.span("hello world");
+    `,
+    `
+        import { styled } from '@compiled/react';
+
+        styled.span({}, {});
     `,
   ],
   invalid: createInvalidTestCases([

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -32,9 +32,10 @@ tester.run('no-styled-tagged-template-expression', noEmptyStyledExpressionRule, 
 
         styled.span("hello world");
     `,
-    `
+    ` 
         import { styled } from '@compiled/react';
 
+        // Considered valid due to the scope of this rule only covering arguments of length 0 and 1.
         styled.span({}, {});
     `,
   ],

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -42,7 +42,7 @@ tester.run('no-styled-tagged-template-expression', noEmptyStyledExpressionRule, 
     ` 
         import { styled } from '@compiled/react';
 
-        // Considered valid (not checking) due to boolean operations within styled calls being unused within Atlassian repositories
+        // Considered valid (not checking) due to boolean operations within styled calls not being used with empty objects
         styled.span(true && {});
     `,
   ],

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -1,7 +1,7 @@
 import type { RuleTester } from 'eslint';
 
 import { typeScriptTester as tester } from '../../../test-utils';
-import { noStyledEmptyExpressionRule } from '../index';
+import { noEmptyStyledExpressionRule } from '../index';
 
 type InvalidTestCase = Omit<RuleTester.InvalidTestCase, 'errors'>;
 
@@ -11,7 +11,7 @@ const createInvalidTestCases = (tests: InvalidTestCase[]) =>
     errors: [{ messageId: 'unexpected' }],
   }));
 
-tester.run('no-styled-tagged-template-expression', noStyledEmptyExpressionRule, {
+tester.run('no-styled-tagged-template-expression', noEmptyStyledExpressionRule, {
   valid: [
     `
       import { styled } from 'styled';

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -20,6 +20,13 @@ tester.run('no-styled-tagged-template-expression', noStyledEmptyExpressionRule, 
         color: blue
       });
     `,
+    `
+      import { styled } from 'styled';
+
+      styled.span({
+        color: blue
+      });
+    `,
   ],
   invalid: createInvalidTestCases([
     {

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -1,2 +1,65 @@
 // How can I test a rule that emits a warning/error message, but makes no changes in the code?
 // Is there an Assert for ESLint?
+
+import type { RuleTester } from 'eslint';
+
+import { typeScriptTester as tester } from '../../../test-utils';
+import { noStyledEmptyExpressionRule } from '../index';
+
+// Omitting errors in this type so createInvalidTestCases can be used to automatically add them
+type InvalidTestCase = Omit<RuleTester.InvalidTestCase, 'errors'>;
+
+const createInvalidTestCases = (tests: InvalidTestCase[]) =>
+  tests.map((t) => ({
+    ...t,
+    errors: [{ messageId: 'unexpected' }],
+  }));
+
+tester.run('no-styled-tagged-template-expression', noStyledEmptyExpressionRule, {
+  valid: [
+    `
+      import { styled } from 'styled';
+
+      styled.div\`color: blue\`;
+    `,
+    `
+      import { styled } from '@compiled/react-clone';
+
+      styled.div\`color: blue\`;
+    `,
+  ],
+  invalid: createInvalidTestCases([
+    {
+      name: 'styled.div({}) is passed an empty object',
+      code: `
+            import { styled } from '@compiled/react';
+
+            styled.div({});
+        `,
+    },
+    {
+      name: 'styled.div({}) is passed no arguments',
+      code: `
+            import { styled } from '@compiled/react';
+
+            styled.div();
+        `,
+    },
+    {
+      name: 'styled.span({}) is passed an empty object',
+      code: `
+            import { styled } from '@compiled/react';
+
+            styled.span({});
+        `,
+    },
+    {
+      name: 'styled.span({}) is passed no arguments',
+      code: `
+            import { styled } from '@compiled/react';
+
+            styled.span();
+        `,
+    },
+  ]),
+});

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -30,6 +30,7 @@ tester.run('no-styled-tagged-template-expression', noEmptyStyledExpressionRule, 
     `
         import { styled } from '@compiled/react';
 
+        // Considered valid due to the scope of this rule only checking for empty objects and arrays
         styled.span("hello world");
     `,
     ` 
@@ -37,6 +38,12 @@ tester.run('no-styled-tagged-template-expression', noEmptyStyledExpressionRule, 
 
         // Considered valid due to the scope of this rule only covering arguments of length 0 and 1.
         styled.span({}, {});
+    `,
+    ` 
+        import { styled } from '@compiled/react';
+
+        // Considered valid (not checking) due to boolean operations within styled calls being unused within Atlassian repositories
+        styled.span(true && {});
     `,
   ],
   invalid: createInvalidTestCases([

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/__tests__/rule.test.ts
@@ -1,12 +1,8 @@
-// How can I test a rule that emits a warning/error message, but makes no changes in the code?
-// Is there an Assert for ESLint?
-
 import type { RuleTester } from 'eslint';
 
 import { typeScriptTester as tester } from '../../../test-utils';
 import { noStyledEmptyExpressionRule } from '../index';
 
-// Omitting errors in this type so createInvalidTestCases can be used to automatically add them
 type InvalidTestCase = Omit<RuleTester.InvalidTestCase, 'errors'>;
 
 const createInvalidTestCases = (tests: InvalidTestCase[]) =>
@@ -20,12 +16,9 @@ tester.run('no-styled-tagged-template-expression', noStyledEmptyExpressionRule, 
     `
       import { styled } from 'styled';
 
-      styled.div\`color: blue\`;
-    `,
-    `
-      import { styled } from '@compiled/react-clone';
-
-      styled.div\`color: blue\`;
+      styled.div({
+        color: blue
+      });
     `,
   ],
   invalid: createInvalidTestCases([

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
@@ -8,18 +8,11 @@ type RuleModule = Rule.RuleModule;
 const isEmptyStyledExpression = (node: CallExpression): boolean => {
   const [firstArg] = node.arguments;
   if (firstArg?.type === 'ObjectExpression') {
-    // Check if it has properties. If empty, return true.
     return firstArg.properties.length === 0;
   }
   return true;
 };
 
-/**
- * Creation of the rule to identify empty styled.div/span() calls and raise an error message
- * @param isEmptyStyledTag
- * @param messageId
- * @returns
- */
 export const createNoEmptyStyledExpressionRule =
   (
     isEmptyStyledExpression: (node: CallExpression) => boolean,
@@ -41,7 +34,6 @@ export const createNoEmptyStyledExpressionRule =
           return;
         }
 
-        // Prints the unexpected message for all CallExpression nodes that match the isEmptyStyledTag criteria
         context.report({
           messageId,
           node,
@@ -50,13 +42,10 @@ export const createNoEmptyStyledExpressionRule =
     };
   };
 
-/**
- * The module declaration for the No Styled Empty Expression rule.
- */
 export const noEmptyStyledExpressionRule: Rule.RuleModule = {
   meta: {
     docs: {
-      url: '',
+      url: 'https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/no-empty-styled-expression',
     },
     messages: {
       unexpected:

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
@@ -7,10 +7,11 @@ type RuleModule = Rule.RuleModule;
 
 const isEmptyStyledExpression = (node: CallExpression): boolean => {
   const [firstArg] = node.arguments;
-  if (firstArg?.type === 'ObjectExpression') {
+  if (node.arguments.length === 0) return true;
+  else if (node.arguments.length === 1 && firstArg?.type === 'ObjectExpression') {
     return firstArg.properties.length === 0;
   }
-  return true;
+  return false;
 };
 
 export const createNoEmptyStyledExpressionRule =

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
@@ -1,0 +1,73 @@
+import type { Rule, Scope } from 'eslint';
+import type { ObjectExpression } from 'estree';
+
+import { COMPILED_IMPORT } from '../../utils/constants';
+
+type Definition = Scope.Definition;
+type Node = Rule.Node;
+type Reference = Scope.Reference;
+type RuleModule = Rule.RuleModule;
+
+const isStyledImportSpecifier = (def: Definition) =>
+  def.node.type === 'ImportSpecifier' &&
+  def.node.imported.type === 'Identifier' &&
+  def.node.imported.name === 'styled' &&
+  def.parent?.type === 'ImportDeclaration' &&
+  def.parent?.source.value === COMPILED_IMPORT;
+
+const isEmptyStyledExpression = (node: Node, references: Reference[]): boolean =>
+  (node.type === 'CallExpression' && // If it's a CallExpression > MemberExpression with null arguments and uses the styled import from Compiled
+    node.callee.type === 'MemberExpression' &&
+    node.arguments.length === 0 && // No arguments at all
+    references.some((reference) => reference.resolved?.defs.some(isStyledImportSpecifier))) ||
+  (node.type === 'CallExpression' && // If it's a CallExpression > MemberExpression with arguments but no properties
+    node.callee.type === 'MemberExpression' &&
+    node.arguments.map((obj) => {
+      const object: ObjectExpression = obj as ObjectExpression;
+      return Object.keys(object.properties).length === 0;
+    }) && // The object passed as an argument itself is empty
+    references.some((reference) => reference.resolved?.defs.some(isStyledImportSpecifier)));
+
+/**
+ * Creation of the rule to identify empty styled.div/span() calls and raise an error message
+ * @param isEmptyStyledTag
+ * @param messageId
+ * @returns
+ */
+export const createNoStyledEmptyExpressionRule =
+  (
+    isEmptyStyledExpression: (node: Node, references: Reference[]) => boolean,
+    messageId: string
+  ): RuleModule['create'] =>
+  (context) => ({
+    CallExpression(node) {
+      const { references } = context.getScope();
+      if (!isEmptyStyledExpression(node, references)) {
+        return;
+      }
+
+      // Prints the unexpected message for all CallExpression nodes that match the isEmptyStyledTag criteria
+      context.report({
+        messageId,
+        node,
+      });
+    },
+  });
+
+/**
+ * The module declaration for the No Styled Empty Expression rule.
+ */
+export const noStyledEmptyExpressionRule: Rule.RuleModule = {
+  meta: {
+    docs: {
+      url: '',
+    },
+    fixable: 'code',
+    messages: {
+      unexpected:
+        'Unexpected empty expression/empty object argument passed to styled.div() from @compiled/react',
+    },
+    type: 'problem',
+  },
+  create: createNoStyledEmptyExpressionRule(isEmptyStyledExpression, 'unexpected'),
+};

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
@@ -20,7 +20,7 @@ const isEmptyStyledExpression = (node: CallExpression): boolean => {
  * @param messageId
  * @returns
  */
-export const createNoStyledEmptyExpressionRule =
+export const createNoEmptyStyledExpressionRule =
   (
     isEmptyStyledExpression: (node: CallExpression) => boolean,
     messageId: string
@@ -53,7 +53,7 @@ export const createNoStyledEmptyExpressionRule =
 /**
  * The module declaration for the No Styled Empty Expression rule.
  */
-export const noStyledEmptyExpressionRule: Rule.RuleModule = {
+export const noEmptyStyledExpressionRule: Rule.RuleModule = {
   meta: {
     docs: {
       url: '',
@@ -65,5 +65,5 @@ export const noStyledEmptyExpressionRule: Rule.RuleModule = {
     },
     type: 'problem',
   },
-  create: createNoStyledEmptyExpressionRule(isEmptyStyledExpression, 'unexpected'),
+  create: createNoEmptyStyledExpressionRule(isEmptyStyledExpression, 'unexpected'),
 };

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
@@ -8,7 +8,9 @@ type RuleModule = Rule.RuleModule;
 const isEmptyStyledExpression = (node: CallExpression): boolean => {
   const [firstArg] = node.arguments;
   if (node.arguments.length === 0) return true;
-  else if (node.arguments.length === 1 && firstArg?.type === 'ObjectExpression') {
+  else if (node.arguments.length === 1 && firstArg?.type === 'ArrayExpression') {
+    return firstArg.elements.length === 0;
+  } else if (node.arguments.length === 1 && firstArg?.type === 'ObjectExpression') {
     return firstArg.properties.length === 0;
   }
   return false;

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
@@ -1,32 +1,18 @@
-import type { Rule, Scope } from 'eslint';
-import type { ObjectExpression } from 'estree';
+import type { Rule } from 'eslint';
+import type { CallExpression } from 'estree';
 
-import { COMPILED_IMPORT } from '../../utils/constants';
+import { isStyledImportSpecifier } from '../../utils/styled-import';
 
-type Definition = Scope.Definition;
-type Node = Rule.Node;
-type Reference = Scope.Reference;
 type RuleModule = Rule.RuleModule;
 
-const isStyledImportSpecifier = (def: Definition) =>
-  def.node.type === 'ImportSpecifier' &&
-  def.node.imported.type === 'Identifier' &&
-  def.node.imported.name === 'styled' &&
-  def.parent?.type === 'ImportDeclaration' &&
-  def.parent?.source.value === COMPILED_IMPORT;
-
-const isEmptyStyledExpression = (node: Node, references: Reference[]): boolean =>
-  (node.type === 'CallExpression' && // If it's a CallExpression > MemberExpression with null arguments and uses the styled import from Compiled
-    node.callee.type === 'MemberExpression' &&
-    node.arguments.length === 0 && // No arguments at all
-    references.some((reference) => reference.resolved?.defs.some(isStyledImportSpecifier))) ||
-  (node.type === 'CallExpression' && // If it's a CallExpression > MemberExpression with arguments but no properties
-    node.callee.type === 'MemberExpression' &&
-    node.arguments.map((obj) => {
-      const object: ObjectExpression = obj as ObjectExpression;
-      return Object.keys(object.properties).length === 0;
-    }) && // The object passed as an argument itself is empty
-    references.some((reference) => reference.resolved?.defs.some(isStyledImportSpecifier)));
+const isEmptyStyledExpression = (node: CallExpression): boolean => {
+  const [firstArg] = node.arguments;
+  if (firstArg?.type === 'ObjectExpression') {
+    // Check if it has properties. If empty, return true.
+    return firstArg.properties.length === 0;
+  }
+  return true;
+};
 
 /**
  * Creation of the rule to identify empty styled.div/span() calls and raise an error message
@@ -36,23 +22,33 @@ const isEmptyStyledExpression = (node: Node, references: Reference[]): boolean =
  */
 export const createNoStyledEmptyExpressionRule =
   (
-    isEmptyStyledExpression: (node: Node, references: Reference[]) => boolean,
+    isEmptyStyledExpression: (node: CallExpression) => boolean,
     messageId: string
   ): RuleModule['create'] =>
-  (context) => ({
-    CallExpression(node) {
-      const { references } = context.getScope();
-      if (!isEmptyStyledExpression(node, references)) {
-        return;
-      }
+  (context) => {
+    return {
+      'CallExpression[callee.type="MemberExpression"]': (node: CallExpression) => {
+        const { references } = context.getScope();
 
-      // Prints the unexpected message for all CallExpression nodes that match the isEmptyStyledTag criteria
-      context.report({
-        messageId,
-        node,
-      });
-    },
-  });
+        const isStyledImported = references.some((reference) =>
+          reference.resolved?.defs.some(isStyledImportSpecifier)
+        );
+        if (!isStyledImported) {
+          return;
+        }
+
+        if (!isEmptyStyledExpression(node)) {
+          return;
+        }
+
+        // Prints the unexpected message for all CallExpression nodes that match the isEmptyStyledTag criteria
+        context.report({
+          messageId,
+          node,
+        });
+      },
+    };
+  };
 
 /**
  * The module declaration for the No Styled Empty Expression rule.

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
@@ -22,15 +22,11 @@ export const createNoEmptyStyledExpressionRule =
     return {
       'CallExpression[callee.type="MemberExpression"]': (node: CallExpression) => {
         const { references } = context.getScope();
-
         const isStyledImported = references.some((reference) =>
           reference.resolved?.defs.some(isStyledImportSpecifier)
         );
-        if (!isStyledImported) {
-          return;
-        }
 
-        if (!isEmptyStyledExpression(node)) {
+        if (!isStyledImported || !isEmptyStyledExpression(node)) {
           return;
         }
 

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
@@ -58,7 +58,6 @@ export const noEmptyStyledExpressionRule: Rule.RuleModule = {
     docs: {
       url: '',
     },
-    fixable: 'code',
     messages: {
       unexpected:
         'Unexpected empty expression/empty object argument passed to styled.div() from @compiled/react',

--- a/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/utils.ts
+++ b/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression/utils.ts
@@ -1,17 +1,9 @@
 import type { Rule, Scope } from 'eslint';
 
-import { COMPILED_IMPORT } from '../../utils/constants';
+import { isStyledImportSpecifier } from '../../utils/styled-import';
 
-type Definition = Scope.Definition;
 type Node = Rule.Node;
 type Reference = Scope.Reference;
-
-const isStyledImportSpecifier = (def: Definition) =>
-  def.node.type === 'ImportSpecifier' &&
-  def.node.imported.type === 'Identifier' &&
-  def.node.imported.name === 'styled' &&
-  def.parent?.type === 'ImportDeclaration' &&
-  def.parent?.source.value === COMPILED_IMPORT;
 
 export const isStyled = (node: Node, references: Reference[]): boolean =>
   (node.type === 'MemberExpression' &&

--- a/packages/eslint-plugin/src/utils/styled-import.ts
+++ b/packages/eslint-plugin/src/utils/styled-import.ts
@@ -1,0 +1,11 @@
+import type { Scope } from 'eslint';
+
+import { COMPILED_IMPORT } from './constants';
+type Definition = Scope.Definition;
+
+export const isStyledImportSpecifier = (def: Definition): boolean =>
+  def.node.type === 'ImportSpecifier' &&
+  def.node.imported.type === 'Identifier' &&
+  def.node.imported.name === 'styled' &&
+  def.parent?.type === 'ImportDeclaration' &&
+  def.parent?.source.value === COMPILED_IMPORT;


### PR DESCRIPTION
- Raises an error for all styled.element() calls where either an empty object argument is passed, or no argument at all.
- Wrote tests for valid/invalid cases
- Moved common utility function `isStyledImportSpecifier` to the `eslint-plugin/src/utils` folder
- Added to recommended Compiled eslint rules as a warning
- Worked on code quality with Nathan