### PR TITLE
Add media query typing to XCSS prop / createStrictAPI

### DIFF
--- a/.changeset/fair-dolphins-tie.md
+++ b/.changeset/fair-dolphins-tie.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+The CSS map transform now allows top level at rules to be defined.

--- a/.changeset/modern-eels-tie.md
+++ b/.changeset/modern-eels-tie.md
@@ -27,7 +27,7 @@ Now takes an optional second generic to define what media queries are supported:
 ```diff
 createStrictAPI<
   { color: 'var(--text)' }
-+  '(min-width: 30rem)' | '(min-width: 48rem)'
++  { media: '(min-width: 30rem)' | '(min-width: 48rem)' }
 >();
 ```
 

--- a/.changeset/modern-eels-tie.md
+++ b/.changeset/modern-eels-tie.md
@@ -1,0 +1,34 @@
+---
+'@compiled/react': patch
+---
+
+- The CSS map API now allows defining top level media queries. Previously you had to define them inside a `@media` object, this restriction has now been removed bringing it inline with the CSS function API.
+- The XCSS prop and strict API types now allow defining and using media queries.
+
+**XCSS prop**
+
+The XCSS prop now takes top level media queries. Nested media queries is not allowed.
+
+```jsx
+import { cssMap, css } from '@compiled/react';
+
+const styles = cssMap({
+  valid: { '@media (min-width: 30rem)': { color: 'green' } },
+  invalid: { '@media': { '(min-width: 30rem)': { color: 'red' } } },
+});
+
+<Component xcss={styles.valid} />;
+```
+
+**createStrictAPI**
+
+Now takes an optional second generic to define what media queries are supported:
+
+```diff
+createStrictAPI<
+  { color: 'var(--text)' }
++  '(min-width: 30rem)' | '(min-width: 48rem)'
+>();
+```
+
+Which is then flushed to all output APIs.

--- a/packages/babel-plugin/src/css-map/process-selectors.ts
+++ b/packages/babel-plugin/src/css-map/process-selectors.ts
@@ -8,7 +8,7 @@ import {
   errorIfNotValidObjectProperty,
   getKeyValue,
   hasExtendedSelectorsKey as propertyHasExtendedSelectorsKey,
-  isAtRule,
+  isAtRuleObject,
   objectKeyIsLiteralValue,
   isPlainSelector,
 } from '../utils/css-map';
