### PR TITLE
Add `importSources` option to jsx-pragma rule

### DIFF
--- a/.changeset/purple-squids-switch.md
+++ b/.changeset/purple-squids-switch.md
@@ -2,4 +2,4 @@
 '@compiled/eslint-plugin': patch
 ---
 
-Add `onlyRunIfImportingCompiled` option to `jsx-pragma` rule, to specify additional libraries that should be considered Compiled imports
+Add `importSources` option to `jsx-pragma` rule, to specify additional libraries that should be considered Compiled imports

--- a/.changeset/purple-squids-switch.md
+++ b/.changeset/purple-squids-switch.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Add `onlyRunIfImportingCompiled` option to `jsx-pragma` rule, to specify additional libraries that should be considered Compiled imports

--- a/packages/eslint-plugin/src/rules/jsx-pragma/README.md
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/README.md
@@ -64,7 +64,7 @@ import { jsx } from '@emotion/react';
 ```js
 // [{
 //   "detectConflictWithOtherLibraries": true,
-//   "alsoAddCompiledPragmaFor": ["@atlaskit/css"],
+//   "importSources": ["@atlaskit/css"],
 // }]
 
 /** @jsx jsx */
@@ -117,7 +117,7 @@ defaults to automatic.
 ### `detectConflictWithOtherLibraries: boolean`
 
 Raises a linting error if `css` or `jsx` is imported from `@emotion/react` (or `@emotion/core`) in the same file
-as a Compiled import. By default, Compiled import is an import from `@compiled/react`, but you can change this by specifying `alsoAddCompiledPragmaFor`.
+as a Compiled import. By default, Compiled import is an import from `@compiled/react`, but you can change this by specifying `importSources`.
 
 This is important as Emotion can't be used with Compiled in the same file, and ignoring this linting error will
 result in a confusing runtime error.
@@ -129,12 +129,14 @@ This defaults to `true`.
 By default, the `jsx-pragma` rule suggests adding the Compiled JSX pragma whenever the `css` attribute is being
 used. This may not be ideal if your codebase uses a mix of Compiled and other libraries (e.g. Emotion,
 styled-components). Setting `onlyRunIfImportingCompiled` to true turns off this rule unless `css` or `cssMap`
-are imported from Compiled (`@compiled/react`, unless you specify `alsoAddCompiledPragmaFor`).
+are imported from Compiled (`@compiled/react`, unless you specify `importSources`).
 
 Note that this option does not affect `xcss`.
 
 This option defaults to `false`.
 
-### `alsoAddCompiledPragmaFor: boolean`
+### `importSources: boolean`
 
 By default, we consider an import from Compiled to be one from `@compiled/react`, in the context of the `detectConflictWithOtherLibraries` and `onlyRunIfImportingCompiled` options described above. However, if you are providing a wrapper around `@compiled/react`, you can specify _additional_ libraries that should be considered a "Compiled import".
+
+Note that `@compiled/react` is always implicitly included.

--- a/packages/eslint-plugin/src/rules/jsx-pragma/README.md
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/README.md
@@ -28,7 +28,7 @@ The `--fix` option on the command line automatically fixes problems reported by 
 👎 Examples of **incorrect** code for this rule:
 
 ```js
-// [{ "pragma": "jsx" }]
+// [{ "runtime": "automatic" }]
 
 /** @jsx jsx */
     ^^^^^^^^ should use jsxImportSource pragma
@@ -36,7 +36,7 @@ import { jsx } from '@compiled/react';
 ```
 
 ```js
-// [{ "pragma": "jsxImportSource" }]
+// [{ "runtime": "classic" }]
 
 /** @jsxImportSource @compiled/react */
     ^^^^^^^^^^^^^^^^ should use jsx pragma
@@ -44,8 +44,6 @@ import { jsx } from '@compiled/react';
 ```
 
 ```js
-// [{ "pragma": "jsxImportSource" }]
-
 import '@compiled/react';
 
 <div css={{ display: 'block' }} />;
@@ -57,6 +55,20 @@ import '@compiled/react';
 
 /** @jsx jsx */
 import { css } from '@compiled/react';
