### PR TITLE
Add missing typecheck command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Validate
         run: yarn lint
 
+      - name: Typecheck
+        run: yarn typecheck
+
       - name: Run tests
         run: yarn test:cover --ci
 

--- a/examples/webpack/src/ui/typescript.tsx
+++ b/examples/webpack/src/ui/typescript.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { styled } from '@compiled/react';
 
 import { primary } from '../common/constants';

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "test:imports": "node test/test-imports",
     "test:parcel": "jest --testMatch '**/src/**/*.parceltest.{ts,tsx}'",
     "test:vr": "yarn loki --host host.docker.internal",
-    "test:watch": "jest --no-cache --watch"
+    "test:watch": "jest --no-cache --watch",
+    "typecheck": "tsc --noEmit"
   },
   "husky": {
     "hooks": {

--- a/packages/tsconfig.options.json
+++ b/packages/tsconfig.options.json
@@ -16,6 +16,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
+    "skipLibCheck": true,
     "target": "es6",
     "typeRoots": ["../node_modules/@types", "../types"]
   }

--- a/stories/compiled.tsx
+++ b/stories/compiled.tsx
@@ -1,4 +1,4 @@
-import '@compiled/react';
+/** @jsxImportSource @compiled/react */
 
 export default {
   title: 'benchmarks/compiled',

--- a/stories/composing-styles-on-user-defined-components.tsx
+++ b/stories/composing-styles-on-user-defined-components.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { styled } from '@compiled/react';
 
 export default {

--- a/stories/conditional-rules-css-props.tsx
+++ b/stories/conditional-rules-css-props.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import '@compiled/react';
 
 export default {

--- a/stories/css-combinators.tsx
+++ b/stories/css-combinators.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { css } from '@compiled/react';
 
 export default {

--- a/stories/css-map.tsx
+++ b/stories/css-map.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { cssMap, css } from '@compiled/react';
 import { useState } from 'react';
 

--- a/stories/css-object-expression.tsx
+++ b/stories/css-object-expression.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { css } from '@compiled/react';
 
 import { primaryCallExpression, primaryTaggedTemplateExpression } from './mixins';

--- a/stories/css-prop-dynamic-object.tsx
+++ b/stories/css-prop-dynamic-object.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { useState } from 'react';
 import '@compiled/react';
 

--- a/stories/css-prop-keyframes.tsx
+++ b/stories/css-prop-keyframes.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { css } from '@compiled/react';
 
 export default {

--- a/stories/css-prop-static-object.tsx
+++ b/stories/css-prop-static-object.tsx
@@ -1,4 +1,4 @@
-import '@compiled/react';
+/** @jsxImportSource @compiled/react */
 import { hoverObjectLiteral } from './mixins';
 
 const inlineMixinFunc = () => ({
@@ -23,7 +23,6 @@ export const ObjectLiteralSpreadFromFunc = (): JSX.Element => {
       css={{
         display: 'flex',
         fontSize: '50px',
-        color: 'blue',
         ...inlineMixinFunc(),
       }}>
       red text
@@ -37,7 +36,6 @@ export const ObjectLiteralSpreadFromObj = (): JSX.Element => {
       css={{
         display: 'flex',
         fontSize: '50px',
-        color: 'blue',
         ...inlineMixinObj,
       }}>
       green text

--- a/stories/css-prop-string.tsx
+++ b/stories/css-prop-string.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { css } from '@compiled/react';
 
 import {

--- a/stories/css-tagged-template-expression.tsx
+++ b/stories/css-tagged-template-expression.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { css } from '@compiled/react';
 
 import { primaryTaggedTemplateExpression } from './mixins';

--- a/stories/edge-cases-interpolations.tsx
+++ b/stories/edge-cases-interpolations.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { styled } from '@compiled/react';
 
 const Container = styled.div<{ color?: string }>`

--- a/stories/jsx-import-source-pragma.tsx
+++ b/stories/jsx-import-source-pragma.tsx
@@ -29,6 +29,7 @@ export const WithClassName = (): JSX.Element => (
 );
 
 export const NoClassName = (): JSX.Element => (
+  // @ts-expect-error — ClassName doesn't exist! Error!
   <DivWithoutClassName css={{ color: 'red' }}>
     <span>Text is NOT red and there is a type error</span>
   </DivWithoutClassName>

--- a/stories/jsx-pragma.tsx
+++ b/stories/jsx-pragma.tsx
@@ -24,16 +24,19 @@ const DivWithoutClassName = ({ children }: { children: JSX.Element }) => {
 };
 
 export const LocalJSXNamespace = (): JSX.Element => (
+  // @ts-expect-error — Hack to compile with jsx pragma
   <div css={{ fontSize: 30, color: 'blue' }}>Sourced from local JSX Namespace</div>
 );
 
 export const WithClassName = (): JSX.Element => (
+  // @ts-expect-error — Hack to compile with jsx pragma
   <DivWithClassName css={{ color: 'red' }}>
     <span>Text is now red</span>
   </DivWithClassName>
 );
 
 export const NoClassName = (): JSX.Element => (
+  // @ts-expect-error — Hack to compile with jsx pragma
   <DivWithoutClassName css={{ color: 'red' }}>
     <span>Text is NOT red and there is a type error</span>
   </DivWithoutClassName>

--- a/stories/keyframes-object-call-expression.tsx
+++ b/stories/keyframes-object-call-expression.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { css, keyframes, styled } from '@compiled/react';
 
 import './keyframes/globals';

--- a/stories/keyframes-tagged-template-expression.tsx
+++ b/stories/keyframes-tagged-template-expression.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { css, keyframes, styled } from '@compiled/react';
 
 import './keyframes/globals';

--- a/stories/simple-function-mixins.tsx
+++ b/stories/simple-function-mixins.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { styled } from '@compiled/react';
 import { colorMixin, colors, objectStyles } from '@compiled-private/module-a';
 

--- a/stories/static-evaluation.tsx
+++ b/stories/static-evaluation.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { styled } from '@compiled/react';
 
 export default {

--- a/stories/style-buckets.tsx
+++ b/stories/style-buckets.tsx
@@ -1,4 +1,4 @@
-import '@compiled/react';
+/** @jsxImportSource @compiled/react */
 
 import { hoverObjectLiteral } from './mixins';
 

--- a/stories/styled-interpolation-function-behavior.tsx
+++ b/stories/styled-interpolation-function-behavior.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @compiled/react */
 import { styled } from '@compiled/react';
 
 export default {


### PR DESCRIPTION
This pull request adds a typecheck command and adds it to the CI run. It also fixes a ton of violations. One thing I haven't reconciled yet is how to typecheck the project references with the same command, any ideas let me know! Perhaps we just exclude packages and assume they're typechecked when generating the types?...