### PR TITLE
Option to increase specificity of generated styles to enable XCSSProp migration

### DIFF
--- a/.changeset/early-peaches-sneeze.md
+++ b/.changeset/early-peaches-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@compiled/babel-plugin': patch
+'@compiled/css': patch
+---
+
+Introduce a new config option `increaseSpecificity` that increases the specificity of all generated Compiled classes. This is useful when migrating between two or more other styling solutions to Compiled.

--- a/.storybook/.babelrc.json
+++ b/.storybook/.babelrc.json
@@ -5,6 +5,7 @@
       {
         "importReact": false,
         "optimizeCss": false,
+        "increaseSpecificity": true,
         "transformerBabelPlugins": [
           [
             "@babel/plugin-proposal-decorators",

--- a/packages/babel-plugin/src/types.ts
+++ b/packages/babel-plugin/src/types.ts
@@ -88,6 +88,15 @@ export interface PluginOptions {
    * Default to `true`
    */
   processXcss?: boolean;
+
+  /**
+   * Increases the specificity of all declared Compiled styles.
+   * Generally you would only use this for migration purposes when mixing two or more styling
+   * solutions.
+   *
+   * Default to `false`.
+   */
+  increaseSpecificity?: boolean;
 }
 
 export interface State extends PluginPass {

--- a/packages/css/src/__tests__/transform.test.ts
+++ b/packages/css/src/__tests__/transform.test.ts
@@ -452,27 +452,48 @@ describe('#css-transform', () => {
     expect(actual.classNames).toEqual(expected.classNames);
   });
 
-  it('should add extra specificity to declarations', () => {
-    const styles = `
-      padding: 8px;
-      color: red;
-      :before {
-        content: var(--hello-world);
-        margin-right: 8px;
-        color: pink;
-      }
-    `;
-    const { sheets: actual } = transformCss(styles, { increaseSpecificity: true });
+  describe('increased specificity', () => {
+    it('should add extra specificity to declarations', () => {
+      const styles = `
+        padding: 8px;
+        color: red;
+        :before {
+          content: var(--hello-world);
+          margin-right: 8px;
+          color: pink;
+        }
+        ::after {
+          color: red;
+        }
+      `;
+      const { sheets: actual } = transformCss(styles, { increaseSpecificity: true });
 
-    expect(actual.join('\n')).toMatchInlineSnapshot(`
-      "._ca0qftgi:not(#\\9){padding-top:8px}
-      ._u5f3ftgi:not(#\\9){padding-right:8px}
-      ._n3tdftgi:not(#\\9){padding-bottom:8px}
-      ._19bvftgi:not(#\\9){padding-left:8px}
-      ._syaz5scu:not(#\\9){color:red}
-      ._1kt9o5oc:not(#\\9):before{content:var(--hello-world)}
-      ._eid3ftgi:not(#\\9):before{margin-right:8px}
-      ._is0632ev:not(#\\9):before{color:pink}"
-    `);
+      expect(actual.join('\n')).toMatchInlineSnapshot(`
+        "._ca0qftgi:not(#\\9){padding-top:8px}
+        ._u5f3ftgi:not(#\\9){padding-right:8px}
+        ._n3tdftgi:not(#\\9){padding-bottom:8px}
+        ._19bvftgi:not(#\\9){padding-left:8px}
+        ._syaz5scu:not(#\\9){color:red}
+        ._1kt9o5oc:not(#\\9):before{content:var(--hello-world)}
+        ._eid3ftgi:not(#\\9):before{margin-right:8px}
+        ._is0632ev:not(#\\9):before{color:pink}
+        ._14rn5scu:not(#\\9):after{color:red}"
+      `);
+    });
+
+    it('should increase & selector specificity', () => {
+      const styles = `
+        div & { color: red; }
+        div:hover & { color: red; }
+        div &:hover { color: red; }
+      `;
+      const { sheets: actual } = transformCss(styles, { increaseSpecificity: true });
+
+      expect(actual.join('\n')).toMatchInlineSnapshot(`
+        "div ._kqan5scu:not(#\\9){color:red}
+        div:hover ._12hc5scu:not(#\\9){color:red}
+        div ._wntz5scu:not(#\\9):hover{color:red}"
+      `);
+    });
   });
 });

--- a/packages/css/src/__tests__/transform.test.ts
+++ b/packages/css/src/__tests__/transform.test.ts
@@ -1,8 +1,4 @@
-import { transformCss as transform } from '../transform';
-
-interface TransformOpts {
-  optimizeCss?: boolean;
-}
+import { transformCss as transform, type TransformOpts } from '../transform';
 
 const transformCss = (code: string, opts: TransformOpts = { optimizeCss: false }) =>
   transform(code, opts);
@@ -438,5 +434,18 @@ describe('#css-transform', () => {
         ._otyridpf{margin-bottom:0}"
       `);
     });
+  });
+
+  it('should add extra specificity after atomicizing without affecting class names', () => {
+    const actual = transformCss(`margin-left: 0;`, { increaseSpecificity: true });
+    const expected = transformCss(`margin-left: 0;`, { increaseSpecificity: false });
+
+    expect(actual.classNames).toEqual(expected.classNames);
+  });
+
+  it('should add extra specificity to declarations', () => {
+    const { sheets: actual } = transformCss(`margin-left: 0;`, { increaseSpecificity: true });
+
+    expect(actual.join()).toMatchInlineSnapshot(`"._18u0idpf:not(#\\9){margin-left:0}"`);
   });
 });

--- a/packages/css/src/__tests__/transform.test.ts
+++ b/packages/css/src/__tests__/transform.test.ts
@@ -437,15 +437,42 @@ describe('#css-transform', () => {
   });
 
   it('should add extra specificity after atomicizing without affecting class names', () => {
-    const actual = transformCss(`margin-left: 0;`, { increaseSpecificity: true });
-    const expected = transformCss(`margin-left: 0;`, { increaseSpecificity: false });
+    const styles = `
+      padding: 8px;
+      color: red;
+      :before {
+        content: var(--hello-world);
+        margin-right: 8px;
+        color: pink;
+      }
+    `;
+    const actual = transformCss(styles, { increaseSpecificity: true });
+    const expected = transformCss(styles, { increaseSpecificity: false });
 
     expect(actual.classNames).toEqual(expected.classNames);
   });
 
   it('should add extra specificity to declarations', () => {
-    const { sheets: actual } = transformCss(`margin-left: 0;`, { increaseSpecificity: true });
+    const styles = `
+      padding: 8px;
+      color: red;
+      :before {
+        content: var(--hello-world);
+        margin-right: 8px;
+        color: pink;
+      }
+    `;
+    const { sheets: actual } = transformCss(styles, { increaseSpecificity: true });
 
-    expect(actual.join()).toMatchInlineSnapshot(`"._18u0idpf:not(#\\9){margin-left:0}"`);
+    expect(actual.join('\n')).toMatchInlineSnapshot(`
+      "._ca0qftgi:not(#\\9){padding-top:8px}
+      ._u5f3ftgi:not(#\\9){padding-right:8px}
+      ._n3tdftgi:not(#\\9){padding-bottom:8px}
+      ._19bvftgi:not(#\\9){padding-left:8px}
+      ._syaz5scu:not(#\\9){color:red}
+      ._1kt9o5oc:not(#\\9):before{content:var(--hello-world)}
+      ._eid3ftgi:not(#\\9):before{margin-right:8px}
+      ._is0632ev:not(#\\9):before{color:pink}"
+    `);
   });
 });

--- a/packages/css/src/plugins/__tests__/increase-specificity.test.ts
+++ b/packages/css/src/plugins/__tests__/increase-specificity.test.ts
@@ -18,7 +18,7 @@ describe('increase specicifity plugin', () => {
 
     expect(actual).toMatchInlineSnapshot(`
       "
-            :not(#\\9) .foo {}
+            .foo:not(#\\9) {}
           "
     `);
   });
@@ -33,7 +33,7 @@ describe('increase specicifity plugin', () => {
     expect(actual).toMatchInlineSnapshot(`
       "
             @media {
-              :not(#\\9) .foo {}
+              .foo:not(#\\9) {}
             }
           "
     `);

--- a/packages/css/src/plugins/__tests__/increase-specificity.test.ts
+++ b/packages/css/src/plugins/__tests__/increase-specificity.test.ts
@@ -11,29 +11,29 @@ const transform = (css: TemplateStringsArray) => {
 };
 
 describe('increase specicifity plugin', () => {
-  it('should increase specicifity of declared classes', () => {
-    const actual = transform`
-      .foo {}
-    `;
+  it('should ignore non-prefixed class names', () => {
+    const actual = transform`.foo {}`;
 
-    expect(actual).toMatchInlineSnapshot(`
-      "
-            .foo:not(#\\9) {}
-          "
-    `);
+    expect(actual).toMatchInlineSnapshot(`".foo {}"`);
+  });
+
+  it('should increase specicifity of declared classes', () => {
+    const actual = transform`._foo {}`;
+
+    expect(actual).toMatchInlineSnapshot(`"._foo:not(#\\9) {}"`);
   });
 
   it('should ignore atrules', () => {
     const actual = transform`
       @media {
-        .foo {}
+        ._foo {}
       }
     `;
 
     expect(actual).toMatchInlineSnapshot(`
       "
             @media {
-              .foo:not(#\\9) {}
+              ._foo:not(#\\9) {}
             }
           "
     `);
@@ -55,22 +55,22 @@ describe('increase specicifity plugin', () => {
 
   it('should prepend selector before other pseudos', () => {
     const actual = transform`
-      .foo:hover {
+      ._foo:hover {
         color: red;
       }
 
-      .baz::before {
+      ._baz::before {
         content: "bar";
       }
     `;
 
     expect(actual).toMatchInlineSnapshot(`
       "
-            .foo:not(#\\9):hover {
+            ._foo:not(#\\9):hover {
               color: red;
             }
 
-            .baz:not(#\\9)::before {
+            ._baz:not(#\\9)::before {
               content: "bar";
             }
           "

--- a/packages/css/src/plugins/__tests__/increase-specificity.test.ts
+++ b/packages/css/src/plugins/__tests__/increase-specificity.test.ts
@@ -1,0 +1,55 @@
+import postcss from 'postcss';
+
+import { increaseSpecificity } from '../increase-specificity';
+
+const transform = (css: TemplateStringsArray) => {
+  const result = postcss([increaseSpecificity()]).process(css[0], {
+    from: undefined,
+  });
+
+  return result.css;
+};
+
+describe('increase specicifity plugin', () => {
+  it('should increase specicifity of declared classes', () => {
+    const actual = transform`
+      .foo {}
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            :not(#\\9) .foo {}
+          "
+    `);
+  });
+
+  it('should ignore atrules', () => {
+    const actual = transform`
+      @media {
+        .foo {}
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            @media {
+              :not(#\\9) .foo {}
+            }
+          "
+    `);
+  });
+
+  it('should ignore root elements', () => {
+    const actual = transform`
+      html {}
+      :root {}
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            html {}
+            :root {}
+          "
+    `);
+  });
+});

--- a/packages/css/src/plugins/__tests__/increase-specificity.test.ts
+++ b/packages/css/src/plugins/__tests__/increase-specificity.test.ts
@@ -52,4 +52,28 @@ describe('increase specicifity plugin', () => {
           "
     `);
   });
+
+  it('should prepend selector before other pseudos', () => {
+    const actual = transform`
+      .foo:hover {
+        color: red;
+      }
+
+      .baz::before {
+        content: "bar";
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+            .foo:not(#\\9):hover {
+              color: red;
+            }
+
+            .baz:not(#\\9)::before {
+              content: "bar";
+            }
+          "
+    `);
+  });
 });

--- a/packages/css/src/plugins/increase-specificity.ts
+++ b/packages/css/src/plugins/increase-specificity.ts
@@ -20,7 +20,7 @@ export const increaseSpecificity = (): Plugin => {
       root.walkRules((rule) => {
         rule.selectors = rule.selectors.map((selector) => {
           if (selector.startsWith('.')) {
-            return INCREASE_SPECIFICITY_SELECTOR + ' ' + selector;
+            return selector + INCREASE_SPECIFICITY_SELECTOR;
           }
 
           return selector;

--- a/packages/css/src/plugins/increase-specificity.ts
+++ b/packages/css/src/plugins/increase-specificity.ts
@@ -1,0 +1,31 @@
+import type { Plugin } from 'postcss';
+
+const INCREASE_SPECIFICITY_SELECTOR = ':not(#\\9)';
+
+/**
+ * Increase the specificity of classes generated in Compiled by prepending ":not(#\\9)".
+ * This rule should run after CSS declarations have been atomicized and should not affect
+ * the original generated class name.
+ *
+ * This means generated class names with / without the increased specificity are the same,
+ * so when running Compiled together with (in product) + without it (in platform) they will
+ * keep the deterministic behaviour of the last declared style wins, but enjoying increased
+ * specificity when used in non-Compiled contexts for migration purposes, e.g. xcss prop
+ * being passed to Emotion CSS-in-JS!
+ */
+export const increaseSpecificity = (): Plugin => {
+  return {
+    postcssPlugin: 'increase-specificity',
+    OnceExit(root) {
+      root.walkRules((rule) => {
+        rule.selectors = rule.selectors.map((selector) => {
+          if (selector.startsWith('.')) {
+            return INCREASE_SPECIFICITY_SELECTOR + ' ' + selector;
+          }
+
+          return selector;
+        });
+      });
+    },
+  };
+};

--- a/packages/css/src/plugins/increase-specificity.ts
+++ b/packages/css/src/plugins/increase-specificity.ts
@@ -3,7 +3,7 @@ import type { Plugin } from 'postcss';
 const INCREASE_SPECIFICITY_SELECTOR = ':not(#\\9)';
 
 /**
- * Increase the specificity of classes generated in Compiled by prepending ":not(#\\9)".
+ * Increase the specificity of classes generated in Compiled by appended ":not(#\\9)".
  * This rule should run after CSS declarations have been atomicized and should not affect
  * the original generated class name.
  *

--- a/packages/css/src/plugins/increase-specificity.ts
+++ b/packages/css/src/plugins/increase-specificity.ts
@@ -28,7 +28,8 @@ export const increaseSpecificity = (): Plugin => {
     OnceExit(root) {
       root.walkRules((rule) => {
         rule.selectors = rule.selectors.map((selector) => {
-          if (selector.includes('.')) {
+          if (selector.includes('._')) {
+            // This rule should only apply to Compiled generated class names.
             return parser.astSync(selector).toString();
           }
 

--- a/packages/css/src/plugins/increase-specificity.ts
+++ b/packages/css/src/plugins/increase-specificity.ts
@@ -20,6 +20,14 @@ export const increaseSpecificity = (): Plugin => {
       root.walkRules((rule) => {
         rule.selectors = rule.selectors.map((selector) => {
           if (selector.startsWith('.')) {
+            if (selector.includes(':')) {
+              // Split up the selector and put it back together where the specificity
+              // selector is the first pseudo. If we don't do this before/after psuedos
+              // seem to break.
+              const parts = selector.split(':');
+              return parts[0] + [INCREASE_SPECIFICITY_SELECTOR, ...parts.slice(1)].join(':');
+            }
+
             return selector + INCREASE_SPECIFICITY_SELECTOR;
           }
 

--- a/packages/css/src/transform.ts
+++ b/packages/css/src/transform.ts
@@ -14,10 +14,10 @@ import { normalizeCSS } from './plugins/normalize-css';
 import { parentOrphanedPseudos } from './plugins/parent-orphaned-pseudos';
 import { sortAtRulePseudos } from './plugins/sort-at-rule-pseudos';
 
-interface TransformOpts {
+export interface TransformOpts {
   optimizeCss?: boolean;
   classNameCompressionMap?: Record<string, string>;
-  UNSAFE_increaseSpecificity?: boolean;
+  increaseSpecificity?: boolean;
 }
 
 /**
@@ -48,7 +48,7 @@ export const transformCss = (
         classNameCompressionMap: opts.classNameCompressionMap,
         callback: (className: string) => classNames.push(className),
       }),
-      increaseSpecificity(),
+      ...(opts.increaseSpecificity ? [increaseSpecificity()] : []),
       sortAtRulePseudos(),
       ...(process.env.AUTOPREFIXER === 'off' ? [] : [autoprefixer()]),
       whitespace(),

--- a/packages/css/src/transform.ts
+++ b/packages/css/src/transform.ts
@@ -9,6 +9,7 @@ import { discardDuplicates } from './plugins/discard-duplicates';
 import { discardEmptyRules } from './plugins/discard-empty-rules';
 import { expandShorthands } from './plugins/expand-shorthands';
 import { extractStyleSheets } from './plugins/extract-stylesheets';
+import { increaseSpecificity } from './plugins/increase-specificity';
 import { normalizeCSS } from './plugins/normalize-css';
 import { parentOrphanedPseudos } from './plugins/parent-orphaned-pseudos';
 import { sortAtRulePseudos } from './plugins/sort-at-rule-pseudos';
@@ -16,6 +17,7 @@ import { sortAtRulePseudos } from './plugins/sort-at-rule-pseudos';
 interface TransformOpts {
   optimizeCss?: boolean;
   classNameCompressionMap?: Record<string, string>;
+  UNSAFE_increaseSpecificity?: boolean;
 }
 
 /**
@@ -46,6 +48,7 @@ export const transformCss = (
         classNameCompressionMap: opts.classNameCompressionMap,
         callback: (className: string) => classNames.push(className),
       }),
+      increaseSpecificity(),
       sortAtRulePseudos(),
       ...(process.env.AUTOPREFIXER === 'off' ? [] : [autoprefixer()]),
       whitespace(),

--- a/packages/css/src/transform.ts
+++ b/packages/css/src/transform.ts
@@ -15,7 +15,7 @@ import { sortAtRulePseudos } from './plugins/sort-at-rule-pseudos';
 
 interface TransformOpts {
   optimizeCss?: boolean;
-  classNameCompressionMap?: object;
+  classNameCompressionMap?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
This pull request introduces a new option to Compiled for increasing the specificity of all styles generated by Compiled, without changing the class name. This enables Compiled to remain deterministic when you have styles built from two or more sources that may or may not have increased specificity turned on.

We're going to be using this for migration to XCSSProp where the platform components haven't yet been migrated to Compiled (away from Emotion). We need to ensure that styles passed through XCSSProp win over Emotion styles in a deterministic way. This was chosen over other solutions such as prepending Emotion styles to the head instead of appending as the unknown of legacy styles in Jira and beyond being unintentionally affected.

To enable set `increaseSpecificity` to true in your Compiled config:

```diff
+increaseSpecificity: true
```

---

**TODO**

- [x] Investigate VR test failure
- [x] Edge case tests