### PR TITLE
Fix Compiled runtime being added unexpectedly for xcss prop usage

### DIFF
--- a/.changeset/tasty-vans-happen.md
+++ b/.changeset/tasty-vans-happen.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Compiled runtime is no-longer inserted for non-Compiled xcss prop usage.

--- a/packages/babel-plugin/src/babel-plugin.ts
+++ b/packages/babel-plugin/src/babel-plugin.ts
@@ -108,14 +108,6 @@ export default declare<State>((api) => {
               }
             }
           }
-
-          // Default to true
-          const processXcss = state.opts.processXcss ?? true;
-
-          if (processXcss && /(x|X)css={/.test(file.code)) {
-            // xcss prop was found, turn on Compiled but just for xcss
-            state.usesXcss = true;
-          }
         },
         exit(path, state) {
           if (!state.compiledImports && !state.usesXcss) {
@@ -274,7 +266,8 @@ export default declare<State>((api) => {
         visitClassNamesPath(path, { context: 'root', state, parentPath: path });
       },
       JSXOpeningElement(path, state) {
-        if (state.usesXcss) {
+        const compiledXCSSProp = state.opts.processXcss ?? true;
+        if (compiledXCSSProp) {
           visitXcssPropPath(path, { context: 'root', state, parentPath: path });
         }
 

--- a/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
+++ b/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
@@ -337,7 +337,7 @@ describe('xcss prop transformation', () => {
 // i.e. xcss prop, where @compiled/react isn't imported but
 // @compiled/babel-plugin will still process the xcss usages.
 describe('xcss prop interacting with other libraries', () => {
-  it('should skip importing Compiled runtime no Compiled API usage was found', () => {
+  it('should skip importing Compiled runtime when no direct Compiled usage was found', () => {
     const result = transform(
       `
       /** @jsx jsx */
@@ -380,7 +380,7 @@ describe('xcss prop interacting with other libraries', () => {
     `);
   });
 
-  it('should import Compiled runtime when using inline object xcss', () => {
+  it('should import Compiled runtime when inline object is used in xcss', () => {
     const result = transform(
       `
       /** @jsx jsx */

--- a/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
+++ b/packages/babel-plugin/src/xcss-prop/__tests__/transformation.test.ts
@@ -199,15 +199,8 @@ describe('xcss prop transformation', () => {
     `
     );
 
-    // Ideally this shouldn't import @compiled/react/runtime at all because those
-    // are unused, and xcss runs at runtime here.
-    //
-    // Tree-shaking should get rid of these, but not adding these imports in the first
-    // place is something we could do in a future PR perhaps.
     expect(result).toMatchInlineSnapshot(`
-      "import * as React from "react";
-      import { ax, ix, CC, CS } from "@compiled/react/runtime";
-      import { Box, xcss } from "@atlaskit/primitives";
+      "import { Box, xcss } from "@atlaskit/primitives";
       <Box
         xcss={xcss({
           color: "red",
@@ -344,7 +337,7 @@ describe('xcss prop transformation', () => {
 // i.e. xcss prop, where @compiled/react isn't imported but
 // @compiled/babel-plugin will still process the xcss usages.
 describe('xcss prop interacting with other libraries', () => {
-  it("xcss prop in primitive component shouldn't affect css prop from Emotion", () => {
+  it('should skip importing Compiled runtime no Compiled API usage was found', () => {
     const result = transform(
       `
       /** @jsx jsx */
@@ -364,8 +357,7 @@ describe('xcss prop interacting with other libraries', () => {
     );
 
     expect(result).toMatchInlineSnapshot(`
-      "import { ax, ix, CC, CS } from "@compiled/react/runtime";
-      import { css, jsx } from "@emotion/react";
+      "import { css, jsx } from "@emotion/react";
       import { Box, xcss } from "@atlaskit/primitives";
       import Button from "@atlaskit/button";
       export function Mixed() {
@@ -388,7 +380,7 @@ describe('xcss prop interacting with other libraries', () => {
     `);
   });
 
-  it("xcss prop shouldn't affect css prop from Emotion", () => {
+  it('should import Compiled runtime when using inline object xcss', () => {
     const result = transform(
       `
       /** @jsx jsx */

--- a/packages/babel-plugin/src/xcss-prop/index.ts
+++ b/packages/babel-plugin/src/xcss-prop/index.ts
@@ -105,6 +105,7 @@ export const visitXcssPropPath = (path: NodePath<t.JSXOpeningElement>, meta: Met
         );
     }
 
+    meta.state.usesXcss = true;
     path.parentPath.replaceWith(compiledTemplate(jsxElementNode, sheets, meta));
   } else {
     // We make the assumption that xcss prop only takes member expressions such as:
@@ -118,6 +119,8 @@ export const visitXcssPropPath = (path: NodePath<t.JSXOpeningElement>, meta: Met
       // This covers the legacy use case of runtime xcss prop.
       return;
     }
+
+    meta.state.usesXcss = true;
 
     path.parentPath.replaceWith(compiledTemplate(jsxElementNode, sheets, meta));
   }

--- a/packages/babel-plugin/src/xcss-prop/index.ts
+++ b/packages/babel-plugin/src/xcss-prop/index.ts
@@ -121,7 +121,6 @@ export const visitXcssPropPath = (path: NodePath<t.JSXOpeningElement>, meta: Met
     }
 
     meta.state.usesXcss = true;
-
     path.parentPath.replaceWith(compiledTemplate(jsxElementNode, sheets, meta));
   }
 };


### PR DESCRIPTION
Currently Compiled will add its runtime even if there is no direct Compiled xcss prop usage (e.g. xcss prop from ADS primitive components!).

This pull request resolves that by moving some checks around (thanks @dddlr for putting in the initial plumbing!).