@@ -150,7 +150,7 @@ export const mergeExtendedSelectorsIntoProperties = (
     // variable, so we can skip it now
     if (propertyHasExtendedSelectorsKey(property)) continue;
 
-    if (isAtRule(propertyKey)) {
+    if (isAtRuleObject(propertyKey)) {
       const atRuleType = getKeyValue(propertyKey);
       const atRules = collapseAtRule(property, atRuleType, meta);
 
@@ -162,6 +162,7 @@ export const mergeExtendedSelectorsIntoProperties = (
             meta.parentPath
           );
         }
+
         mergedProperties.push(atRuleValue);
         addedSelectors.add(atRuleName);
       }

--- a/packages/babel-plugin/src/utils/css-map.ts
+++ b/packages/babel-plugin/src/utils/css-map.ts
@@ -17,8 +17,18 @@ export const getKeyValue = (key: ObjectKeyWithLiteralValue): string => {
   throw new Error(`Expected an identifier or a string literal, got type ${(key as any).type}`);
 };
 
-export const isAtRule = (key: ObjectKeyWithLiteralValue): key is ObjectKeyWithLiteralValue =>
-  getKeyValue(key).startsWith('@');
+export const isAtRuleObject = (
+  key: ObjectKeyWithLiteralValue
+): key is ObjectKeyWithLiteralValue => {
+  const keyValue = getKeyValue(key);
+  if (keyValue.includes(' ')) {
+    // Anything that includes a space character won't have an at rule "object".
+    // So we can skip it here.
+    return false;
+  }
+
+  return keyValue.startsWith('@');
+};
 
 export const isPlainSelector = (selector: string): boolean => selector.startsWith(':');
 

--- a/packages/babel-plugin/src/utils/css-map.ts
+++ b/packages/babel-plugin/src/utils/css-map.ts
@@ -1,9 +1,29 @@
 import * as t from '@babel/types';
+import type { AtRules } from 'csstype';
 
 import type { Metadata } from '../types';
 import { buildCodeFrameError } from '../utils/ast';
 
 export const EXTENDED_SELECTORS_KEY = 'selectors';
+
+const atRules: Record<AtRules, boolean> = {
+  '@charset': true,
+  '@counter-style': true,
+  '@document': true,
+  '@font-face': true,
+  '@font-feature-values': true,
+  '@font-palette-values': true,
+  '@import': true,
+  '@keyframes': true,
+  '@layer': true,
+  '@media': true,
+  '@namespace': true,
+  '@page': true,
+  '@property': true,
+  '@scroll-timeline': true,
+  '@supports': true,
+  '@viewport': true,
+};
 
 type ObjectKeyWithLiteralValue = t.Identifier | t.StringLiteral;
 
@@ -21,13 +41,7 @@ export const isAtRuleObject = (
   key: ObjectKeyWithLiteralValue
 ): key is ObjectKeyWithLiteralValue => {
   const keyValue = getKeyValue(key);
-  if (keyValue.includes(' ')) {
-    // Anything that includes a space character won't have an at rule "object".
-    // So we can skip it here.
-    return false;
-  }
-
-  return keyValue.startsWith('@');
+  return keyValue in atRules;
 };
 
 export const isPlainSelector = (selector: string): boolean => selector.startsWith(':');

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -19,6 +19,6 @@ type MediaQuery =
   | '(prefers-color-scheme: dark)'
   | '(prefers-color-scheme: light)';
 
-const { css, XCSSProp, cssMap, cx } = createStrictAPI<CSSPropertiesSchema, MediaQuery>();
+const { css, XCSSProp, cssMap, cx } = createStrictAPI<CSSPropertiesSchema, { media: MediaQuery }>();
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -10,6 +10,15 @@ interface CSSPropertiesSchema {
   bkgrnd: 'red' | 'green';
 }
 
-const { css, XCSSProp, cssMap, cx } = createStrictAPI<CSSPropertiesSchema>();
+type MediaQuery =
+  | '(min-width: 30rem)'
+  | '(min-width: 48rem)'
+  | '(min-width: 64rem)'
+  | '(min-width: 90rem)'
+  | '(min-width: 110rem)'
+  | '(prefers-color-scheme: dark)'
+  | '(prefers-color-scheme: light)';
+
+const { css, XCSSProp, cssMap, cx } = createStrictAPI<CSSPropertiesSchema, MediaQuery>();
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -145,7 +145,8 @@ export interface CompiledAPI<
     TAllowedPseudos,
     TAllowedMediaQueries,
     TSchema,
-    TRequiredProperties
+    TRequiredProperties,
+    'strict'
   >;
 }
 

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -4,6 +4,10 @@ import { type CompiledStyles, cx, type Internal$XCSSProp } from '../xcss-prop';
 
 import type { AllowedStyles, ApplySchema, ApplySchemaMap, CompiledSchemaShape } from './types';
 
+export interface StrictOptions {
+  media: string;
+}
+
 export interface CompiledAPI<
   TSchema extends CompiledSchemaShape,
   TAllowedMediaQueries extends string
@@ -164,17 +168,19 @@ export interface CompiledAPI<
  *
  * To set up:
  *
- * 1. Declare the API in a module (either local or in a package):
+ * 1. Declare the API in a module (either local or in a package), optionally declaring accepted media queries.
  *
  * @example
  * ```tsx
  * // ./foo.ts
- * const { css } = createStrictAPI<{
+ * interface Schema {
  *   color: 'var(--ds-text)',
  *   '&:hover': { color: 'var(--ds-text-hover)' }
- * }>();
+ * }
  *
- * export { css };
+ * const { css, cssMap, XCSSProp, cx } = createStrictAPI<Schema, { media: '(min-width: 30rem)' }>();
+ *
+ * export { css, cssMap, XCSSProp, cx };
  * ```
  *
  * 2. Configure Compiled to pick up this module:
