### PR TITLE
Fix XCSSProp types

### DIFF
--- a/.changeset/strong-oranges-turn.md
+++ b/.changeset/strong-oranges-turn.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Fix `cssMap` returned from `createStrictAPI` to return types based on the generic input, fixing usage with the `XCSSProp` API.

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -331,7 +331,7 @@ describe('createStrictAPI()', () => {
         />
       );
 
-      expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
+      expect(getByTestId('button')).toHaveCompiledCss('color', 'var(--ds-text)');
     });
 
     it('should error with values not in the strict `CompiledAPI`', () => {

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -271,6 +271,46 @@ describe('createStrictAPI()', () => {
   });
 
   describe('XCSSProp', () => {
+    it('should allow valid values from cssMap', () => {
+      function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', never>> }) {
+        return <button data-testid="button" className={xcss} />;
+      }
+
+      const styles = cssMap({ bg: { background: 'var(--ds-surface)' } });
+      const { getByTestId } = render(<Button xcss={styles.bg} />);
+
+      expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
+    });
+
+    it('should disallow invalid values from cssMap', () => {
+      function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', never>> }) {
+        return <button data-testid="button" className={xcss} />;
+      }
+
+      const styles = cssMap({ bg: { accentColor: 'red' } });
+      // @ts-expect-error — Type 'CompiledStyles<{ accentColor: "red"; }>' is not assignable to type ...
+      const { getByTestId } = render(<Button xcss={styles.bg} />);
+
+      expect(getByTestId('button')).toHaveCompiledCss('accent-color', 'red');
+    });
+
+    it('should allow constrained background and pseudo', () => {
+      function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', '&:hover'>> }) {
+        return <button data-testid="button" className={xcss} />;
+      }
+
+      const styles = cssMap({
+        primary: {
+          background: 'var(--ds-surface)',
+          '&:hover': { background: 'var(--ds-surface-hover)' },
+        },
+      });
+
+      const { getByTestId } = render(<Button xcss={styles.primary} />);
+
+      expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
+    });
+
     it('should allow valid values', () => {
       function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', never>> }) {
         return <button data-testid="button" className={xcss} />;

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -288,8 +288,12 @@ describe('createStrictAPI()', () => {
       }
 
       const styles = cssMap({ bg: { accentColor: 'red' } });
-      // @ts-expect-error — Type 'CompiledStyles<{ accentColor: "red"; }>' is not assignable to type ...
-      const { getByTestId } = render(<Button xcss={styles.bg} />);
+      const { getByTestId } = render(
+        <Button
+          // @ts-expect-error — Type 'CompiledStyles<{ accentColor: "red"; }>' is not assignable to type ...
+          xcss={styles.bg}
+        />
+      );
 
       expect(getByTestId('button')).toHaveCompiledCss('accent-color', 'red');
     });

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -311,6 +311,102 @@ describe('createStrictAPI()', () => {
       expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
     });
 
+    it('should type error on a partially invalid declaration', () => {
+      function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', '&:hover'>> }) {
+        return <button data-testid="button" className={xcss} />;
+      }
+
+      const styles = cssMap({
+        bad: {
+          // @ts-expect-error — Property 'bad' is incompatible with index signature.
+          foo: 'bar',
+          color: 'var(--ds-text)',
+        },
+      });
+
+      const { getByTestId } = render(
+        <Button
+          // @ts-expect-error — Type 'CompiledStyles<{ foo: string; color: "var(--ds-text)"; }>' is not assignable to type
+          xcss={styles.bad}
+        />
+      );
+
+      expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
+    });
+
+    it('should error with values not in the strict `CompiledAPI`', () => {
+      function Button({
+        xcss,
+      }: {
+        xcss: ReturnType<typeof XCSSProp<'background' | 'color', '&:hover'>>;
+      }) {
+        return <button data-testid="button" className={xcss} />;
+      }
+
+      const styles = cssMap({
+        primary: {
+          // @ts-expect-error -- This is not in the `createStrictAPI` schema—this should be a css variable.
+          color: 'red',
+          background: 'var(--ds-surface)',
+          '&:hover': { background: 'var(--ds-surface-hover)' },
+        },
+      });
+
+      const { getByTestId } = render(
+        <Button
+          // @ts-expect-error -- Errors because `color` conflicts with the `XCSSProp` schema–`color` should be a css variable.
+          xcss={styles.primary}
+        />
+      );
+
+      expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
+    });
+
+    it('should error with properties not in the `XCSSProp`', () => {
+      function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'color', '&:focus'>> }) {
+        return <button data-testid="button" className={xcss} />;
+      }
+
+      const styles = cssMap({
+        primary: {
+          background: 'var(--ds-surface)',
+          '&:hover': { background: 'var(--ds-surface-hover)' },
+        },
+      });
+
+      const { getByTestId } = render(
+        <Button
+          // @ts-expect-error -- Errors because `background` + `&:hover` are not in the `XCSSProp` schema.
+          xcss={styles.primary}
+        />
+      );
+
+      expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
+    });
+
+    it('should error with invalid values', () => {
+      function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', '&:hover'>> }) {
+        return <button data-testid="button" className={xcss} />;
+      }
+
+      const styles = cssMap({
+        primary: {
+          // @ts-expect-error -- Fails because `foo` is not assignable to our CSSProperties whatsoever.
+          foo: 'bar',
+          background: 'var(--ds-surface)',
+          '&:hover': {
+            // This does not fail, but would if the above was removed; this should be tested in raw `cssMap` fully.
+            foo: 'bar',
+            background: 'var(--ds-surface-hover)',
+          },
+        },
+      });
+
+      const { getByTestId } = render(<Button xcss={styles.primary} />);
+
+      expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
+    });
+
     it('should allow valid values', () => {
       function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', never>> }) {
         return <button data-testid="button" className={xcss} />;

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -21,6 +21,7 @@ type PickObjects<TObject> = {
 type CSSStyles<TSchema extends CompiledSchema> = StrictCSSProperties &
   PseudosDeclarations &
   EnforceSchema<TSchema>;
+
 type CSSMapStyles<TSchema extends CompiledSchema> = Record<string, CSSStyles<TSchema>>;
 
 interface CompiledAPI<TSchema extends CompiledSchema> {
@@ -57,9 +58,9 @@ interface CompiledAPI<TSchema extends CompiledSchema> {
    * ```
    */
   cssMap<TStylesMap extends CSSMapStyles<TSchema>>(
-    // NOTE: This should match the generic `TStylesMap extends …` as we want this arg to strictly satisfy this type, not just extend it.
-    // The "extends" functionality is to infer and build the return type, this is to enforce the input type.
-    styles: CSSMapStyles<TSchema>
+    // We intersection type the generic both with the concrete type and the generic to ensure the output has the generic applied.
+    // Without both it would allow either the input to now have excess property check kick in, or have all values set as the output.
+    styles: CSSMapStyles<TSchema> & TStylesMap
   ): {
     readonly [P in keyof TStylesMap]: CompiledStyles<TStylesMap[P]>;
   };

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -59,7 +59,8 @@ interface CompiledAPI<TSchema extends CompiledSchema> {
    */
   cssMap<TStylesMap extends CSSMapStyles<TSchema>>(
     // We intersection type the generic both with the concrete type and the generic to ensure the output has the generic applied.
-    // Without both it would allow either the input to now have excess property check kick in, or have all values set as the output.
+    // Without both it would either have the input arg not have excess property check kick in allowing unexpected values or
+    // have all values set as the output making usage with XCSSProp have type violations unexpectedly.
     styles: CSSMapStyles<TSchema> & TStylesMap
   ): {
     readonly [P in keyof TStylesMap]: CompiledStyles<TStylesMap[P]>;


### PR DESCRIPTION
This pull request fixes a missed use case introduced in #1582 or later. The change in types resulted in output type of `cssMap` from `createStrictAPI` no longer being generic, meaning "every value" was considered to be used breaking usage in XCSSProp (as all values breaks most XCSSProp declarations).

The fix is to add more tests to cover the known use cases and to bring the generic back in as an intersection type. My brain hurts to try and understand it but all the tests pass so I'm not too worried. Potentially we might be missing test cases, I'll go over more in my head just in case.