### PR TITLE
Fix unexpected type violation with XCSSProp from createStrictAPI()

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -22,6 +22,7 @@
             "optimizeCss": false,
             "importSources": [
               "./packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api",
+              "./packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive",
               "@fixture/strict-api-test"
             ]
           }

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
@@ -1,0 +1,34 @@
+import { createStrictAPI } from '../../index';
+
+type Color = 'var(--ds-text)';
+type ColorHovered = 'var(--ds-text-hovered)';
+type ColorPressed = 'var(--ds-text-pressed)';
+type Background = 'var(--ds-bold)' | 'var(--ds-success)';
+type BackgroundHovered = 'var(--ds-bold-hovered)' | 'var(--ds-success-hovered)';
+type BackgroundPressed = 'var(--ds-bold-pressed)' | 'var(--ds-success-pressed)';
+
+interface Properties {
+  color: Color;
+  backgroundColor: Background;
+}
+
+interface HoveredProperties extends Omit<Properties, 'backgroundColor' | 'color'> {
+  color: ColorHovered;
+  backgroundColor: BackgroundHovered;
+}
+
+interface PressedProperties extends Omit<Properties, 'backgroundColor' | 'color'> {
+  color: ColorPressed;
+  backgroundColor: BackgroundPressed;
+}
+
+interface StrictAPI extends Properties {
+  '&:hover': HoveredProperties;
+  '&:active': PressedProperties;
+  '&::before': Properties;
+  '&::after': Properties;
+}
+
+const { css, XCSSProp, cssMap, cx } = createStrictAPI<StrictAPI>();
+
+export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -1,0 +1,235 @@
+/** @jsxImportSource @compiled/react */
+import { render } from '@testing-library/react';
+
+import type { XCSSProp } from './__fixtures__/strict-api-recursive';
+import { css, cssMap } from './__fixtures__/strict-api-recursive';
+
+describe('createStrictAPI()', () => {
+  describe('type violations', () => {
+    it('should violate types for css()', () => {
+      const styles = css({
+        // @ts-expect-error — Type '""' is not assignable to type ...
+        color: '',
+        // @ts-expect-error — Type '""' is not assignable to type ...
+        backgroundColor: '',
+        '&:hover': {
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          color: '',
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          backgroundColor: '',
+        },
+        '&:active': {
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          color: '',
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          backgroundColor: '',
+        },
+        '&::before': {
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          color: '',
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          backgroundColor: '',
+        },
+        '&::after': {
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          color: '',
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          backgroundColor: '',
+        },
+      });
+
+      const { getByTestId } = render(<div css={styles} data-testid="div" />);
+
+      expect(getByTestId('div')).toBeDefined();
+    });
+
+    it('should violate types for cssMap()', () => {
+      const styles = cssMap({
+        primary: {
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          color: 's',
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          backgroundColor: '',
+          '&:hover': {
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            color: '',
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            backgroundColor: '',
+          },
+          '&:active': {
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            color: '',
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            backgroundColor: '',
+          },
+          '&::before': {
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            color: '',
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            backgroundColor: '',
+          },
+          '&::after': {
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            color: '',
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            backgroundColor: '',
+          },
+        },
+      });
+
+      const { getByTestId } = render(<div css={styles.primary} data-testid="div" />);
+
+      expect(getByTestId('div')).toBeDefined();
+    });
+
+    it('should violate types for xcss prop', () => {
+      function Component(_: {
+        xcss: ReturnType<
+          typeof XCSSProp<
+            'backgroundColor' | 'color',
+            '&:hover' | '&:active' | '&::before' | '&::after'
+          >
+        >;
+      }) {
+        return <div data-testid="div" />;
+      }
+
+      const { getByTestId } = render(
+        <Component
+          xcss={{
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            color: '',
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            backgroundColor: '',
+            '&:hover': {
+              // @ts-expect-error — Type '""' is not assignable to type ...
+              color: '',
+              // @ts-expect-error — Type '""' is not assignable to type ...
+              backgroundColor: '',
+            },
+            '&:active': {
+              // @ts-expect-error — Type '""' is not assignable to type ...
+              color: '',
+              // @ts-expect-error — Type '""' is not assignable to type ...
+              backgroundColor: '',
+            },
+            '&::before': {
+              // @ts-expect-error — Type '""' is not assignable to type ...
+              color: '',
+              // @ts-expect-error — Type '""' is not assignable to type ...
+              backgroundColor: '',
+            },
+            '&::after': {
+              // @ts-expect-error — Type '""' is not assignable to type ...
+              color: '',
+              // @ts-expect-error — Type '""' is not assignable to type ...
+              backgroundColor: '',
+            },
+          }}
+        />
+      );
+
+      expect(getByTestId('div')).toBeDefined();
+    });
+  });
+
+  describe('type success', () => {
+    it('should pass type check for css()', () => {
+      const styles = css({
+        color: 'var(--ds-text)',
+        backgroundColor: 'var(--ds-bold)',
+        '&:hover': {
+          color: 'var(--ds-text-hovered)',
+          backgroundColor: 'var(--ds-bold-hovered)',
+        },
+        '&:active': {
+          color: 'var(--ds-text-pressed)',
+          backgroundColor: 'var(--ds-bold-pressed)',
+        },
+        '&::before': {
+          color: 'var(--ds-text)',
+          backgroundColor: 'var(--ds-bold)',
+        },
+        '&::after': {
+          color: 'var(--ds-text)',
+          backgroundColor: 'var(--ds-bold)',
+        },
+      });
+
+      const { getByTestId } = render(<div css={styles} data-testid="div" />);
+
+      expect(getByTestId('div')).toHaveCompiledCss('color', 'var(--ds-text)');
+    });
+
+    it('should pass type check for cssMap()', () => {
+      const styles = cssMap({
+        primary: {
+          color: 'var(--ds-text)',
+          backgroundColor: 'var(--ds-bold)',
+          '&:hover': {
+            color: 'var(--ds-text-hovered)',
+            backgroundColor: 'var(--ds-bold-hovered)',
+          },
+          '&:active': {
+            color: 'var(--ds-text-pressed)',
+            backgroundColor: 'var(--ds-bold-pressed)',
+          },
+          '&::before': {
+            color: 'var(--ds-text)',
+            backgroundColor: 'var(--ds-bold)',
+          },
+          '&::after': {
+            color: 'var(--ds-text)',
+            backgroundColor: 'var(--ds-bold)',
+          },
+        },
+      });
+
+      const { getByTestId } = render(<div css={styles.primary} data-testid="div" />);
+
+      expect(getByTestId('div')).toHaveCompiledCss('color', 'var(--ds-text)');
+    });
+
+    it('should pass type check for xcss prop', () => {
+      function Component({
+        xcss,
+      }: {
+        xcss: ReturnType<
+          typeof XCSSProp<
+            'backgroundColor' | 'color',
+            '&:hover' | '&:active' | '&::before' | '&::after'
+          >
+        >;
+      }) {
+        return <div data-testid="div" className={xcss} />;
+      }
+
+      const { getByTestId } = render(
+        <Component
+          xcss={{
+            color: 'var(--ds-text)',
+            backgroundColor: 'var(--ds-bold)',
+            '&:hover': {
+              color: 'var(--ds-text-hovered)',
+              backgroundColor: 'var(--ds-bold-hovered)',
+            },
+            '&:active': {
+              color: 'var(--ds-text-pressed)',
+              backgroundColor: 'var(--ds-bold-pressed)',
+            },
+            '&::before': {
+              color: 'var(--ds-text)',
+              backgroundColor: 'var(--ds-bold)',
+            },
+            '&::after': {
+              color: 'var(--ds-text)',
+              backgroundColor: 'var(--ds-bold)',
+            },
+          }}
+        />
+      );
+
+      expect(getByTestId('div')).toHaveCompiledCss('color', 'var(--ds-text)');
+    });
+  });
+});

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -14,10 +14,6 @@ type EnforceSchema<TObject> = {
     : never;
 };
 