+import { jsx } from '@emotion/react';
+
+<div css={css({ display: 'block' })} />;
+          ^^^ cannot mix Compiled and Emotion
+```
+
+```js
+// [{
+//   "detectConflictWithOtherLibraries": true,
+//   "alsoAddCompiledPragmaFor": ["@atlaskit/css"],
+// }]
+
+/** @jsx jsx */
+import { css } from '@atlaskit/css';
 import { jsx } from '@emotion/react';
 
 <div css={css({ display: 'block' })} />;
@@ -105,7 +117,7 @@ defaults to automatic.
 ### `detectConflictWithOtherLibraries: boolean`
 
 Raises a linting error if `css` or `jsx` is imported from `@emotion/react` (or `@emotion/core`) in the same file
-as a Compiled import.
+as a Compiled import. By default, Compiled import is an import from `@compiled/react`, but you can change this by specifying `alsoAddCompiledPragmaFor`.
 
 This is important as Emotion can't be used with Compiled in the same file, and ignoring this linting error will
 result in a confusing runtime error.
@@ -117,8 +129,12 @@ This defaults to `true`.
 By default, the `jsx-pragma` rule suggests adding the Compiled JSX pragma whenever the `css` attribute is being
 used. This may not be ideal if your codebase uses a mix of Compiled and other libraries (e.g. Emotion,
 styled-components). Setting `onlyRunIfImportingCompiled` to true turns off this rule unless `css` or `cssMap`
-are imported from `@compiled/react`.
+are imported from Compiled (`@compiled/react`, unless you specify `alsoAddCompiledPragmaFor`).
 
 Note that this option does not affect `xcss`.
 
 This option defaults to `false`.
+
+### `alsoAddCompiledPragmaFor: boolean`
+
+By default, we consider an import from Compiled to be one from `@compiled/react`, in the context of the `detectConflictWithOtherLibraries` and `onlyRunIfImportingCompiled` options described above. However, if you are providing a wrapper around `@compiled/react`, you can specify _additional_ libraries that should be considered a "Compiled import".

--- a/packages/eslint-plugin/src/rules/jsx-pragma/README.md
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/README.md
@@ -129,7 +129,7 @@ This defaults to `true`.
 By default, the `jsx-pragma` rule suggests adding the Compiled JSX pragma whenever the `css` attribute is being
 used. This may not be ideal if your codebase uses a mix of Compiled and other libraries (e.g. Emotion,
 styled-components). Setting `onlyRunIfImportingCompiled` to true turns off this rule unless `css` or `cssMap`
-are imported from Compiled (`@compiled/react`, unless you specify `importSources`).
+are imported from Compiled (`@compiled/react`, unless `importSources` is specified and not empty).
 
 Note that this option does not affect `xcss`.
 

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
@@ -232,7 +232,7 @@ import { css } from '@compiled/react';
         // check the raw message, not the messageId, to ensure that this
         // says "jsxImportSource pragma" and not "jsx pragma"
         {
-          message: 'To use the `css` prop you must set the jsx pragma.',
+          message: 'To use the `css` prop you must set the jsxImportSource pragma.',
         },
       ],
     },

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
@@ -105,6 +105,16 @@ tester.run('jsx-pragma', jsxPragmaRule, {
       `,
       options: [{ onlyRunIfImportingCompiled: true }],
     },
+    {
+      name: 'when importSources is non-empty, onlyRunIfImportingCompiled should automatically be set to true',
+      // If we get an error here, then onlyRunIfImportingCompiled was not set to true.
+      code: `
+        /** @jsx jsx */
+        import { css, jsx } from '@emotion/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [{ importSources: ['@atlaskit/css'] }],
+    },
   ],
   invalid: [
     {
@@ -595,6 +605,24 @@ import { css } from '@atlaskit/css';
           messageId: 'missingPragma',
         },
       ],
+    },
+    {
+      name: 'when importSources is empty, onlyRunIfImportingCompiled should not automatically be set to true',
+      code: `
+        import { css } from '@emotion/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      output: `
+        /** @jsxImportSource @compiled/react */
+import { css } from '@emotion/react';
+        <div css={css({ display: 'block' })} />
+      `,
+      errors: [
+        {
+          messageId: 'missingPragma',
+        },
+      ],
+      options: [{ importSources: [] }],
     },
   ],
 });

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
@@ -3,25 +3,41 @@ import { jsxPragmaRule } from '../index';
 
 tester.run('jsx-pragma', jsxPragmaRule, {
   valid: [
-    `
-      /** @jsxImportSource @compiled/react */
-      <div css={{ display: 'block' }} />
-    `,
-    `
-      <AnotherComponent className={xcss} />
-    `,
-    `
-      <div className={anythingElse} />
-    `,
-    `
-      /** @jsxImportSource @compiled/react */
-      <div className={xcss} />
-    `,
-    `
-      /** @jsxImportSource @compiled/react */
-      <div className={innerXcss} />
-    `,
     {
+      name: 'should be valid if automatic jsx pragma is used',
+      code: `
+        /** @jsxImportSource @compiled/react */
+        <div css={{ display: 'block' }} />
+      `,
+    },
+    {
+      name: 'should be valid if using xcss on a React component',
+      code: `
+        <AnotherComponent className={xcss} />
+      `,
+    },
+    {
+      name: 'should be valid if not using xcss on a JSX element',
+      code: `
+        <div className={anythingElse} />
+      `,
+    },
+    {
+      name: 'should be valid if using xcss on a JSX element with automatic jsx pragma',
+      code: `
+        /** @jsxImportSource @compiled/react */
+        <div className={xcss} />
+      `,
+    },
+    {
+      name: 'should be valid if using xcss under a different name with automatic jsx pragma',
+      code: `
+        /** @jsxImportSource @compiled/react */
+        <div className={innerXcss} />
+      `,
+    },
+    {
+      name: 'should be valid if runtime = automatic and automatic jsx pragma is used',
       code: `
         /** @jsxImportSource @compiled/react */
         <div css={{ display: 'block' }} />
@@ -29,6 +45,7 @@ tester.run('jsx-pragma', jsxPragmaRule, {
       options: [{ runtime: 'automatic' }],
     },
     {
+      name: 'should be valid if runtime = classic and classic jsx pragma is used',
       code: `
         /** @jsx jsx */
         import { jsx } from '@compiled/react';
@@ -46,6 +63,7 @@ tester.run('jsx-pragma', jsxPragmaRule, {
       options: [{ runtime: 'automatic' }],
     },
     {
+      name: 'should be valid if runtime = classic and classic jsx pragma is used with css function call',
       code: `
         /** @jsx jsx */
         import { css, jsx } from '@compiled/react';
@@ -90,26 +108,29 @@ tester.run('jsx-pragma', jsxPragmaRule, {
   ],
   invalid: [
     {
+      name: 'should error if pragma missing when using xcss on JSX element',
       code: `
-      <div className={xcss} />
+        <div className={xcss} />
       `,
       output: `
-      /** @jsxImportSource @compiled/react */
+        /** @jsxImportSource @compiled/react */
 <div className={xcss} />
       `,
       errors: [{ messageId: 'missingPragmaXCSS' }],
     },
     {
+      name: 'should error if pragma missing when using xcss under different name',
       code: `
-      <div className={innerXcss} />
-    `,
+        <div className={innerXcss} />
+      `,
       output: `
-      /** @jsxImportSource @compiled/react */
+        /** @jsxImportSource @compiled/react */
 <div className={innerXcss} />
-    `,
+      `,
       errors: [{ messageId: 'missingPragmaXCSS' }],
     },
     {
+      name: 'should add jsx pragma and Compiled import if neither are there',
       code: `<div css={{ display: 'block' }} />`,
       output: `/** @jsx jsx */
 import { jsx } from '@compiled/react';
@@ -122,6 +143,7 @@ import { jsx } from '@compiled/react';
       ],
     },
     {
+      name: 'should replace automatic jsx pragma with classic pragma, if runtime = classic',
       code: `
         /** @jsxImportSource @compiled/react */
         <div css={{ display: 'block' }} />
@@ -139,6 +161,7 @@ import { jsx } from '@compiled/react';
       ],
     },
     {
+      name: 'should replace automatic jsx pragma with classic pragma, if runtime = classic (with css function call)',
       code: `
         /** @jsxImportSource @compiled/react */
         import { css } from '@compiled/react';
@@ -157,6 +180,7 @@ import { jsx } from '@compiled/react';
       ],
     },
     {
+      name: 'should replace automatic jsx pragma with classic pragma, if runtime = classic',
       code: `
         import '@compiled/react';
         <Fragment>
@@ -173,14 +197,15 @@ import { jsx } from '@compiled/react';
       options: [{ runtime: 'classic' }],
       errors: [
         {
-          message: 'To use the `css` prop you must set the jsx pragma.',
+          messageId: 'missingPragma',
         },
         {
-          message: 'To use the `css` prop you must set the jsx pragma.',
+          messageId: 'missingPragma',
         },
       ],
     },
     {
+      name: 'should add automatic jsx pragma if not specified',
       code: `<div css={{ display: 'block' }} />`,
       output: `/** @jsxImportSource @compiled/react */
 <div css={{ display: 'block' }} />`,
@@ -191,6 +216,7 @@ import { jsx } from '@compiled/react';
       ],
     },
     {
+      name: 'should add automatic jsx pragma if css function call is used',
       code: `
         import { css } from '@compiled/react';
         <div css={css({ display: 'block' })} />
@@ -202,11 +228,12 @@ import { css } from '@compiled/react';
       `,
       errors: [
         {
-          message: 'To use the `css` prop you must set the jsxImportSource pragma.',
+          messageId: 'missingPragma',
         },
       ],
     },
     {
+      name: 'should add classic jsx pragma if css function call is used',
       code: `/** @jsx jsx */ import { jsx } from '@compiled/react';<div css={{ display: 'block' }} />`,
       output: `/** @jsxImportSource @compiled/react */ <div css={{ display: 'block' }} />`,
       errors: [
@@ -216,6 +243,7 @@ import { css } from '@compiled/react';
       ],
     },
     {
+      name: 'should keep other Compiled imports intact when fixing',
       code: `/** @jsx jsx */ import { jsx, styled } from '@compiled/react';<div css={{ display: 'block' }} />`,
       output: `/** @jsxImportSource @compiled/react */ import { styled } from '@compiled/react';<div css={{ display: 'block' }} />`,
       errors: [
@@ -225,6 +253,7 @@ import { css } from '@compiled/react';
       ],
     },
     {
+      name: 'should keep other, renamed Compiled imports intact when fixing',
       code: `/** @jsx jsx */ import { jsx, styled as styl } from '@compiled/react';<div css={{ display: 'block' }} />`,
       output: `/** @jsxImportSource @compiled/react */ import { styled as styl } from '@compiled/react';<div css={{ display: 'block' }} />`,
       errors: [
@@ -234,6 +263,7 @@ import { css } from '@compiled/react';
       ],
     },
     {
+      name: 'should remove React default import',
       code: `
         import React from 'react';
         import { css } from '@compiled/react';
@@ -252,6 +282,7 @@ import { css } from '@compiled/react';
       ],
     },
     {
+      name: 'should keep React import if React is used',
       code: `
         import React from 'react';
         import { css } from '@compiled/react';
@@ -276,6 +307,7 @@ import React from 'react';
       ],
     },
     {
+      name: 'should remove React default import if other React imports are imported separately',
       code: `
         import React, { useState } from 'react';
         import { css } from '@compiled/react';
@@ -300,30 +332,7 @@ import { useState } from 'react';
       ],
     },
     {
-      code: `
-        import React,{useState } from 'react';
-        import { css } from '@compiled/react';
-
-        useState();
-
-        <div css={css({ display: 'block' })} />
-      `,
-      output: `
-        /** @jsxImportSource @compiled/react */
-import { useState } from 'react';
-        import { css } from '@compiled/react';
-
-        useState();
-
-        <div css={css({ display: 'block' })} />
-      `,
-      errors: [
-        {
-          messageId: 'missingPragma',
-        },
-      ],
-    },
-    {
+      name: 'should keep React import if no React default imports present',
       code: `
         import { useState } from 'react';
         import { css } from '@compiled/react';
@@ -348,6 +357,7 @@ import { useState } from 'react';
       ],
     },
     {
+      name: 'should keep React namespace import if used in file',
       code: `
         import * as React from 'react';
         import { css } from '@compiled/react';
@@ -372,6 +382,7 @@ import * as React from 'react';
       ],
     },
     {
+      name: 'should remove React namespace import',
       code: `
         import * as React from 'react';
         import { css } from '@compiled/react';
@@ -532,6 +543,52 @@ import * as React from 'react';
       errors: [
         {
           messageId: 'emotionAndCompiledConflict',
+        },
+      ],
+    },
+    {
+      name: 'should error if Emotion css and Compiled styled are used (with alsoAddCompiledPragmaFor)',
+      code: `
+        import { css } from '@emotion/react';
+        import { styled } from '@atlaskit/css';
+        <div css={css({ display: 'block' })} />
+      `,
+      options: [
+        {
+          alsoAddCompiledPragmaFor: ['@atlaskit/css'],
+          onlyRunIfImportingCompiled: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'emotionAndCompiledConflict',
+        },
+      ],
+    },
+    {
+      name: 'should consider libraries in alsoAddCompiledPragmaFor to be Compiled imports',
+      code: `
+        import { css } from '@atlaskit/css';
+
+        const styles = css({ display: 'block' });
+        <div css={styles} />
+      `,
+      output: `
+        /** @jsxImportSource @compiled/react */
+import { css } from '@atlaskit/css';
+
+        const styles = css({ display: 'block' });
+        <div css={styles} />
+      `,
+      options: [
+        {
+          alsoAddCompiledPragmaFor: ['@atlaskit/css'],
+          onlyRunIfImportingCompiled: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'missingPragma',
         },
       ],
     },

--- a/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/__tests__/rule.test.ts
@@ -196,11 +196,13 @@ import { jsx } from '@compiled/react';
         </Fragment>`,
       options: [{ runtime: 'classic' }],
       errors: [
+        // check the raw message, not the messageId, to ensure that this
+        // says "jsx pragma" and not "jsxImportSource pragma"
         {
-          messageId: 'missingPragma',
+          message: 'To use the `css` prop you must set the jsx pragma.',
         },
         {
-          messageId: 'missingPragma',
+          message: 'To use the `css` prop you must set the jsx pragma.',
         },
       ],
     },
@@ -227,8 +229,10 @@ import { css } from '@compiled/react';
         <div css={css({ display: 'block' })} />
       `,
       errors: [
+        // check the raw message, not the messageId, to ensure that this
+        // says "jsxImportSource pragma" and not "jsx pragma"
         {
-          messageId: 'missingPragma',
+          message: 'To use the `css` prop you must set the jsx pragma.',
         },
       ],
     },
@@ -547,7 +551,7 @@ import * as React from 'react';
       ],
     },
     {
-      name: 'should error if Emotion css and Compiled styled are used (with alsoAddCompiledPragmaFor)',
+      name: 'should error if Emotion css and Compiled styled are used (with importSources)',
       code: `
         import { css } from '@emotion/react';
         import { styled } from '@atlaskit/css';
@@ -555,7 +559,7 @@ import * as React from 'react';
       `,
       options: [
         {
-          alsoAddCompiledPragmaFor: ['@atlaskit/css'],
+          importSources: ['@atlaskit/css'],
           onlyRunIfImportingCompiled: true,
         },
       ],
@@ -566,7 +570,7 @@ import * as React from 'react';
       ],
     },
     {
-      name: 'should consider libraries in alsoAddCompiledPragmaFor to be Compiled imports',
+      name: 'should consider libraries in importSources to be Compiled imports',
       code: `
         import { css } from '@atlaskit/css';
 
@@ -582,7 +586,7 @@ import { css } from '@atlaskit/css';
       `,
       options: [
         {
-          alsoAddCompiledPragmaFor: ['@atlaskit/css'],
+          importSources: ['@atlaskit/css'],
           onlyRunIfImportingCompiled: true,
         },
       ],

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
@@ -14,7 +14,7 @@ type Options = {
   detectConflictWithOtherLibraries: boolean;
   onlyRunIfImportingCompiled: boolean;
   runtime: 'classic' | 'automatic';
-  alsoAddCompiledPragmaFor: string[];
+  importSources: string[];
 };
 
 const getOtherLibraryImports = (context: Rule.RuleContext): ImportDeclaration[] => {
@@ -135,7 +135,7 @@ export const jsxPragmaRule: Rule.RuleModule = {
           onlyRunIfImportingCompiled: {
             type: 'boolean',
           },
-          alsoAddCompiledPragmaFor: {
+          importSources: {
             type: 'array',
             items: [
               {
@@ -155,9 +155,9 @@ export const jsxPragmaRule: Rule.RuleModule = {
     const options: Options = {
       detectConflictWithOtherLibraries: optionsRaw.detectConflictWithOtherLibraries ?? true,
       onlyRunIfImportingCompiled:
-        optionsRaw.onlyRunIfImportingCompiled ?? optionsRaw.alsoAddCompiledPragmaFor ?? false,
+        optionsRaw.onlyRunIfImportingCompiled ?? optionsRaw.importSources ?? false,
       runtime: optionsRaw.runtime ?? 'automatic',
-      alsoAddCompiledPragmaFor: optionsRaw.alsoAddCompiledPragmaFor ?? [],
+      importSources: optionsRaw.importSources ?? [],
     };
 
     const source = context.getSourceCode();
@@ -166,7 +166,7 @@ export const jsxPragmaRule: Rule.RuleModule = {
     const compiledImports = findLibraryImportDeclarations(context);
     const otherCompiledImports = findLibraryImportDeclarations(
       context,
-      options.alsoAddCompiledPragmaFor
+      options.importSources,
     );
     const otherLibraryImports = getOtherLibraryImports(context);
     const jsxPragma = findJsxPragma(comments, compiledImports);

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
@@ -164,10 +164,7 @@ export const jsxPragmaRule: Rule.RuleModule = {
     const comments = source.getAllComments();
 
     const compiledImports = findLibraryImportDeclarations(context);
-    const otherCompiledImports = findLibraryImportDeclarations(
-      context,
-      options.importSources,
-    );
+    const otherCompiledImports = findLibraryImportDeclarations(context, options.importSources);
     const otherLibraryImports = getOtherLibraryImports(context);
     const jsxPragma = findJsxPragma(comments, compiledImports);
     const jsxImportSourcePragma = findJsxImportSourcePragma(comments);

--- a/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
+++ b/packages/eslint-plugin/src/rules/jsx-pragma/index.ts
@@ -155,7 +155,7 @@ export const jsxPragmaRule: Rule.RuleModule = {
     const options: Options = {
       detectConflictWithOtherLibraries: optionsRaw.detectConflictWithOtherLibraries ?? true,
       onlyRunIfImportingCompiled:
-        optionsRaw.onlyRunIfImportingCompiled ?? optionsRaw.importSources ?? false,
+        optionsRaw.onlyRunIfImportingCompiled ?? !!optionsRaw.importSources?.length,
       runtime: optionsRaw.runtime ?? 'automatic',
       importSources: optionsRaw.importSources ?? [],
     };


### PR DESCRIPTION
Currently, the `jsx-pragma` rule only supports detecting and handling `@compiled/react` to ensure the JSX pragma is there.

However, with the `createStrictAPI` from contributions by @kylorhall-atlassian and @itsdouges, we might have Compiled APIs being imported by other libraries (e.g. `@atlaskit/css`). We add an `importSources` option to specify what these additional libraries are. This option affects two other options:

* What is counted as a "Compiled import" in the `detectConflictWithOtherLibraries` option, where we detect whether Compiled imports conflict with Emotion imports
* What is counted as a "Compiled import" in the `onlyRunIfImportingCompiled` option, where we only run this rule if a Compiled import is used in the file.