### PR TITLE
Fix nested types output from createStrictAPI() being unintentionally marked as required

### DIFF
--- a/.changeset/kind-toys-roll.md
+++ b/.changeset/kind-toys-roll.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+cssMap() no longer throws an invariant if no styles were generated.

--- a/.changeset/sour-nails-breathe.md
+++ b/.changeset/sour-nails-breathe.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Fix nested types being forcibly required.

--- a/packages/babel-plugin/src/css-map/index.ts
+++ b/packages/babel-plugin/src/css-map/index.ts
@@ -98,7 +98,7 @@ export const visitCssMapPath = (
         const { sheets, classNames } = transformCssItems(css, meta);
         totalSheets.push(...sheets);
 
-        if (classNames.length !== 1) {
+        if (classNames.length > 1) {
           throw buildCodeFrameError(
             createErrorMessage(ErrorMessages.STATIC_VARIANT_OBJECT),
             property,
@@ -106,7 +106,7 @@ export const visitCssMapPath = (
           );
         }
 
-        return t.objectProperty(property.key, classNames[0]);
+        return t.objectProperty(property.key, classNames[0] || t.stringLiteral(''));
       })
     )
   );

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -5,6 +5,58 @@ import type { XCSSProp } from './__fixtures__/strict-api-recursive';
 import { css, cssMap } from './__fixtures__/strict-api-recursive';
 
 describe('createStrictAPI()', () => {
+  it('should mark all styles as optional in css()', () => {
+    const styles = css({
+      '&:hover': {},
+      '&:active': {},
+      '&::before': {},
+      '&::after': {},
+    });
+
+    const { getByTestId } = render(<div css={styles} data-testid="div" />);
+
+    expect(getByTestId('div')).toBeDefined();
+  });
+
+  it('should mark all styles as optional in cssMap()', () => {
+    const styles = cssMap({
+      nested: {
+        '&:hover': {},
+        '&:active': {},
+        '&::before': {},
+        '&::after': {},
+      },
+    });
+
+    const { getByTestId } = render(<div css={styles.nested} data-testid="div" />);
+
+    expect(getByTestId('div')).toBeDefined();
+  });
+
+  it('should mark all styles as optional in xcss prop', () => {
+    function Component({
+      xcss,
+    }: {
+      xcss: ReturnType<
+        typeof XCSSProp<
+          'backgroundColor' | 'color',
+          '&:hover' | '&:active' | '&::before' | '&::after'
+        >
+      >;
+    }) {
+      return <div data-testid="div" className={xcss} />;
+    }
+
+    const { getByTestId } = render(
+      <Component
+        xcss={{ '&:hover': {}, '&:active': {}, '&::before': {}, '&::after': {} }}
+        data-testid="div"
+      />
+    );
+
+    expect(getByTestId('div')).toBeDefined();
+  });
+
   describe('type violations', () => {
     it('should violate types for css()', () => {
       const styles = css({

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -6,11 +6,11 @@ type PseudosDeclarations = {
   [Q in CSSPseudos]?: StrictCSSProperties;
 };
 
-type EnforceSchema<TObject> = {
-  [P in keyof TObject]?: P extends keyof CompiledSchema
-    ? TObject[P] extends Record<string, unknown>
-      ? EnforceSchema<TObject[P]>
-      : TObject[P]
+type EnforceSchema<TSchema> = {
+  [P in keyof TSchema]?: P extends keyof CompiledSchema
+    ? TSchema[P] extends Record<string, any>
+      ? EnforceSchema<TSchema[P]>
+      : TSchema[P]
     : never;
 };
 


### PR DESCRIPTION
This pull request updates types and adds some tests for this specific use case.