### PR TITLE
Support resolver module path

### DIFF
--- a/.changeset/late-hornets-confess.md
+++ b/.changeset/late-hornets-confess.md
@@ -1,0 +1,5 @@
+---
+'@compiled/webpack-loader': minor
+---
+
+Support resolver module path

--- a/fixtures/resolver-webpack/CHANGELOG.md
+++ b/fixtures/resolver-webpack/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @compiled-private/resolver-webpack
+
+## 0.1.0
+
+### Minor Changes
+
+- 809cc389: Add resolver fixture

--- a/fixtures/resolver-webpack/index.js
+++ b/fixtures/resolver-webpack/index.js
@@ -1,0 +1,11 @@
+const { join } = require('path');
+
+module.exports = {
+  resolveSync(_, request) {
+    if (request === 'test') {
+      return join(__dirname, 'main.js');
+    }
+
+    throw new Error('Unreachable code');
+  },
+};

--- a/fixtures/resolver-webpack/main.js
+++ b/fixtures/resolver-webpack/main.js
@@ -1,0 +1,1 @@
+export const primary = 'very-very red color';

--- a/fixtures/resolver-webpack/package.json
+++ b/fixtures/resolver-webpack/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@compiled-private/resolver-webpack",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/packages/webpack-loader/src/__fixtures__/custom-resolver.tsx
+++ b/packages/webpack-loader/src/__fixtures__/custom-resolver.tsx
@@ -1,0 +1,8 @@
+/** @jsx jsx */
+// @ts-ignore This is a bug where the meta is not updated for the new file import
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { jsx, css } from '@compiled/react';
+// @ts-expect-error
+import { primary } from 'test';
+
+export const App = (): JSX.Element => <div css={css({ color: primary })} />;

--- a/packages/webpack-loader/src/__tests__/compiled-loader.test.ts
+++ b/packages/webpack-loader/src/__tests__/compiled-loader.test.ts
@@ -80,8 +80,6 @@ describe.each<'development' | 'production'>(['development', 'production'])(
         resolver: '@compiled-private/resolver-webpack',
       });
 
-      // console.log('assets', assets['main.js']);
-
       expect(assets['main.js']).toInclude('._syaz8p1k{color:very-very red color');
     });
 

--- a/packages/webpack-loader/src/__tests__/compiled-loader.test.ts
+++ b/packages/webpack-loader/src/__tests__/compiled-loader.test.ts
@@ -75,6 +75,16 @@ describe.each<'development' | 'production'>(['development', 'production'])(
       expect(assets['main.js']).toInclude('._syaz1if8{color:indigo}');
     });
 
