### PR TITLE
Fix Compiled throwing when multiple API imports exist in the same module

### DIFF
--- a/.changeset/polite-timers-rescue.md
+++ b/.changeset/polite-timers-rescue.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Fix the compiler throwing when multiple Compiled imports were used in the same module.

--- a/packages/babel-plugin/src/babel-plugin.ts
+++ b/packages/babel-plugin/src/babel-plugin.ts
@@ -274,7 +274,9 @@ export default declare<State>((api) => {
               specifier.node?.imported.name === apiName
             ) {
               // Enable the API with the local name
-              state.compiledImports[apiName] = specifier.node.local.name;
+              const apiArray = state.compiledImports[apiName] || [];
+              apiArray.push(specifier.node.local.name);
+              state.compiledImports[apiName] = apiArray;
               specifier.remove();
             }
           });

--- a/packages/babel-plugin/src/class-names/index.ts
+++ b/packages/babel-plugin/src/class-names/index.ts
@@ -88,6 +88,7 @@ const extractStyles = (path: NodePath<t.Expression>): t.Expression[] | t.Express
  */
 const getJsxChildrenAsFunction = (path: NodePath<t.JSXElement>) => {
   const children = path.node.children.find((node) => t.isJSXExpressionContainer(node));
+
   if (t.isJSXExpressionContainer(children) && t.isFunction(children.expression)) {
     return children.expression;
   }
@@ -114,7 +115,7 @@ E.g: <ClassNames>{props => <div />}</ClassNames>`,
 export const visitClassNamesPath = (path: NodePath<t.JSXElement>, meta: Metadata): void => {
   if (
     t.isJSXIdentifier(path.node.openingElement.name) &&
-    path.node.openingElement.name.name !== meta.state.compiledImports?.ClassNames
+    !meta.state.compiledImports?.ClassNames?.includes(path.node.openingElement.name.name)
   ) {
     // We aren't interested in this element. Bail out!
     return;

--- a/packages/babel-plugin/src/styled/index.ts
+++ b/packages/babel-plugin/src/styled/index.ts
@@ -35,7 +35,7 @@ const extractStyledDataFromTemplateLiteral = (
   if (
     t.isMemberExpression(node.tag) &&
     t.isIdentifier(node.tag.object) &&
-    node.tag.object.name === meta.state.compiledImports?.styled &&
+    meta.state.compiledImports?.styled?.includes(node.tag.object.name) &&
     t.isIdentifier(node.tag.property)
   ) {
     const tagName = node.tag.property.name;
@@ -47,7 +47,7 @@ const extractStyledDataFromTemplateLiteral = (
   if (
     t.isCallExpression(node.tag) &&
     t.isIdentifier(node.tag.callee) &&
-    node.tag.callee.name === meta.state.compiledImports?.styled &&
+    meta.state.compiledImports?.styled?.includes(node.tag.callee.name) &&
     t.isIdentifier(node.tag.arguments[0])
   ) {
     const tagName = node.tag.arguments[0].name;
@@ -66,7 +66,7 @@ const extractStyledDataFromObjectLiteral = (
   if (
     t.isMemberExpression(node.callee) &&
     t.isIdentifier(node.callee.object) &&
-    node.callee.object.name === meta.state.compiledImports?.styled &&
+    meta.state.compiledImports?.styled?.includes(node.callee.object.name) &&
     t.isExpression(node.arguments[0]) &&
     t.isIdentifier(node.callee.property)
   ) {
@@ -79,7 +79,7 @@ const extractStyledDataFromObjectLiteral = (
   if (
     t.isCallExpression(node.callee) &&
     t.isIdentifier(node.callee.callee) &&
-    node.callee.callee.name === meta.state.compiledImports?.styled &&
+    meta.state.compiledImports?.styled?.includes(node.callee.callee.name) &&
     t.isExpression(node.arguments[0]) &&
     t.isIdentifier(node.callee.arguments[0])
   ) {

--- a/packages/babel-plugin/src/types.ts
+++ b/packages/babel-plugin/src/types.ts
@@ -116,11 +116,11 @@ export interface State extends PluginPass {
    * Means the `styled` api was found as `styledFunction` - as well as CSS prop is enabled in this module.
    */
   compiledImports?: {
-    ClassNames?: string;
-    css?: string;
-    keyframes?: string;
-    styled?: string;
-    cssMap?: string;
+    ClassNames?: string[];
+    css?: string[];
+    keyframes?: string[];
+    styled?: string[];
+    cssMap?: string[];
   };
 
   usesXcss?: boolean;

--- a/packages/babel-plugin/src/utils/is-compiled.ts
+++ b/packages/babel-plugin/src/utils/is-compiled.ts
@@ -15,7 +15,9 @@ export const isCompiledCSSCallExpression = (
 ): node is t.CallExpression =>
   t.isCallExpression(node) &&
   t.isIdentifier(node.callee) &&
-  [state.compiledImports?.css, state.importedCompiledImports?.css].includes(node.callee.name);
+  [...(state.compiledImports?.css || []), state.importedCompiledImports?.css].includes(
+    node.callee.name
+  );
 
 /**
  * Returns `true` if the node is using `css` from `@compiled/react` as a tagged template expression
@@ -30,7 +32,7 @@ export const isCompiledCSSTaggedTemplateExpression = (
 ): node is t.TaggedTemplateExpression =>
   t.isTaggedTemplateExpression(node) &&
   t.isIdentifier(node.tag) &&
-  node.tag.name === state.compiledImports?.css;
+  !!state.compiledImports?.css?.includes(node.tag.name);
 
 /**
  * Returns `true` if the node is using `keyframes` from `@compiled/react` as a call expression
@@ -45,7 +47,7 @@ export const isCompiledKeyframesCallExpression = (
 ): node is t.CallExpression =>
   t.isCallExpression(node) &&
   t.isIdentifier(node.callee) &&
-  node.callee.name === state.compiledImports?.keyframes;
+  !!state.compiledImports?.keyframes?.includes(node.callee.name);
 
 /**
  * Returns `true` if the node is using `cssMap` from `@compiled/react` as a call expression
@@ -60,7 +62,7 @@ export const isCompiledCSSMapCallExpression = (
 ): node is t.CallExpression =>
   t.isCallExpression(node) &&
   t.isIdentifier(node.callee) &&
-  node.callee.name === state.compiledImports?.cssMap;
+  !!state.compiledImports?.cssMap?.includes(node.callee.name);
 
 /**
  * Returns `true` if the node is using `keyframes` from `@compiled/react` as a tagged template expression
@@ -75,7 +77,7 @@ export const isCompiledKeyframesTaggedTemplateExpression = (
 ): node is t.TaggedTemplateExpression =>
   t.isTaggedTemplateExpression(node) &&
   t.isIdentifier(node.tag) &&
-  node.tag.name === state.compiledImports?.keyframes;
+  !!state.compiledImports?.keyframes?.includes(node.tag.name);
 
 /**
  * Returns `true` if the node is using `styled` from `@compiled/react` from a styled.tag usage
@@ -87,7 +89,7 @@ export const isCompiledKeyframesTaggedTemplateExpression = (
 const isCompiledStyledMemberExpression = (node: t.Node, state: State): node is t.MemberExpression =>
   t.isMemberExpression(node) &&
   t.isIdentifier(node.object) &&
-  node.object.name === state.compiledImports?.styled;
+  !!state.compiledImports?.styled?.includes(node.object.name);
 
 /**
  * Returns `true` if the node is using `styled` from `@compiled/react` from a styled(Component) usage
@@ -102,7 +104,7 @@ const isCompiledStyledCompositionCallExpression = (
 ): node is t.CallExpression =>
   t.isCallExpression(node) &&
   t.isIdentifier(node.callee) &&
-  node.callee.name === state.compiledImports?.styled;
+  !!state.compiledImports?.styled?.includes(node.callee.name);
 
 /**
  * Returns `true` if the node is using `styled` from `@compiled/react` as a call expression

--- a/packages/react/src/create-strict-api/__tests__/mixed.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/mixed.test.tsx
@@ -1,0 +1,23 @@
+/** @jsxImportSource @compiled/react */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { css } from '@compiled/react';
+import { css as strictCSS } from '@fixture/strict-api-test';
+import { render } from '@testing-library/react';
+
+describe('strict api used with top level api', () => {
+  it('should mix styles together deterministically', () => {
+    const styles = strictCSS({
+      color: 'var(--ds-text)',
+    });
+    const otherStyles = css({
+      backgroundColor: 'red',
+      color: 'blue',
+    });
+
+    const { getByTestId } = render(<div css={[styles, otherStyles]} data-testid="div" />);
+
+    expect(getByTestId('div')).not.toHaveCompiledCss('color', 'var(--ds-text)');
+    expect(getByTestId('div')).toHaveCompiledCss('color', 'blue');
+    expect(getByTestId('div')).toHaveCompiledCss('backgroundColor', 'red');
+  });
+});


### PR DESCRIPTION
With the introduction of the strict API and custom importSources Compiled can now be used from different imports in the same module. One use case is when migrating to the new strict API but being blocked on something, so having to fallback to the current top-level API.

To ensure a smooth ride we need to enable Compiled to work when multiple imports exist in a module. This pull request changes the internal data structure to capture the local names of all Compiled APIs.

**TODO**

- [x] Update css state to check for multiple modules