### PR TITLE
Fix passing props arrow function directly to styled not working

### DIFF
--- a/.changeset/rare-pans-trade.md
+++ b/.changeset/rare-pans-trade.md
@@ -4,7 +4,7 @@
 
 Previously, if you passed `props => ...` directly to `styled.div` or `css()`, and the return value of the arrow function was an object, you would cause `@compiled/babel-plugin` to crash:
 
-```
+```tsx
 import { styled } from '@compiled/react';
 import React from 'react';
 
@@ -16,7 +16,7 @@ const Component = styled.div(props => ({
 
 While at the same time, wrapping the return value inside a logical expression or ternary expression would make it work perfectly fine:
 
-```
+```tsx
 const Styles = styled.div(
   (props) => (props.isEditing ? {} : { backgroundColor: props.highlightColor }),
 );

--- a/.changeset/rare-pans-trade.md
+++ b/.changeset/rare-pans-trade.md
@@ -1,0 +1,25 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Previously, if you passed `props => ...` directly to `styled.div` or `css()`, and the return value of the arrow function was an object, you would cause `@compiled/babel-plugin` to crash:
+
+```
+import { styled } from '@compiled/react';
+import React from 'react';
+
+const Component = styled.div(props => ({
+  color: `${props.customColor}`,
+  background: props.background,
+}));
+```
+
+While at the same time, wrapping the return value inside a logical expression or ternary expression would make it work perfectly fine:
+
+```
+const Styles = styled.div(
+  (props) => (props.isEditing ? {} : { backgroundColor: props.highlightColor }),
+);
+```
+
+With this version, both of these forms will work without issue. :)

--- a/.changeset/rare-pans-trade.md
+++ b/.changeset/rare-pans-trade.md
@@ -8,7 +8,7 @@ Previously, if you passed `props => ...` directly to `styled.div` or `css()`, an
 import { styled } from '@compiled/react';
 import React from 'react';
 
-const Component = styled.div(props => ({
+const Component = styled.div((props) => ({
   color: `${props.customColor}`,
   background: props.background,
 }));
@@ -17,8 +17,8 @@ const Component = styled.div(props => ({
 While at the same time, wrapping the return value inside a logical expression or ternary expression would make it work perfectly fine:
 
 ```tsx
-const Styles = styled.div(
-  (props) => (props.isEditing ? {} : { backgroundColor: props.highlightColor }),
+const Styles = styled.div((props) =>
+  props.isEditing ? {} : { backgroundColor: props.highlightColor }
 );
 ```
 

--- a/packages/babel-plugin/src/styled/__tests__/behaviour.test.ts
+++ b/packages/babel-plugin/src/styled/__tests__/behaviour.test.ts
@@ -869,6 +869,42 @@ describe('styled component behaviour', () => {
     );
   });
 
+  it('should apply unconditional CSS with props', () => {
+    const actual = transform(`
+      import { styled } from '@compiled/react';
+
+      const Component = styled.div(
+        props => ({ color: props.primary }),
+      );
+    `);
+
+    expect(actual).toIncludeMultiple([
+      'const _="._syaz1q2z{color:var(--_1r7cl4y)}"',
+      '"--_1r7cl4y":ix(__cmplp.primary)',
+    ]);
+
+    expect(actual).toInclude('className={ax(["_syaz1q2z",__cmplp.className])}');
+  });
+
+  it('should apply unconditional CSS with and without props', () => {
+    const actual = transform(`
+      import { styled } from '@compiled/react';
+
+      const Component = styled.div(
+        { background: 'red' },
+        props => ({ color: props.primary }),
+      );
+    `);
+
+    expect(actual).toIncludeMultiple([
+      '._syaz1q2z{color:var(--_1r7cl4y)}',
+      '._bfhk5scu{background-color:red}',
+      '--_1r7cl4y":ix(__cmplp.primary)}',
+    ]);
+
+    expect(actual).toInclude('className={ax(["_bfhk5scu _syaz1q2z",__cmplp.className])}');
+  });
+
   it('should apply conditional CSS with object styles', () => {
     const actual = transform(`
       import { styled } from '@compiled/react';

--- a/packages/babel-plugin/src/utils/__tests__/normalize-props.usage.test.ts
+++ b/packages/babel-plugin/src/utils/__tests__/normalize-props.usage.test.ts
@@ -42,6 +42,14 @@ describe('normalizePropsUsage', () => {
 
   describe('destructured props', () => {
     it('reconstructs destructured props param', () => {
+      const actual = transform(
+        `styled.div(({ customColor }) => ({ backgroundColor: customColor }));`
+      );
+
+      expect(actual).toInclude(`(${P_NAME}) => ({ backgroundColor: ${P_NAME}.customColor,}))`);
+    });
+
+    it('reconstructs destructured props param with logical expression', () => {
       const actual = transform(`
         styled.div(({ width }) => width && { width });
     `);

--- a/packages/babel-plugin/src/utils/css-builders.ts
+++ b/packages/babel-plugin/src/utils/css-builders.ts
@@ -877,16 +877,18 @@ export const buildCss = (node: t.Expression | t.Expression[], meta: Metadata): C
     return buildCss(value, updatedMeta);
   }
 
-  if (t.isArrowFunctionExpression(node) && t.isObjectExpression(node.body)) {
-    return buildCss(node.body, meta);
-  }
+  if (t.isArrowFunctionExpression(node)) {
+    if (t.isObjectExpression(node.body)) {
+      return buildCss(node.body, meta);
+    }
 
-  if (t.isArrowFunctionExpression(node) && t.isLogicalExpression(node.body)) {
-    return extractLogicalExpression(node, meta);
-  }
+    if (t.isLogicalExpression(node.body)) {
+      return extractLogicalExpression(node, meta);
+    }
 
-  if (t.isArrowFunctionExpression(node) && t.isConditionalExpression(node.body)) {
-    return extractConditionalExpression(node.body, meta);
+    if (t.isConditionalExpression(node.body)) {
+      return extractConditionalExpression(node.body, meta);
+    }
   }
 
   if (t.isIdentifier(node)) {

--- a/packages/babel-plugin/src/utils/css-builders.ts
+++ b/packages/babel-plugin/src/utils/css-builders.ts
@@ -877,6 +877,10 @@ export const buildCss = (node: t.Expression | t.Expression[], meta: Metadata): C
     return buildCss(value, updatedMeta);
   }
 
+  if (t.isArrowFunctionExpression(node) && t.isObjectExpression(node.body)) {
+    return buildCss(node.body, meta);
+  }
+
   if (t.isArrowFunctionExpression(node) && t.isLogicalExpression(node.body)) {
     return extractLogicalExpression(node, meta);
   }

--- a/packages/babel-plugin/src/utils/css-builders.ts
+++ b/packages/babel-plugin/src/utils/css-builders.ts
@@ -879,7 +879,7 @@ export const buildCss = (node: t.Expression | t.Expression[], meta: Metadata): C
 
   if (t.isArrowFunctionExpression(node)) {
     if (t.isObjectExpression(node.body)) {
-      return buildCss(node.body, meta);
+      return extractObjectExpression(node.body, meta);
     }
 
     if (t.isLogicalExpression(node.body)) {


### PR DESCRIPTION
For some reason, if you passed `props => ...` directly to `styled.div` or `css()`, and the return value of the arrow function was an object, you would cause `@compiled/babel-plugin` to crash:

```tsx
import { styled } from '@compiled/react';
import React from 'react';

const Component = styled.div(props => ({
  color: `${props.customColor}`,
  background: props.background,
}));
```

On the other hand, wrapping the return value inside a logical expression or ternary expression would make it work perfectly fine:

```tsx
const Styles = styled.div(
  (props) => (props.isEditing ? {} : { backgroundColor: props.highlightColor }),
);
```

(note the above examples exclude TypeScript type annotations for simplicity)

This PR fixes this discrepancy.

---

## Todo

* [x] Add some tests
* [x] Sanity check