+    it('transforms styles imported through an overridden resolver', async () => {
+      const assets = await bundle(join(fixturesPath, 'custom-resolver.tsx'), {
+        resolver: '@compiled-private/resolver-webpack',
+      });
+
+      // console.log('assets', assets['main.js']);
+
+      expect(assets['main.js']).toInclude('._syaz8p1k{color:very-very red color');
+    });
+
     it('fails when using unrecognised compiled syntax', async () => {
       await expect(bundle(join(fixturesPath, 'compiled-error.tsx'))).rejects.toEqual([
         expect.objectContaining({

--- a/packages/webpack-loader/src/__tests__/test-utils.ts
+++ b/packages/webpack-loader/src/__tests__/test-utils.ts
@@ -16,6 +16,7 @@ export interface BundleOptions {
   disableCacheGroup?: boolean;
   mode: 'development' | 'production';
   resolve?: ResolveOptions;
+  resolver?: string;
 }
 
 export function bundle(
@@ -27,6 +28,7 @@ export function bundle(
     disableCacheGroup = false,
     mode,
     resolve = {},
+    resolver,
   }: BundleOptions
 ): Promise<Record<string, string>> {
   const outputPath = join(__dirname, 'dist');
@@ -56,6 +58,7 @@ export function bundle(
                 importReact: false,
                 optimizeCss: false,
                 resolve,
+                resolver,
               },
             },
           ],

--- a/packages/webpack-loader/src/compiled-loader.ts
+++ b/packages/webpack-loader/src/compiled-loader.ts
@@ -1,9 +1,7 @@
-import fs from 'fs';
-import { dirname, normalize } from 'path';
+import { normalize } from 'path';
 
 import { parseAsync, transformFromAstAsync } from '@babel/core';
 import { createError, toBoolean } from '@compiled/utils';
-import { CachedInputFileSystem, ResolverFactory } from 'enhanced-resolve';
 import { getOptions } from 'loader-utils';
 import type { LoaderContext } from 'webpack';
 

--- a/packages/webpack-loader/src/compiled-loader.ts
+++ b/packages/webpack-loader/src/compiled-loader.ts
@@ -7,6 +7,7 @@ import { CachedInputFileSystem, ResolverFactory } from 'enhanced-resolve';
 import { getOptions } from 'loader-utils';
 import type { LoaderContext } from 'webpack';
 
+import { createDefaultResolver } from './create-default-resolver';
 import { pluginName, styleSheetName } from './extract-plugin';
 import type { CompiledLoaderOptions } from './types';
 
@@ -34,6 +35,7 @@ function getLoaderOptions(context: LoaderContext<CompiledLoaderOptions>) {
     addComponentName = false,
     classNameCompressionMap = undefined,
     extractStylesToDirectory = undefined,
+    resolver = undefined,
   }: CompiledLoaderOptions = typeof context.getOptions === 'undefined'
     ? // Webpack v4 flow
       getOptions(context)
@@ -83,6 +85,9 @@ function getLoaderOptions(context: LoaderContext<CompiledLoaderOptions>) {
           extractStylesToDirectory: {
             type: 'object',
           },
+          resolver: {
+            type: 'string',
+          },
         },
       });
 
@@ -101,6 +106,7 @@ function getLoaderOptions(context: LoaderContext<CompiledLoaderOptions>) {
     addComponentName,
     classNameCompressionMap,
     extractStylesToDirectory,
+    resolver,
   };
 }
 
@@ -139,18 +145,6 @@ export default async function compiledLoader(
       plugins: options.transformerBabelPlugins ?? undefined,
     });
 
-    // Setup the default resolver, where webpack will merge any passed in options with the default
-    // resolve configuration. Ideally, we use this.getResolve({ ...resolve, useSyncFileSystemCalls: true, })
-    // However, it does not work correctly when in development mode :/
-    const resolver = ResolverFactory.createResolver({
-      // @ts-expect-error
-      fileSystem: new CachedInputFileSystem(fs, 4000),
-      ...(this._compilation?.options.resolve ?? {}),
-      ...resolve,
-      // This makes the resolver invoke the callback synchronously
-      useSyncFileSystemCalls: true,
-    });
-
     // Transform using the Compiled Babel Plugin - we deliberately turn off using the local config.
     const result = await transformFromAstAsync(ast!, code, {
       babelrc: false,
@@ -177,12 +171,12 @@ export default async function compiledLoader(
             // Turn off compressing class names if stylesheet extraction is off
             classNameCompressionMap: options.extract && options.classNameCompressionMap,
             onIncludedFiles: (files: string[]) => includedFiles.push(...files),
-            resolver: {
-              // The resolver needs to be synchronous, as babel plugins must be synchronous
-              resolveSync: (context: string, request: string) => {
-                return resolver.resolveSync({}, dirname(context), request);
-              },
-            },
+            resolver: options.resolver
+              ? options.resolver
+              : createDefaultResolver({
+                  resolveOptions: resolve,
+                  webpackResolveOptions: this._compilation?.options.resolve,
+                }),
           },
         ],
       ].filter(toBoolean),

--- a/packages/webpack-loader/src/create-default-resolver.ts
+++ b/packages/webpack-loader/src/create-default-resolver.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import { dirname } from 'path';
+
+import type { Resolver } from '@compiled/babel-plugin';
+import { CachedInputFileSystem, ResolverFactory } from 'enhanced-resolve';
+import type { ResolveOptions } from 'webpack';
+
+type Config = {
+  resolveOptions: ResolveOptions;
+  webpackResolveOptions: ResolveOptions | undefined;
+};
+
+export function createDefaultResolver({ resolveOptions, webpackResolveOptions }: Config): Resolver {
+  // Setup the default resolver, where webpack will merge any passed in options with the default
+  // resolve configuration. Ideally, we use this.getResolve({ ...resolve, useSyncFileSystemCalls: true, })
+  // However, it does not work correctly when in development mode :/
+  const resolver = ResolverFactory.createResolver({
+    // @ts-expect-error
+    fileSystem: new CachedInputFileSystem(fs, 4000),
+    ...(webpackResolveOptions ?? {}),
+    ...resolveOptions,
+    // This makes the resolver invoke the callback synchronously
+    useSyncFileSystemCalls: true,
+  });
+
+  return {
+    // The resolver needs to be synchronous, as babel plugins must be synchronous
+    resolveSync: (context: string, request: string) => {
+      return resolver.resolveSync({}, dirname(context), request) as string;
+    },
+  };
+}

--- a/packages/webpack-loader/src/types.ts
+++ b/packages/webpack-loader/src/types.ts
@@ -91,6 +91,11 @@ export interface CompiledLoaderOptions {
    * When set, extract styles to an external CSS file
    */
   extractStylesToDirectory?: { source: string; dest: string };
+
+  /**
+   * Custom resolver for babel plugin, when set overrides default resolver
+   */
+  resolver?: string;
 }
 
 export interface CompiledExtractPluginOptions {


### PR DESCRIPTION
Same as https://github.com/atlassian-labs/compiled/pull/1525 but now for webpack-loader, since Jira's SSR is still on webpack :( 