### PR TITLE
Bail out early in parcel-transformer if @compiled/react is not present

### DIFF
--- a/.changeset/ten-candles-own.md
+++ b/.changeset/ten-candles-own.md
@@ -1,0 +1,5 @@
+---
+'@compiled/parcel-transformer': patch
+---
+
+Allow the transformer to bail early if compiled isn't present

--- a/packages/parcel-transformer/src/index.ts
+++ b/packages/parcel-transformer/src/index.ts
@@ -87,7 +87,10 @@ export default new Transformer<ParcelTransformerOpts>({
     }
 
     const code = await asset.getCode();
-    if (code.indexOf('@compiled/react') === -1) {
+    if (
+      code.indexOf('@compiled/react') === -1 &&
+      (config.importSources?.every((importSource) => code.indexOf(importSource) === -1) ?? true)
+    ) {
       // We only want to parse files that are actually using Compiled.
       // For everything else we bail out.
       return undefined;

--- a/packages/parcel-transformer/src/index.ts
+++ b/packages/parcel-transformer/src/index.ts
@@ -89,7 +89,7 @@ export default new Transformer<ParcelTransformerOpts>({
     const code = await asset.getCode();
     if (
       code.indexOf('@compiled/react') === -1 &&
-      (config.importSources?.every((importSource) => code.indexOf(importSource) === -1) ?? true)
+      (config.importSources?.every((importSource) => !code.includes(importSource)) ?? true)
     ) {
       // We only want to parse files that are actually using Compiled.
       // For everything else we bail out.


### PR DESCRIPTION
# Description
The transformer flames out if we don't have @compiled/react in a page, this PR just allows it to bail early