@@ -200,8 +206,8 @@ export interface CompiledAPI<
  */
 export function createStrictAPI<
   TSchema extends CompiledSchemaShape,
-  TAllowedMediaQueries extends string = never
->(): CompiledAPI<TSchema, TAllowedMediaQueries> {
+  TCreateStrictAPIOptions extends StrictOptions = never
+>(): CompiledAPI<TSchema, TCreateStrictAPIOptions['media']> {
   return {
     css() {
       throw createStrictSetupError();

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -199,7 +199,7 @@ export interface CompiledAPI<
  */
 export function createStrictAPI<
   TSchema extends CompiledSchemaShape,
-  TAllowedMediaQueries extends string = string
+  TAllowedMediaQueries extends string = never
 >(): CompiledAPI<TSchema, TAllowedMediaQueries> {
   return {
     css() {

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -4,7 +4,10 @@ import { type CompiledStyles, cx, type Internal$XCSSProp } from '../xcss-prop';
 
 import type { AllowedStyles, ApplySchema, ApplySchemaMap, CompiledSchemaShape } from './types';
 
-export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
+export interface CompiledAPI<
+  TSchema extends CompiledSchemaShape,
+  TAllowedMediaQueries extends string
+> {
   /**
    * ## CSS
    *
@@ -23,7 +26,7 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    * ```
    */
   css<TStyles extends ApplySchema<TStyles, TSchema>>(
-    styles: AllowedStyles & TStyles
+    styles: AllowedStyles<TAllowedMediaQueries> & TStyles
     // NOTE: This return type is deliberately not using ReadOnly<CompiledStyles<TStyles>>
     // So it type errors when used with XCSS prop. When we update the compiler to work with
     // it we can update the return type so it stops being a type violation.
@@ -45,10 +48,10 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    * ```
    */
   cssMap<
-    TObject extends Record<string, AllowedStyles>,
+    TObject extends Record<string, AllowedStyles<TAllowedMediaQueries>>,
     TStylesMap extends ApplySchemaMap<TObject, TSchema>
   >(
-    styles: Record<string, AllowedStyles> & TStylesMap
+    styles: Record<string, AllowedStyles<TAllowedMediaQueries>> & TStylesMap
   ): {
     readonly [P in keyof TStylesMap]: CompiledStyles<TStylesMap[P]>;
   };
@@ -137,7 +140,13 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
       requiredProperties: TAllowedProperties;
       requiredPseudos: TAllowedPseudos;
     } = never
-  >(): Internal$XCSSProp<TAllowedProperties, TAllowedPseudos, TSchema, TRequiredProperties>;
+  >(): Internal$XCSSProp<
+    TAllowedProperties,
+    TAllowedPseudos,
+    TAllowedMediaQueries,
+    TSchema,
+    TRequiredProperties
+  >;
 }
 
 /**
@@ -188,7 +197,10 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
  * <div css={styles} />
  * ```
  */
-export function createStrictAPI<TSchema extends CompiledSchemaShape>(): CompiledAPI<TSchema> {
+export function createStrictAPI<
+  TSchema extends CompiledSchemaShape,
+  TAllowedMediaQueries extends string = string
+>(): CompiledAPI<TSchema, TAllowedMediaQueries> {
   return {
     css() {
       throw createStrictSetupError();

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -16,7 +16,13 @@ export type CompiledSchemaShape = StrictCSSProperties & {
 
 export type PseudosDeclarations = { [Q in CSSPseudos]?: StrictCSSProperties };
 
-export type AllowedStyles = StrictCSSProperties & PseudosDeclarations;
+export type MediaQueries<TMediaQuery extends string> = {
+  [Q in `@media ${TMediaQuery}`]?: StrictCSSProperties & PseudosDeclarations;
+};
+
+export type AllowedStyles<TMediaQuery extends string> = StrictCSSProperties &
+  PseudosDeclarations &
+  MediaQueries<TMediaQuery>;
 
 export type ApplySchemaValue<
   TSchema,

--- a/packages/react/src/css-map/index.ts
+++ b/packages/react/src/css-map/index.ts
@@ -86,6 +86,19 @@ type ExtendedSelectors = {
 type LooseMediaQueries = Record<`@media ${string}`, CSSProperties & AllPseudos>;
 
 /**
+ * We remap media query keys to `"@media"` so it's blocked inside the strict APIs.
+ * This is done as it's currently impossible to ensure type safety end-to-end — when
+ * passing in unknown media queries from the loose API into the strict API you end up
+ * being also able to pass any styles you want, which makes the whole point of the strict
+ * API meaningless.
+ *
+ * Sorry folks!
+ */
+type RemapMedia<TStyles> = {
+  [Q in keyof TStyles as Q extends `@media ${string}` ? '@media [loose]' : Q]: TStyles[Q];
+};
+
+/**
  * ## CSS Map
  *
  * Creates a collection of named styles that are statically typed and useable with other Compiled APIs.
@@ -109,7 +122,7 @@ export default function cssMap<
 >(
   _styles: TStyles
 ): {
-  readonly [P in keyof TStyles]: CompiledStyles<TStyles[P]>;
+  readonly [P in keyof TStyles]: CompiledStyles<RemapMedia<TStyles[P]>>;
 } {
   throw createSetupError();
 }

--- a/packages/react/src/css-map/index.ts
+++ b/packages/react/src/css-map/index.ts
@@ -83,6 +83,8 @@ type ExtendedSelectors = {
   selectors?: ExtendedSelector;
 };
 
+type LooseMediaQueries = Record<`@media ${string}`, CSSProperties & AllPseudos>;
+
 /**
  * ## CSS Map
  *
@@ -100,7 +102,10 @@ type ExtendedSelectors = {
  * ```
  */
 export default function cssMap<
-  TStyles extends Record<string, CSSProperties & WhitelistedSelector & ExtendedSelectors>
+  TStyles extends Record<
+    string,
+    CSSProperties & WhitelistedSelector & ExtendedSelectors & LooseMediaQueries
+  >
 >(
   _styles: TStyles
 ): {

--- a/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @compiled/react */
 // eslint-disable-next-line import/no-extraneous-dependencies
+import { cssMap as cssMapLoose } from '@compiled/react';
 import { render } from '@testing-library/react';
 
 import { cssMap } from '../../create-strict-api/__tests__/__fixtures__/strict-api';
@@ -29,7 +30,37 @@ const styles = cssMap({
   },
 });
 
+const looseStyles = cssMapLoose({
+  invalid: {
+    '@media': {
+      screen: { color: 'var(--ds-text)' },
+    },
+  },
+  valid: {
+    '@media (min-width: 110rem)': {
+      color: 'var(--ds-text)',
+    },
+  },
+});
+
 describe('xcss prop', () => {
+  it('should allow valid media queries from loose api', () => {
+    const { getByText } = render(<CSSPropComponent xcss={looseStyles.valid} />);
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: '(min-width: 110rem)' });
+  });
+
+  it('should type error invalid media queries from loose api', () => {
+    const { getByText } = render(
+      <CSSPropComponent
+        // @ts-expect-error — Types of property '"@media"' are incompatible.
+        xcss={looseStyles.invalid}
+      />
+    );
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: '(min-width: 110rem)' });
+  });
+
   it('should allow valid media queries in inline xcss prop', () => {
     const { getByText } = render(
       <CSSPropComponent

--- a/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
@@ -130,8 +130,9 @@ describe('xcss prop', () => {
     const { getByText } = render(
       <>
         <CSSPropComponent
-          // NOTE: This doesn't currently error as the excess property check does not
-          // kick in. The callsite of the strict API enforces this however.
+          // NOTE: This doesn't currently error as the output isn't the generic value
+          // when the cssMap call has type supressions. While not ideal this is acceptable
+          // for now. Hopefully we can fix this in the future.
           xcss={styles.invalidMediaQuery}
         />
         <CSSPropComponent

--- a/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
@@ -8,11 +8,17 @@ import type { XCSSProp } from '../../create-strict-api/__tests__/__fixtures__/st
 import type { XCSSAllProperties, XCSSAllPseudos } from '../index';
 
 function CSSPropComponent({
+  testId,
   xcss,
 }: {
+  testId?: string;
   xcss: ReturnType<typeof XCSSProp<XCSSAllProperties, XCSSAllPseudos>>;
 }) {
-  return <div className={xcss}>foo</div>;
+  return (
+    <div data-testid={testId} className={xcss}>
+      foo
+    </div>
+  );
 }
 
 const styles = cssMap({
@@ -74,17 +80,17 @@ describe('xcss prop', () => {
   });
 
   it('should type error invalid media queries from loose api', () => {
-    const { getByText } = render(
+    const { getByTestId } = render(
       <>
         <CSSPropComponent
           // @ts-expect-error — Types of property '"@media"' are incompatible.
           xcss={looseStyles.invalidMediaObject}
         />
-        <CSSPropComponent xcss={styles.invalidMediaObject} />
+        <CSSPropComponent testId="foobar" xcss={styles.invalidMediaObject} />
       </>
     );
 
-    expect(getByText('foo')).toHaveCompiledCss('color', 'var(--ds-text)', { media: 'screen' });
+    expect(getByTestId('foobar')).toHaveCompiledCss('color', 'red', { media: 'screen' });
   });
 
   it('should allow valid media queries in inline xcss prop', () => {
@@ -132,7 +138,7 @@ describe('xcss prop', () => {
   });
 
   it('should type error for unexpected media query', () => {
-    const { getByText } = render(
+    const { getByTestId } = render(
       <>
         <CSSPropComponent
           // NOTE: This doesn't currently error as the output isn't the generic value
@@ -149,6 +155,7 @@ describe('xcss prop', () => {
           xcss={looseStyles.validMediaQueryInvalidProperty}
         />
         <CSSPropComponent
+          testId="foobar"
           xcss={{
             // @ts-expect-error — Types of property '"@media"' are incompatible.
             '@media (min-width: 100px)': {
@@ -159,7 +166,9 @@ describe('xcss prop', () => {
       </>
     );
 
-    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: 'screen' });
+    expect(getByTestId('foobar')).toHaveCompiledCss('color', 'var(--ds-text)', {
+      media: '(min-width: 100px)',
+    });
   });
 
   it('should type check top level media query styles from cssMap', () => {

--- a/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
@@ -16,10 +16,16 @@ function CSSPropComponent({
 }
 
 const styles = cssMap({
-  invalid: {
+  invalidMediaObject: {
     // @ts-expect-error — @media at rule object is not allowed in strict cssMap
     '@media': {
       screen: { color: 'red' },
+    },
+  },
+  invalidQuery: {
+    // @ts-expect-error — this specific @media is not in our allowed types
+    '@media (min-width: 100px)': {
+      color: 'red',
     },
   },
   valid: {
@@ -108,7 +114,7 @@ describe('xcss prop', () => {
   });
 
   it('should type error for disallowed nested media query object from cssMap', () => {
-    const { getByText } = render(<CSSPropComponent xcss={styles.invalid} />);
+    const { getByText } = render(<CSSPropComponent xcss={styles.invalidMediaObject} />);
 
     expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: 'screen' });
   });

--- a/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
@@ -60,8 +60,13 @@ const looseStyles = cssMapLoose({
 });
 
 describe('xcss prop', () => {
-  it('should allow valid media queries from loose api', () => {
-    const { getByText } = render(<CSSPropComponent xcss={looseStyles.valid} />);
+  it('should block all usage of loose media queries in strict api as it is unsafe', () => {
+    const { getByText } = render(
+      <CSSPropComponent
+        // @ts-expect-error — Block all media queries in strict xcss prop
+        xcss={looseStyles.valid}
+      />
+    );
 
     expect(getByText('foo')).toHaveCompiledCss('color', 'var(--ds-text)', {
       media: '(min-width: 110rem)',
@@ -136,12 +141,11 @@ describe('xcss prop', () => {
           xcss={styles.invalidMediaQuery}
         />
         <CSSPropComponent
-          // TODO: This really needs to type error else we're opening a can of worms.
-          // @ts-expect-error — Types of property '"@media"' are incompatible.
+          // @ts-expect-error — Passing loose media queries to XCSS prop is not supported.
           xcss={looseStyles.invalidMediaQuery}
         />
         <CSSPropComponent
-          // @ts-expect-error — Types of property '"@media"' are incompatible.
+          // @ts-expect-error — Passing loose media queries to XCSS prop is not supported.
           xcss={looseStyles.validMediaQueryInvalidProperty}
         />
         <CSSPropComponent

--- a/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
@@ -1,0 +1,86 @@
+/** @jsxImportSource @compiled/react */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { render } from '@testing-library/react';
+
+import { cssMap } from '../../create-strict-api/__tests__/__fixtures__/strict-api';
+import type { XCSSProp } from '../../create-strict-api/__tests__/__fixtures__/strict-api';
+import type { XCSSAllProperties, XCSSAllPseudos } from '../index';
+
+function CSSPropComponent({
+  xcss,
+}: {
+  xcss: ReturnType<typeof XCSSProp<XCSSAllProperties, XCSSAllPseudos>>;
+}) {
+  return <div className={xcss}>foo</div>;
+}
+
+const styles = cssMap({
+  invalid: {
+    // @ts-expect-error — @media at rule object is not allowed in strict cssMap
+    '@media': {
+      screen: { color: 'red' },
+    },
+  },
+  valid: {
+    '@media (min-width: 110rem)': {
+      // @ts-expect-error — color should be a value from the strict schema
+      color: 'red',
+    },
+  },
+});
+
+describe('xcss prop', () => {
+  it('should allow valid media queries in inline xcss prop', () => {
+    const { getByText } = render(
+      <CSSPropComponent
+        xcss={{
+          '@media (min-width: 110rem)': {
+            color: 'var(--ds-text)',
+          },
+        }}
+      />
+    );
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: '(min-width: 110rem)' });
+  });
+
+  it('should allow valid media queries in inline xcss prop', () => {
+    const { getByText } = render(
+      <CSSPropComponent
+        xcss={{
+          '@media (min-width: 110rem)': {
+            // @ts-expect-error — color should be a value from the strict schema
+            color: 'red',
+          },
+        }}
+      />
+    );
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: '(min-width: 110rem)' });
+  });
+
+  it('should allow valid psuedo through inline xcss prop', () => {
+    const { getByText } = render(
+      <CSSPropComponent
+        xcss={{ '@media (min-width: 30rem)': { '&:hover': { color: 'var(--ds-text-hover)' } } }}
+      />
+    );
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'var(--ds-text-hover)', {
+      media: '(min-width: 30rem)',
+      target: ':hover',
+    });
+  });
+
+  it('should type error for disallowed nested media query object from cssMap', () => {
+    const { getByText } = render(<CSSPropComponent xcss={styles.invalid} />);
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: 'screen' });
+  });
+
+  it('should type check top level media query styles from cssMap', () => {
+    const { getByText } = render(<CSSPropComponent xcss={styles.valid} />);
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: '(min-width: 110rem)' });
+  });
+});

--- a/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/media-query-strict.test.tsx
@@ -47,7 +47,9 @@ describe('xcss prop', () => {
   it('should allow valid media queries from loose api', () => {
     const { getByText } = render(<CSSPropComponent xcss={looseStyles.valid} />);
 
-    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: '(min-width: 110rem)' });
+    expect(getByText('foo')).toHaveCompiledCss('color', 'var(--ds-text)', {
+      media: '(min-width: 110rem)',
+    });
   });
 
   it('should type error invalid media queries from loose api', () => {
@@ -58,7 +60,7 @@ describe('xcss prop', () => {
       />
     );
 
-    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: '(min-width: 110rem)' });
+    expect(getByText('foo')).toHaveCompiledCss('color', 'var(--ds-text)', { media: 'screen' });
   });
 
   it('should allow valid media queries in inline xcss prop', () => {
@@ -72,7 +74,9 @@ describe('xcss prop', () => {
       />
     );
 
-    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: '(min-width: 110rem)' });
+    expect(getByText('foo')).toHaveCompiledCss('color', 'var(--ds-text)', {
+      media: '(min-width: 110rem)',
+    });
   });
 
   it('should allow valid media queries in inline xcss prop', () => {

--- a/packages/react/src/xcss-prop/__tests__/media-query.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/media-query.test.tsx
@@ -1,0 +1,53 @@
+/** @jsxImportSource @compiled/react */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { cssMap } from '@compiled/react';
+import { render } from '@testing-library/react';
+
+import type { XCSSProp, XCSSAllProperties, XCSSAllPseudos } from '../index';
+
+function CSSPropComponent({ xcss }: { xcss: XCSSProp<XCSSAllProperties, XCSSAllPseudos> }) {
+  return <div className={xcss}>foo</div>;
+}
+
+const styles = cssMap({
+  invalid: {
+    '@media': { screen: { color: 'red' } },
+  },
+  valid: { '@media screen': { color: 'red' } },
+});
+
+describe('xcss prop', () => {
+  it('should allow valid media queries in inline xcss prop', () => {
+    const { getByText } = render(<CSSPropComponent xcss={{ '@media screen': { color: 'red' } }} />);
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: 'screen' });
+  });
+
+  it('should allow valid psuedo through inline xcss prop', () => {
+    const { getByText } = render(
+      <CSSPropComponent xcss={{ '@media screen': { '&:hover': { color: 'green' } } }} />
+    );
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'green', {
+      media: 'screen',
+      target: ':hover',
+    });
+  });
+
+  it('should type error for disallowed nested media query object from cssMap', () => {
+    const { getByText } = render(
+      <CSSPropComponent
+        // @ts-expect-error — @media object is not allowed in xcss prop
+        xcss={styles.invalid}
+      />
+    );
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: 'screen' });
+  });
+
+  it('should type check top level media query styles from cssMap', () => {
+    const { getByText } = render(<CSSPropComponent xcss={styles.valid} />);
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'red', { media: 'screen' });
+  });
+});

--- a/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
@@ -177,7 +177,7 @@ describe('xcss prop', () => {
     ).toBeObject();
   });
 
-  it('should type error when passing in at rules to xcss prop', () => {
+  it('should type error when passing in @media property to xcss prop', () => {
     function CSSPropComponent({ xcss }: { xcss: XCSSProp<'color', '&:hover'> }) {
       return <div className={xcss}>foo</div>;
     }

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -46,7 +46,10 @@ type XCSSMediaQuery<
  * must declare them so the (lack-of a) excess property check doesn't bite us and allow
  * unexpected values through.
  */
-type BlockedRules = {
+type BlockedRules<TMode extends 'loose' | 'strict'> = {
+  // To ensure styles that aren't allowed through XCSS prop strict APIs we block any
+  // loose media queries from being passed through as we can't ensure they're correct.
+  '@media [loose]'?: TMode extends 'loose' ? any : never;
   selectors?: never;
 } & {
   // We also block all type level at rule "objects" that are present on cssMap.
@@ -151,7 +154,14 @@ export type XCSSProp<
     requiredProperties: TAllowedProperties;
     requiredPseudos: TAllowedPseudos;
   } = never
-> = Internal$XCSSProp<TAllowedProperties, TAllowedPseudos, string, object, TRequiredProperties>;
+> = Internal$XCSSProp<
+  TAllowedProperties,
+  TAllowedPseudos,
+  string,
+  object,
+  TRequiredProperties,
+  'loose'
+>;
 
 export type Internal$XCSSProp<
   TAllowedProperties extends keyof StrictCSSProperties,
@@ -161,7 +171,8 @@ export type Internal$XCSSProp<
   TRequiredProperties extends {
     requiredProperties: TAllowedProperties;
     requiredPseudos: TAllowedPseudos;
-  }
+  },
+  TMode extends 'loose' | 'strict'
 > =
   | (MarkAsRequired<
       XCSSValue<TAllowedProperties, TSchema, ''>,
@@ -172,7 +183,7 @@ export type Internal$XCSSProp<
         TRequiredProperties['requiredPseudos']
       > &
       XCSSMediaQuery<TAllowedProperties, TAllowedPseudos, TAllowedMediaQueries, TSchema> &
-      BlockedRules)
+      BlockedRules<TMode>)
   | false
   | null
   | undefined;

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -34,12 +34,11 @@ type XCSSMediaQuery<
   TAllowedProperties extends keyof StrictCSSProperties,
   TAllowedPseudos extends CSSPseudos,
   TAllowedMediaQueries extends string,
-  TRequiredProperties extends { requiredProperties: TAllowedProperties },
   TSchema
 > = {
   [Q in `@media ${TAllowedMediaQueries}`]?:
     | XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''>
-    | XCSSPseudo<TAllowedProperties, TAllowedPseudos, TRequiredProperties, TSchema>;
+    | XCSSPseudo<TAllowedProperties, TAllowedPseudos, never, TSchema>;
 };
 
 /**
@@ -172,13 +171,7 @@ export type Internal$XCSSProp<
         XCSSPseudo<TAllowedProperties, TAllowedPseudos, TRequiredProperties, TSchema>,
         TRequiredProperties['requiredPseudos']
       > &
-      XCSSMediaQuery<
-        TAllowedProperties,
-        TAllowedPseudos,
-        TAllowedMediaQueries,
-        TRequiredProperties,
-        TSchema
-      > &
+      XCSSMediaQuery<TAllowedProperties, TAllowedPseudos, TAllowedMediaQueries, TSchema> &
       BlockedRules)
   | false
   | null

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -38,10 +38,7 @@ type XCSSMediaQuery<
   TSchema
 > = {
   [Q in `@media ${TAllowedMediaQueries}`]?:
-    | MarkAsRequired<
-        XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''>,
-        TRequiredProperties['requiredProperties']
-      >
+    | XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''>
     | XCSSPseudo<TAllowedProperties, TAllowedPseudos, TRequiredProperties, TSchema>;
 };
 

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -37,7 +37,7 @@ type XCSSMediaQuery<
   TSchema
 > = {
   [Q in `@media ${TAllowedMediaQueries}`]?:
-    | XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''>
+    | XCSSValue<TAllowedProperties, TSchema, ''>
     | XCSSPseudo<TAllowedProperties, TAllowedPseudos, never, TSchema>;
 };
 


### PR DESCRIPTION
This pull request introduces media query support to XCSS prop, and in turn changes some internals to make it function. Read on for the individual changes to each API.

---

**cssMap changes**

The CSS map API now allows defining top level media queries. Previously you had to define them inside a `@media` object, this restriction has now been removed bringing it inline with the CSS function API.

```jsx
import { cssMap } from '@compiled/react';

const styles = cssMap({
  topLevel: { '@media (min-width: 30rem)': { color: 'green' } },
  nested: { '@media': { '(min-width: 30rem)': { color: 'red' } } },
});
```

Both APIs are still supported however only the top level definition will pass type checking with XCSS prop. In the future we'll remove support for the nested object.

For the strict API the default media query type is `@media ${never}`. Meaning, by default, no media queries are available. Yo can expand it to specific string values passing in a string literal union as the second generic arg.

> **Note** — Loose media queries can't be passed to strict XCSS prop! This is because we can't ensure the type safety of that object.

**XCSS prop changes**

The XCSS prop now takes top level media queries. Nested media queries is not allowed.

```jsx
import { cssMap, css } from '@compiled/react';

const styles = cssMap({
  valid: { '@media (min-width: 30rem)': { color: 'green' } },
  invalid: { '@media': { '(min-width: 30rem)': { color: 'red' } } },
});

<Component xcss={styles.valid} />;
```

**createStrictAPI changes**

Now takes an optional second generic to define what media queries are supported:

```diff
createStrictAPI<
  { color: 'var(--text)' }
+  { media: '(min-width: 30rem)' | '(min-width: 48rem)' }
>();
```

Which is then flushed to all output APIs.
