### PR TITLE
strict-api to import from local instead of @compiled/react

### DIFF
--- a/.changeset/clean-beds-laugh.md
+++ b/.changeset/clean-beds-laugh.md
@@ -1,6 +1,0 @@
----
-'@compiled/eslint-plugin': minor
-'@compiled/react': minor
----
-
-Added no-empty-styled-expression rule to eslint plugin rule declarations

--- a/.changeset/clean-beds-laugh.md
+++ b/.changeset/clean-beds-laugh.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': minor
+---
+
+Added no-empty-styled-expression rule to eslint plugin rule declarations

--- a/.changeset/clean-beds-laugh.md
+++ b/.changeset/clean-beds-laugh.md
@@ -1,5 +1,5 @@
 ---
-'@compiled/eslint-plugin': minor
+'@compiled/eslint-plugin': patch
 ---
 
 Added no-empty-styled-expression rule to eslint plugin rule declarations

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://unpkg.com/@changesets/config@1.0.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
-  "commit": false,
-  "linked": [["@compiled/babel-plugin", "@compiled/babel-plugin-strip-runtime"]],
-  "access": "public",
-  "baseBranch": "master"
-}

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@1.0.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "linked": [["@compiled/babel-plugin", "@compiled/babel-plugin-strip-runtime"]],
+  "access": "public",
+  "baseBranch": "master"
+}

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -1,5 +1,4 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { createStrictAPI } from '@compiled/react';
+import { createStrictAPI } from '../../index';
 
 const { css, XCSSProp, cssMap, cx } = createStrictAPI<{
   '&:hover': {


### PR DESCRIPTION
- updated `strict-api.ts` to import from local rather than `@compiled/react`
- removed changeset due to unnecessary version bump