### PR TITLE
Feature/add no empty styled expressions rule declaration

### DIFF
--- a/.changeset/clean-beds-laugh.md
+++ b/.changeset/clean-beds-laugh.md
@@ -1,0 +1,6 @@
+---
+'@compiled/eslint-plugin': minor
+'@compiled/react': minor
+---
+
+Added no-empty-styled-expression rule to eslint plugin rule declarations

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -4,6 +4,7 @@ import { localCXXCSSRule } from './rules/local-cx-xcss';
 import { noCssPropWithoutCssFunctionRule } from './rules/no-css-prop-without-css-function';
 import { noCssTaggedTemplateExpressionRule } from './rules/no-css-tagged-template-expression';
 import { noEmotionCssRule } from './rules/no-emotion-css';
+import { noEmptyStyledExpressionRule } from './rules/no-empty-styled-expression';
 import { noExportedCssRule } from './rules/no-exported-css';
 import { noExportedKeyframesRule } from './rules/no-exported-keyframes';
 import { noInvalidCssMapRule } from './rules/no-invalid-css-map';
@@ -25,6 +26,7 @@ export const rules = {
   'no-keyframes-tagged-template-expression': noKeyframesTaggedTemplateExpressionRule,
   'no-styled-tagged-template-expression': noStyledTaggedTemplateExpressionRule,
   'no-suppress-xcss': noSuppressXCSS,
+  'no-empry-styled-expression': noEmptyStyledExpressionRule,
 };
 
 export const configs = {

--- a/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
+++ b/packages/eslint-plugin/src/rules/no-empty-styled-expression/index.ts
@@ -16,7 +16,7 @@ const isEmptyStyledExpression = (node: CallExpression): boolean => {
   return false;
 };
 
-export const createNoEmptyStyledExpressionRule =
+const createNoEmptyStyledExpressionRule =
   (
     isEmptyStyledExpression: (node: CallExpression) => boolean,
     messageId: string

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { createStrictAPI } from '@compiled/react';
 
 const { css, XCSSProp, cssMap, cx } = createStrictAPI<{


### PR DESCRIPTION
- Disabled `no-extraneous-dependencies` check for the strict-api fie that's causing pre-commit errors
- Added `no-empty-styled-expression` rule to plugin declaration
- Added changeset