### PR TITLE
Fix r18 JSX namespace types

### DIFF
--- a/.changeset/clever-readers-relax.md
+++ b/.changeset/clever-readers-relax.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Add `ElementType` to the Compiled JSX namespace. This is needed to ensure types are the same in the Compiled JSX namspace and the default React one, such as returning `undefined`, `string`, and other freshly valid types.

--- a/packages/react/src/jsx/jsx-local-namespace.ts
+++ b/packages/react/src/jsx/jsx-local-namespace.ts
@@ -49,6 +49,9 @@ type WithConditionalCSSProp<TProps> = 'className' extends keyof TProps
     {};
 
 // Unpack all here to avoid infinite self-referencing when defining our own JSX namespace
+// Based on the code from @types/react@18.2.8 / @emotion-js
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/3197efc097d522c4bf02b94e1a0766d007d6cdeb/types/react/index.d.ts#LL3204C13-L3204C13
+type ReactJSXElementType = string | React.JSXElementConstructor<any>;
 type ReactJSXElement = JSX.Element;
 type ReactJSXElementClass = JSX.ElementClass;
 type ReactJSXElementAttributesProperty = JSX.ElementAttributesProperty;
@@ -59,6 +62,7 @@ type ReactJSXIntrinsicClassAttributes<T> = JSX.IntrinsicClassAttributes<T>;
 type ReactJSXIntrinsicElements = JSX.IntrinsicElements;
 
 export namespace CompiledJSX {
+  export type ElementType = ReactJSXElementType;
   export type Element = ReactJSXElement;
   export type ElementClass = ReactJSXElementClass;
   export type ElementAttributesProperty = ReactJSXElementAttributesProperty;


### PR DESCRIPTION
Inspiration: https://github.com/emotion-js/emotion/pull/3048/

This pull request adds a new type to Compiled's JSX namespace to fix usage with React 18 and its new return types (undefined / string / etc).