### PR TITLE
Change `processXcss` in `@compiled/babel-plugin` to false by default

### DIFF
--- a/.changeset/polite-turtles-knock.md
+++ b/.changeset/polite-turtles-knock.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+Change processXcss to false by default, to avoid potentially breaking Compiled usages that are dependent on Emotion

--- a/packages/babel-plugin/src/babel-plugin.ts
+++ b/packages/babel-plugin/src/babel-plugin.ts
@@ -109,8 +109,8 @@ export default declare<State>((api) => {
             }
           }
 
-          // Default to true
-          const processXcss = state.opts.processXcss ?? true;
+          // Default to false
+          const processXcss = state.opts.processXcss;
 
           if (processXcss && /(x|X)css={/.test(file.code)) {
             // xcss prop was found, turn on Compiled but just for xcss


### PR DESCRIPTION
`xcss` code isn't stable yet, so best not to have it set to true by default just yet

- [ ] Figure out how to pass `processXcss: true` for files like `packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx`