### PR TITLE
Fix Compiled props being incorrectly forwarded when default values used

### DIFF
--- a/.changeset/two-dryers-sniff.md
+++ b/.changeset/two-dryers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Fix props (used by Compiled) being incorrectly forwarded to React when default values are used.

--- a/packages/babel-plugin/src/utils/normalize-props-usage.ts
+++ b/packages/babel-plugin/src/utils/normalize-props-usage.ts
@@ -116,17 +116,20 @@ const normalizeDestructuredString = (
  * @returns A member expression.
  */
 const createNestedMemberExpression = (objectChain: string[]): t.Identifier | t.MemberExpression => {
-  if (objectChain.length === 1) return t.identifier(objectChain[0]);
-  if (objectChain.length > 1) {
-    const [init, last] = [
-      objectChain.slice(0, objectChain.length - 1),
-      objectChain[objectChain.length - 1],
-    ];
-    return t.memberExpression(createNestedMemberExpression(init), t.identifier(last));
+  if (objectChain.length === 0) {
+    throw new Error(
+      'Could not build a Compiled component, due to objectChain being empty when generating a member expression. This is likely a bug with Compiled - please file a bug report.'
+    );
   }
-  throw new Error(
-    'Could not build a Compiled component, due to objectChain being empty when generating a member expression. This is likely a bug with Compiled - please file a bug report.'
-  );
+  if (objectChain.length === 1) {
+    return t.identifier(objectChain[0]);
+  }
+
+  const [initial, last] = [
+    objectChain.slice(0, objectChain.length - 1),
+    objectChain[objectChain.length - 1],
+  ];
+  return t.memberExpression(createNestedMemberExpression(initial), t.identifier(last));
 };
 
 const normalizeDestructuredObject = (

--- a/packages/babel-plugin/src/utils/normalize-props-usage.ts
+++ b/packages/babel-plugin/src/utils/normalize-props-usage.ts
@@ -108,6 +108,27 @@ const normalizeDestructuredString = (
   });
 };
 
+/**
+ * Create a member expression from a list of strings. For example, if
+ * `objectChain = ['a', 'b', 'c']`, the generated member expression will be
+ * `a.b.c`.
+ * @param objectChain List of strings
+ * @returns A member expression.
+ */
+const createNestedMemberExpression = (objectChain: string[]): t.Identifier | t.MemberExpression => {
+  if (objectChain.length === 1) return t.identifier(objectChain[0]);
+  if (objectChain.length > 1) {
+    const [init, last] = [
+      objectChain.slice(0, objectChain.length - 1),
+      objectChain[objectChain.length - 1],
+    ];
+    return t.memberExpression(createNestedMemberExpression(init), t.identifier(last));
+  }
+  throw new Error(
+    'Could not build a Compiled component, due to objectChain being empty when generating a member expression. This is likely a bug with Compiled - please file a bug report.'
+  );
+};
+
 const normalizeDestructuredObject = (
   bindings: Record<string, Binding>,
   values: Record<string, t.Expression>,
@@ -128,10 +149,10 @@ const normalizeDestructuredObject = (
           // passing null to the function will still result in the
           // default value being used.
           reference.replaceWith(
-            t.logicalExpression('??', t.identifier(objectChain.join('.')), defaultValue)
+            t.logicalExpression('??', createNestedMemberExpression(objectChain), defaultValue)
           );
         } else {
-          reference.replaceWithSourceString(objectChain.join('.'));
+          reference.replaceWith(createNestedMemberExpression(objectChain));
         }
       });
     }


### PR DESCRIPTION
Fixes #1629 

https://github.com/atlassian-labs/compiled/blob/9860df3850ac5023ffa93201f5648fd7c81807c5/packages/babel-plugin/src/utils/build-styled-component.ts#L80 expects a MemberExpression in order to detect what props shouldn't be forwarded to React. All other props are forwarded to React. (see this PR for more context: https://github.com/atlassian-labs/compiled/pull/1273)

However, when we handle default values in situations like these...

```
import { styled } from '@compiled/react';
const styled.div({
    margin: ({ marginTop = 12 }) => marginTop,
});
```

`@compiled/babel-plugin` used the `t.identifier` function to generate the `__cmplp.marginTop` expression:

```
styled.div<{
  marginTop?: string;
}>({
  marginTop: __cmplp => __cmplp.marginTop ?? '24px'
})
```

The above appears correct, because the build output is identical and Babel doesn't stop us from passing invalid expressions to the `t.identifier` function... however, the use of `t.identifier` and `t.memberExpression` meant that it would never get detected as a MemberExpression, and thus the prop would never _not_ be forwarded to React :(

This  PR fixes this by replacing `t.identifier` with `t.memberExpression`.