-type PickObjects<TObject> = {
-  [P in keyof TObject]: TObject[P] extends Record<string, unknown> ? TObject[P] : never;
-};
-
 type CSSStyles<TSchema extends CompiledSchema> = StrictCSSProperties &
   PseudosDeclarations &
   EnforceSchema<TSchema>;
@@ -150,13 +146,7 @@ interface CompiledAPI<TSchema extends CompiledSchema> {
       requiredProperties: TAllowedProperties;
       requiredPseudos: TAllowedPseudos;
     } = never
-  >(): Internal$XCSSProp<
-    TAllowedProperties,
-    TAllowedPseudos,
-    TSchema,
-    PickObjects<TSchema>,
-    TRequiredProperties
-  >;
+  >(): Internal$XCSSProp<TAllowedProperties, TAllowedPseudos, TSchema, TRequiredProperties>;
 }
 
 type CompiledSchema = StrictCSSProperties & PseudosDeclarations;

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -5,11 +5,11 @@ import type { CSSPseudos, CSSProperties } from '../types';
 
 type MarkAsRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
-type XCSSItem<TStyleDecl extends keyof CSSProperties, TCompiledTypedProperty> = {
+type XCSSItem<TStyleDecl extends keyof CSSProperties, TSchema> = {
   [Q in keyof CSSProperties]: Q extends TStyleDecl
     ?
         | CompiledPropertyDeclarationReference
-        | (Q extends keyof TCompiledTypedProperty ? TCompiledTypedProperty[Q] : CSSProperties[Q])
+        | (Q extends keyof TSchema ? TSchema[Q] : CSSProperties[Q])
     : never;
 };
 
@@ -17,14 +17,11 @@ type XCSSPseudos<
   TAllowedProperties extends keyof CSSProperties,
   TAllowedPseudos extends CSSPseudos,
   TRequiredProperties extends { requiredProperties: TAllowedProperties },
-  TCompiledTypedPseudo
+  TSchema
 > = {
   [Q in CSSPseudos]?: Q extends TAllowedPseudos
     ? MarkAsRequired<
-        XCSSItem<
-          TAllowedProperties,
-          Q extends keyof TCompiledTypedPseudo ? TCompiledTypedPseudo[Q] : object
-        >,
+        XCSSItem<TAllowedProperties, Q extends keyof TSchema ? TSchema[Q] : object>,
         TRequiredProperties['requiredProperties']
       >
     : never;
@@ -143,24 +140,23 @@ export type XCSSProp<
     requiredProperties: TAllowedProperties;
     requiredPseudos: TAllowedPseudos;
   } = never
-> = Internal$XCSSProp<TAllowedProperties, TAllowedPseudos, object, object, TRequiredProperties>;
+> = Internal$XCSSProp<TAllowedProperties, TAllowedPseudos, object, TRequiredProperties>;
 
 export type Internal$XCSSProp<
   TAllowedProperties extends keyof CSSProperties,
   TAllowedPseudos extends CSSPseudos,
-  TCompiledTypedProperty,
-  TCompiledTypedPseudo,
+  TSchema,
   TRequiredProperties extends {
     requiredProperties: TAllowedProperties;
     requiredPseudos: TAllowedPseudos;
   }
 > =
   | (MarkAsRequired<
-      XCSSItem<TAllowedProperties, TCompiledTypedProperty>,
+      XCSSItem<TAllowedProperties, TSchema>,
       TRequiredProperties['requiredProperties']
     > &
       MarkAsRequired<
-        XCSSPseudos<TAllowedProperties, TAllowedPseudos, TRequiredProperties, TCompiledTypedPseudo>,
+        XCSSPseudos<TAllowedProperties, TAllowedPseudos, TRequiredProperties, TSchema>,
         TRequiredProperties['requiredPseudos']
       > &
       BlockedRules)


### PR DESCRIPTION
When we were instrumenting `createStrictAPI` in platform we noticed there were some unexpected type violations. I've simplified the types internally and they go away. Since no other type violations went away / came up I'm confident in this change.

Let me know what you think!