### PR TITLE
Fix CSS func types

### DIFF
--- a/.changeset/funny-camels-punch.md
+++ b/.changeset/funny-camels-punch.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Fix css function base types to have CSS property values available in intellisense.

--- a/packages/react/src/css/index.ts
+++ b/packages/react/src/css/index.ts
@@ -36,7 +36,9 @@ export default function css<TProps = unknown>(
   ...interpolations: CssFunction<TProps>[]
 ): CSSProps<TProps>;
 
-export default function css<T = unknown>(styles: CssObject<T> | CssObject<T>[]): CSSProps<T>;
+export default function css<T = unknown>(
+  styles: CssObject<T> | CssObject<T>[] | CSSProps<T> | CSSProps<T>[]
+): CSSProps<T>;
 
 export default function css<T = unknown>(
   _styles: TemplateStringsArray | CssObject<T> | CssObject<T>[],


### PR DESCRIPTION
This adds basic intellisense back to the CSS function. It's not exhaustive, e.g. doesn't include pseudos / media. But it's a step forward.