### PR TITLE
Refactor strict API types

### DIFF
--- a/.changeset/tricky-poems-greet.md
+++ b/.changeset/tricky-poems-greet.md
@@ -19,9 +19,9 @@ interface Schema {
 createStrictAPI<Schema>();
 ```
 
-If you missed a value / didn't type every possible pseudo it would fallback to the CSSProperties value from csstype. This was mostly unexpected. So for example right now `&:hover` has been typed, but no other pseudo. So it nothing else would benefit from the schema types.
+If you missed a value / didn't type every possible pseudo it would fallback to the CSSProperties value from csstype. This was mostly unexpected. So for example right now `&:hover` has been typed, but no other pseudo... meaning no other pseudos would benefit from the schema types!
 
-With this refactor it now always falls back to the top level types if not defined, meaning you only need to type the values you want to explicitly support. In the previous example we're now able to remove the `background` property as it's the same as the top one. All pseudos are now typed as well.
+With this refactor all CSS properties use the top types unless a more specific one is defined, meaning you only need to type the values you want to explicitly support. In the previous example we're now able to remove the `background` property as it's the same as the top one.
 
 ```diff
 interface Schema {

--- a/.changeset/tricky-poems-greet.md
+++ b/.changeset/tricky-poems-greet.md
@@ -1,0 +1,37 @@
+---
+'@compiled/react': minor
+---
+
+Types for `createStrictAPI` have been refactored to improve type inference and expectations.
+
+Previously defining the schema came with a lot of redundant work. For every pseudo that you wanted to type you would have to define it, and then all of the base types again, like so:
+
+```ts
+interface Schema {
+  background: 'var(--bg)';
+  color: 'var(--color)';
+  '&:hover': {
+    background: 'var(--bg)';
+    color: 'var(--color-hovered)';
+  };
+}
+
+createStrictAPI<Schema>();
+```
+
+If you missed a value / didn't type every possible pseudo it would fallback to the CSSProperties value from csstype. This was mostly unexpected. So for example right now `&:hover` has been typed, but no other pseudo. So it nothing else would benefit from the schema types.
+
+With this refactor it now always falls back to the top level types if not defined, meaning you only need to type the values you want to explicitly support. In the previous example we're now able to remove the `background` property as it's the same as the top one. All pseudos are now typed as well.
+
+```diff
+interface Schema {
+  background: 'var(--bg)';
+  color: 'var(--color)';
+  '&:hover': {
+-    background: 'var(--bg)';
+    color: 'var(--color-hovered)';
+  };
+}
+
+createStrictAPI<Schema>();
+```

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
@@ -1,3 +1,5 @@
+/* eslint-disable prefer-const */
+import type { CompiledAPI } from '../../index';
 import { createStrictAPI } from '../../index';
 
 type Color = 'var(--ds-text)';
@@ -29,6 +31,11 @@ interface StrictAPI extends Properties {
   '&:active': PressedProperties;
 }
 
-const { css, XCSSProp, cssMap, cx } = createStrictAPI<StrictAPI>();
+let css: CompiledAPI<StrictAPI>['css'];
+let cssMap: CompiledAPI<StrictAPI>['cssMap'];
+let cx: CompiledAPI<StrictAPI>['cx'];
+let XCSSProp: CompiledAPI<StrictAPI>['XCSSProp'];
+
+({ css, cssMap, cx, XCSSProp } = createStrictAPI<StrictAPI>());
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-const */
-import type { CompiledAPI } from '../../index';
 import { createStrictAPI } from '../../index';
 
 type Color = 'var(--ds-text)';
@@ -31,11 +29,6 @@ interface StrictAPI extends Properties {
   '&:active': PressedProperties;
 }
 
-let css: CompiledAPI<StrictAPI>['css'];
-let cssMap: CompiledAPI<StrictAPI>['cssMap'];
-let cx: CompiledAPI<StrictAPI>['cx'];
-let XCSSProp: CompiledAPI<StrictAPI>['XCSSProp'];
-
-({ css, cssMap, cx, XCSSProp } = createStrictAPI<StrictAPI>());
+const { css, cssMap, cx, XCSSProp } = createStrictAPI<StrictAPI>();
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
@@ -24,11 +24,11 @@ interface PressedProperties {
   backgroundColor: BackgroundPressed;
 }
 
-interface StrictAPI extends Properties {
+interface CSSPropertiesSchema extends Properties {
   '&:hover': HoveredProperties;
   '&:active': PressedProperties;
 }
 
-const { css, cssMap, cx, XCSSProp } = createStrictAPI<StrictAPI>();
+const { css, cssMap, cx, XCSSProp } = createStrictAPI<CSSPropertiesSchema>();
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
@@ -6,18 +6,20 @@ type ColorPressed = 'var(--ds-text-pressed)';
 type Background = 'var(--ds-bold)' | 'var(--ds-success)';
 type BackgroundHovered = 'var(--ds-bold-hovered)' | 'var(--ds-success-hovered)';
 type BackgroundPressed = 'var(--ds-bold-pressed)' | 'var(--ds-success-pressed)';
+type Space = 'var(--ds-space-050)' | 'var(--ds-space-0)';
 
 interface Properties {
   color: Color;
   backgroundColor: Background;
+  padding: Space;
 }
 
-interface HoveredProperties extends Omit<Properties, 'backgroundColor' | 'color'> {
+interface HoveredProperties {
   color: ColorHovered;
   backgroundColor: BackgroundHovered;
 }
 
-interface PressedProperties extends Omit<Properties, 'backgroundColor' | 'color'> {
+interface PressedProperties {
   color: ColorPressed;
   backgroundColor: BackgroundPressed;
 }
@@ -25,8 +27,6 @@ interface PressedProperties extends Omit<Properties, 'backgroundColor' | 'color'
 interface StrictAPI extends Properties {
   '&:hover': HoveredProperties;
   '&:active': PressedProperties;
-  '&::before': Properties;
-  '&::after': Properties;
 }
 
 const { css, XCSSProp, cssMap, cx } = createStrictAPI<StrictAPI>();

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -5,7 +5,7 @@ interface API {
     color: 'var(--ds-text-hover)';
     background: 'var(--ds-surface-hover)' | 'var(--ds-surface-sunken-hover)';
   };
-  color: 'var(--ds-text)';
+  color: 'var(--ds-text)' | 'var(--ds-text-bold)';
   background: 'var(--ds-surface)' | 'var(--ds-surface-sunken)';
   bkgrnd: 'red' | 'green';
 }

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -1,6 +1,8 @@
+/* eslint-disable prefer-const */
+import type { CompiledAPI } from '../../index';
 import { createStrictAPI } from '../../index';
 
-const { css, XCSSProp, cssMap, cx } = createStrictAPI<{
+interface API {
   '&:hover': {
     color: 'var(--ds-text-hover)';
     background: 'var(--ds-surface-hover)' | 'var(--ds-surface-sunken-hover)';
@@ -8,6 +10,13 @@ const { css, XCSSProp, cssMap, cx } = createStrictAPI<{
   color: 'var(--ds-text)';
   background: 'var(--ds-surface)' | 'var(--ds-surface-sunken)';
   bkgrnd: 'red' | 'green';
-}>();
+}
+
+let css: CompiledAPI<API>['css'];
+let cssMap: CompiledAPI<API>['cssMap'];
+let cx: CompiledAPI<API>['cx'];
+let XCSSProp: CompiledAPI<API>['XCSSProp'];
+
+({ css, XCSSProp, cssMap, cx } = createStrictAPI<API>());
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-const */
-import type { CompiledAPI } from '../../index';
 import { createStrictAPI } from '../../index';
 
 interface API {
@@ -12,11 +10,6 @@ interface API {
   bkgrnd: 'red' | 'green';
 }
 
-let css: CompiledAPI<API>['css'];
-let cssMap: CompiledAPI<API>['cssMap'];
-let cx: CompiledAPI<API>['cx'];
-let XCSSProp: CompiledAPI<API>['XCSSProp'];
-
-({ css, XCSSProp, cssMap, cx } = createStrictAPI<API>());
+const { css, XCSSProp, cssMap, cx } = createStrictAPI<API>();
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -1,6 +1,6 @@
 import { createStrictAPI } from '../../index';
 
-interface API {
+interface CSSPropertiesSchema {
   '&:hover': {
     color: 'var(--ds-text-hover)';
     background: 'var(--ds-surface-hover)' | 'var(--ds-surface-sunken-hover)';
@@ -10,6 +10,6 @@ interface API {
   bkgrnd: 'red' | 'green';
 }
 
-const { css, XCSSProp, cssMap, cx } = createStrictAPI<API>();
+const { css, XCSSProp, cssMap, cx } = createStrictAPI<CSSPropertiesSchema>();
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/css-func.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/css-func.test.tsx
@@ -1,0 +1,49 @@
+/** @jsxImportSource @compiled/react */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { css } from '@compiled/react';
+import type { XCSSProp } from '@fixture/strict-api-test';
+import { css as strictCSS } from '@fixture/strict-api-test';
+import { render } from '@testing-library/react';
+
+function Button({
+  xcss,
+  testId,
+}: {
+  testId: string;
+  xcss: ReturnType<typeof XCSSProp<'backgroundColor', '&:hover'>>;
+}) {
+  return <button data-testid={testId} className={xcss} />;
+}
+
+describe('css func from strict api', () => {
+  it('should type error when passing css func result into xcss prop', () => {
+    const strictStyles = strictCSS({
+      backgroundColor: 'var(--ds-surface)',
+    });
+    const looseStyles = css({
+      backgroundColor: 'red',
+    });
+
+    const { getByTestId } = render(
+      <>
+        <Button
+          testId="button-1"
+          // @ts-expect-error — CSS func currently doesn't work with XCSS prop so should type error
+          xcss={strictStyles}
+        />
+        <Button
+          testId="button-2"
+          // @ts-expect-error — CSS func currently doesn't work with XCSS prop so should type error
+          xcss={looseStyles}
+        />
+        <div data-testid="div-1" css={[strictStyles, looseStyles]} />
+        <div data-testid="div-2" css={[looseStyles, strictStyles]} />
+      </>
+    );
+
+    expect(getByTestId('button-1').className).toEqual('');
+    expect(getByTestId('button-2').className).toEqual('');
+    expect(getByTestId('div-1')).toHaveCompiledCss('background-color', 'red');
+    expect(getByTestId('div-2')).toHaveCompiledCss('background-color', 'var(--ds-surface)');
+  });
+});

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -59,13 +59,6 @@ describe('createStrictAPI()', () => {
 
   describe('type violations', () => {
     it('should violate types for css()', () => {
-      css({
-        color: 'var(--ds-text)',
-        '&:hover': {
-          color: 'var(--ds-text-hovered)',
-        },
-      });
-
       const styles = css({
         // @ts-expect-error — Type '""' is not assignable to type ...
         color: '',

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -162,15 +162,15 @@ describe('createStrictAPI()', () => {
             backgroundColor: '',
             '&:hover': {
               // @ts-expect-error — Type '""' is not assignable to type ...
-              color: '',
+              color: 'var(--ds-text)',
               // @ts-expect-error — Type '""' is not assignable to type ...
-              backgroundColor: '',
+              backgroundColor: 'var(--ds-success)',
             },
             '&:active': {
               // @ts-expect-error — Type '""' is not assignable to type ...
-              color: '',
+              color: 'var(--ds-text)',
               // @ts-expect-error — Type '""' is not assignable to type ...
-              backgroundColor: '',
+              backgroundColor: 'var(--ds-success)',
             },
             '&::before': {
               // @ts-expect-error — Type '""' is not assignable to type ...

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -59,6 +59,13 @@ describe('createStrictAPI()', () => {
 
   describe('type violations', () => {
     it('should violate types for css()', () => {
+      css({
+        color: 'var(--ds-text)',
+        '&:hover': {
+          color: 'var(--ds-text-hovered)',
+        },
+      });
+
       const styles = css({
         // @ts-expect-error — Type '""' is not assignable to type ...
         color: '',
@@ -99,7 +106,7 @@ describe('createStrictAPI()', () => {
       const styles = cssMap({
         primary: {
           // @ts-expect-error — Type '""' is not assignable to type ...
-          color: 's',
+          color: '',
           // @ts-expect-error — Type '""' is not assignable to type ...
           backgroundColor: '',
           '&:hover': {
@@ -188,21 +195,31 @@ describe('createStrictAPI()', () => {
   describe('type success', () => {
     it('should pass type check for css()', () => {
       const styles = css({
+        // @ts-expect-error — should be a value from the schema
+        padding: '10px',
         color: 'var(--ds-text)',
         backgroundColor: 'var(--ds-bold)',
         '&:hover': {
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
           color: 'var(--ds-text-hovered)',
           backgroundColor: 'var(--ds-bold-hovered)',
         },
         '&:active': {
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
           color: 'var(--ds-text-pressed)',
           backgroundColor: 'var(--ds-bold-pressed)',
         },
         '&::before': {
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
           color: 'var(--ds-text)',
           backgroundColor: 'var(--ds-bold)',
         },
         '&::after': {
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
           color: 'var(--ds-text)',
           backgroundColor: 'var(--ds-bold)',
         },
@@ -218,19 +235,30 @@ describe('createStrictAPI()', () => {
         primary: {
           color: 'var(--ds-text)',
           backgroundColor: 'var(--ds-bold)',
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
           '&:hover': {
+            accentColor: 'red',
+            // @ts-expect-error — should be a value from the schema
+            padding: '10px',
             color: 'var(--ds-text-hovered)',
             backgroundColor: 'var(--ds-bold-hovered)',
           },
           '&:active': {
+            // @ts-expect-error — should be a value from the schema
+            padding: '10px',
             color: 'var(--ds-text-pressed)',
             backgroundColor: 'var(--ds-bold-pressed)',
           },
           '&::before': {
+            // @ts-expect-error — should be a value from the schema
+            padding: '10px',
             color: 'var(--ds-text)',
             backgroundColor: 'var(--ds-bold)',
           },
           '&::after': {
+            // @ts-expect-error — should be a value from the schema
+            padding: '10px',
             color: 'var(--ds-text)',
             backgroundColor: 'var(--ds-bold)',
           },

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -146,7 +146,7 @@ describe('createStrictAPI()', () => {
           accentColor: 'red',
           all: 'inherit',
           '&:hover': { color: 'var(--ds-text-hover)' },
-          '&:invalid': { color: 'orange' },
+          '&:invalid': { color: 'var(--ds-text)' },
         },
       });
 
@@ -275,8 +275,8 @@ describe('createStrictAPI()', () => {
       function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', never>> }) {
         return <button data-testid="button" className={xcss} />;
       }
-
       const styles = cssMap({ bg: { background: 'var(--ds-surface)' } });
+
       const { getByTestId } = render(<Button xcss={styles.bg} />);
 
       expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
@@ -302,7 +302,6 @@ describe('createStrictAPI()', () => {
       function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', '&:hover'>> }) {
         return <button data-testid="button" className={xcss} />;
       }
-
       const styles = cssMap({
         primary: {
           background: 'var(--ds-surface)',

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -347,7 +347,7 @@ describe('createStrictAPI()', () => {
         </>
       );
 
-      expect(getByTestId('button-invalid')).toHaveCompiledCss('background', 'var(--ds-surface)');
+      expect(getByTestId('button-invalid-root')).toHaveCompiledCss('color', 'red');
     });
 
     it('should allow valid values from cssMap', () => {

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -1,4 +1,6 @@
 /** @jsxImportSource @compiled/react */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { cssMap as cssMapLoose } from '@compiled/react';
 import { render } from '@testing-library/react';
 
 import { css, cssMap, XCSSProp, cx } from './__fixtures__/strict-api';
@@ -355,9 +357,16 @@ describe('createStrictAPI()', () => {
         return <button data-testid={testId} className={xcss} />;
       }
 
-      const styles = cssMap({
+      const stylesOne = cssMapLoose({
         primary: {
-          // @ts-expect-error -- This is not in the `createStrictAPI` schema—this should be a css variable.
+          color: 'red',
+          background: 'var(--ds-surface)',
+          '&:hover': { background: 'var(--ds-surface-hover)' },
+        },
+      });
+      const stylesTwo = cssMap({
+        primary: {
+          // @ts-expect-error — This is not in the `createStrictAPI` schema—this should be a css variable.
           color: 'red',
           background: 'var(--ds-surface)',
           '&:hover': { background: 'var(--ds-surface-hover)' },
@@ -366,11 +375,20 @@ describe('createStrictAPI()', () => {
 
       const { getByTestId } = render(
         <>
-          <Button testId="button-1" xcss={styles.primary} />
+          <Button
+            testId="button-1"
+            // @ts-expect-error — This is not in the `createStrictAPI` schema—this should be a css variable.
+            xcss={stylesOne.primary}
+          />
+          <Button
+            testId="button-3"
+            // @ts-expect-error — This is not in the `createStrictAPI` schema—this should be a css variable.
+            xcss={stylesTwo.stylesTwo}
+          />
           <Button
             testId="button-2"
             xcss={{
-              // @ts-expect-error -- This is not in the `createStrictAPI` schema—this should be a css variable.
+              // @ts-expect-error — This is not in the `createStrictAPI` schema—this should be a css variable.
               color: 'red',
             }}
           />
@@ -394,7 +412,7 @@ describe('createStrictAPI()', () => {
 
       const { getByTestId } = render(
         <Button
-          // @ts-expect-error -- Errors because `background` + `&:hover` are not in the `XCSSProp` schema.
+          // @ts-expect-error — Errors because `background` + `&:hover` are not in the `XCSSProp` schema.
           xcss={styles.primary}
         />
       );
@@ -408,13 +426,13 @@ describe('createStrictAPI()', () => {
       }
       const styles = cssMap({
         primary: {
-          // @ts-expect-error -- Fails because `foo` is not assignable to our CSSProperties whatsoever.
+          // @ts-expect-error — Fails because `foo` is not assignable to our CSSProperties whatsoever.
           foo: 'bar',
           background: 'var(--ds-surface)',
         },
         hover: {
           '&:hover': {
-            // @ts-expect-error -- Fails because `foo` is not assignable to our CSSProperties whatsoever.
+            // @ts-expect-error — Fails because `foo` is not assignable to our CSSProperties whatsoever.
             foo: 'bar',
             background: 'var(--ds-surface-hover)',
           },

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -347,10 +347,12 @@ describe('createStrictAPI()', () => {
     it('should error with values not in the strict `CompiledAPI`', () => {
       function Button({
         xcss,
+        testId,
       }: {
+        testId: string;
         xcss: ReturnType<typeof XCSSProp<'background' | 'color', '&:hover'>>;
       }) {
-        return <button data-testid="button" className={xcss} />;
+        return <button data-testid={testId} className={xcss} />;
       }
 
       const styles = cssMap({
@@ -363,13 +365,19 @@ describe('createStrictAPI()', () => {
       });
 
       const { getByTestId } = render(
-        <Button
-          // @ts-expect-error -- Errors because `color` conflicts with the `XCSSProp` schema–`color` should be a css variable.
-          xcss={styles.primary}
-        />
+        <>
+          <Button testId="button-1" xcss={styles.primary} />
+          <Button
+            testId="button-2"
+            xcss={{
+              // @ts-expect-error -- This is not in the `createStrictAPI` schema—this should be a css variable.
+              color: 'red',
+            }}
+          />
+        </>
       );
 
-      expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
+      expect(getByTestId('button-1')).toHaveCompiledCss('background', 'var(--ds-surface)');
     });
 
     it('should error with properties not in the `XCSSProp`', () => {

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -290,7 +290,9 @@ describe('createStrictAPI()', () => {
       }) {
         return <button data-testid={testId} className={xcss} />;
       }
-      // NOTE: Even though valid, it cannot be consumed within `xcss` due to technical reasons
+      // NOTE: For some reason the "background" property is being expanded to "string" instead of
+      // staying narrowed as "var(--ds-surface-hover)" meaning it breaks when used with the strict
+      // schema loaded XCSS prop. This is a bug and unexpected.
       const stylesValidRoot = cssMapLoose({
         primary: {
           color: 'var(--ds-text)',
@@ -332,12 +334,16 @@ describe('createStrictAPI()', () => {
           />
           <Button
             testId="button-valid-root"
-            // @ts-expect-error — We do not accept loose `cssMap` values
+            // @ts-expect-error — For some reason the "background" property is being expanded to "string" instead of
+            // staying narrowed as "var(--ds-surface-hover)" meaning it breaks when used with the strict
+            // schema loaded XCSS prop. This is a bug and unexpected.
             xcss={stylesValidRoot.primary}
           />
           <Button
             testId="button-valid-root-cx"
-            // @ts-expect-error — We do not accept loose `cssMap` values
+            // @ts-expect-error — For some reason the "background" property is being expanded to "string" instead of
+            // staying narrowed as "var(--ds-surface-hover)" meaning it breaks when used with the strict
+            // schema loaded XCSS prop. This is a bug and unexpected.
             xcss={cx(stylesValidRoot.primary, stylesValid.primary)}
           />
           <Button

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -2,7 +2,7 @@ import type { StrictCSSProperties, CSSPseudos } from '../types';
 import { createStrictSetupError } from '../utils/error';
 import { type CompiledStyles, cx, type Internal$XCSSProp } from '../xcss-prop';
 
-import type { AllowedStyles, ApplySchema, CompiledSchemaShape } from './types';
+import type { AllowedStyles, ApplySchema, ApplySchemaMap, CompiledSchemaShape } from './types';
 
 export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
   /**
@@ -20,7 +20,9 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    * <div css={redText} />
    * ```
    */
-  css<TStyles extends AllowedStyles>(styles: ApplySchema<TStyles, TSchema>): StrictCSSProperties;
+  css<TStyles extends ApplySchema<TStyles, TSchema>>(
+    styles: AllowedStyles & TStyles
+  ): CompiledStyles<TStyles>;
   /**
    * ## CSS Map
    *
@@ -37,9 +39,9 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    * <div css={styles.solid} />
    * ```
    */
-  cssMap<TStylesMap extends Record<string, AllowedStyles>>(styles: {
-    [P in keyof TStylesMap]: ApplySchema<TStylesMap[P], TSchema>;
-  }): {
+  cssMap<TStylesMap extends ApplySchemaMap<TStylesMap, TSchema>>(
+    styles: Record<string, AllowedStyles> & TStylesMap
+  ): {
     readonly [P in keyof TStylesMap]: CompiledStyles<TStylesMap[P]>;
   };
   /**

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -2,9 +2,9 @@ import type { StrictCSSProperties, CSSPseudos } from '../types';
 import { createStrictSetupError } from '../utils/error';
 import { type CompiledStyles, cx, type Internal$XCSSProp } from '../xcss-prop';
 
-import type { AllowedStyles, ApplySchema, CompiledSchema } from './types';
+import type { AllowedStyles, ApplySchema, CompiledSchemaShape } from './types';
 
-export interface CompiledAPI<TSchema extends CompiledSchema> {
+export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
   /**
    * ## CSS
    *
@@ -178,7 +178,7 @@ export interface CompiledAPI<TSchema extends CompiledSchema> {
  * <div css={styles} />
  * ```
  */
-export function createStrictAPI<TSchema extends CompiledSchema>(): CompiledAPI<TSchema> {
+export function createStrictAPI<TSchema extends CompiledSchemaShape>(): CompiledAPI<TSchema> {
   return {
     css() {
       throw createStrictSetupError();

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -1,34 +1,8 @@
-import type { StrictCSSProperties, CSSPseudoClasses, CSSPseudos } from '../types';
+import type { StrictCSSProperties, CSSPseudos } from '../types';
 import { createStrictSetupError } from '../utils/error';
 import { type CompiledStyles, cx, type Internal$XCSSProp } from '../xcss-prop';
 
-type CompiledSchema = StrictCSSProperties & { [Q in CSSPseudoClasses]?: StrictCSSProperties };
-
-type AllowedStyles = StrictCSSProperties & PseudosDeclarations;
-
-type PseudosDeclarations = {
-  [Q in CSSPseudos]?: StrictCSSProperties;
-};
-
-type ApplySchemaValue<
-  TSchema,
-  TKey extends keyof StrictCSSProperties,
-  TPseudoKey extends CSSPseudoClasses | ''
-> = TKey extends keyof TSchema
-  ? TPseudoKey extends keyof TSchema
-    ? TKey extends keyof TSchema[TPseudoKey]
-      ? TSchema[TPseudoKey][TKey]
-      : TSchema[TKey]
-    : TSchema[TKey]
-  : StrictCSSProperties[TKey];
-
-type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | '' = ''> = {
-  [TKey in keyof TObject]?: TKey extends keyof StrictCSSProperties
-    ? ApplySchemaValue<TSchema, TKey, TPseudoKey>
-    : TKey extends CSSPseudoClasses
-    ? ApplySchema<TObject[TKey], TSchema, TKey>
-    : ApplySchema<TObject[TKey], TSchema>;
-};
+import type { AllowedStyles, ApplySchema, CompiledSchema } from './types';
 
 export interface CompiledAPI<TSchema extends CompiledSchema> {
   /**

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -1,4 +1,4 @@
-import type { StrictCSSProperties, CSSPseudos } from '../types';
+import type { StrictCSSProperties, CSSPseudos, CSSProps } from '../types';
 import { createStrictSetupError } from '../utils/error';
 import { type CompiledStyles, cx, type Internal$XCSSProp } from '../xcss-prop';
 
@@ -11,6 +11,8 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    * Creates styles that are statically typed and useable with other Compiled APIs.
    * For further details [read the documentation](https://compiledcssinjs.com/docs/api-css).
    *
+   * This API does not currently work with XCSS prop.
+   *
    * @example
    * ```
    * const redText = css({
@@ -22,7 +24,10 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    */
   css<TStyles extends ApplySchema<TStyles, TSchema>>(
     styles: AllowedStyles & TStyles
-  ): Readonly<CompiledStyles<TStyles>>;
+    // NOTE: This return type is deliberately not using ReadOnly<CompiledStyles<TStyles>>
+    // So it type errors when used with XCSS prop. When we update the compiler to work with
+    // it we can update the return type so it stops being a type violation.
+  ): CSSProps<unknown>;
   /**
    * ## CSS Map
    *

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -22,7 +22,7 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    */
   css<TStyles extends ApplySchema<TStyles, TSchema>>(
     styles: AllowedStyles & TStyles
-  ): CompiledStyles<TStyles>;
+  ): Readonly<CompiledStyles<TStyles>>;
   /**
    * ## CSS Map
    *

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -44,7 +44,10 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    * <div css={styles.solid} />
    * ```
    */
-  cssMap<TStylesMap extends ApplySchemaMap<TStylesMap, TSchema>>(
+  cssMap<
+    TObject extends Record<string, AllowedStyles>,
+    TStylesMap extends ApplySchemaMap<TObject, TSchema>
+  >(
     styles: Record<string, AllowedStyles> & TStylesMap
   ): {
     readonly [P in keyof TStylesMap]: CompiledStyles<TStylesMap[P]>;

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -1,6 +1,6 @@
 import type { StrictCSSProperties, CSSPseudoClasses, CSSPseudos } from '../types';
 
-export type CompiledSchema = StrictCSSProperties & {
+export type CompiledSchemaShape = StrictCSSProperties & {
   [Q in CSSPseudoClasses]?: StrictCSSProperties;
 };
 

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -1,0 +1,29 @@
+import type { StrictCSSProperties, CSSPseudoClasses, CSSPseudos } from '../types';
+
+export type CompiledSchema = StrictCSSProperties & {
+  [Q in CSSPseudoClasses]?: StrictCSSProperties;
+};
+
+export type PseudosDeclarations = { [Q in CSSPseudos]?: StrictCSSProperties };
+
+export type AllowedStyles = StrictCSSProperties & PseudosDeclarations;
+
+export type ApplySchemaValue<
+  TSchema,
+  TKey extends keyof StrictCSSProperties,
+  TPseudoKey extends CSSPseudoClasses | ''
+> = TKey extends keyof TSchema
+  ? TPseudoKey extends keyof TSchema
+    ? TKey extends keyof TSchema[TPseudoKey]
+      ? TSchema[TPseudoKey][TKey]
+      : TSchema[TKey]
+    : TSchema[TKey]
+  : StrictCSSProperties[TKey];
+
+export type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | '' = ''> = {
+  [TKey in keyof TObject]?: TKey extends keyof StrictCSSProperties
+    ? ApplySchemaValue<TSchema, TKey, TPseudoKey>
+    : TKey extends CSSPseudoClasses
+    ? ApplySchema<TObject[TKey], TSchema, TKey>
+    : ApplySchema<TObject[TKey], TSchema>;
+};

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -1,4 +1,9 @@
-import type { StrictCSSProperties, CSSPseudoClasses, CSSPseudos } from '../types';
+import type {
+  StrictCSSProperties,
+  CSSPseudoClasses,
+  CSSPseudoElements,
+  CSSPseudos,
+} from '../types';
 
 export type CompiledSchemaShape = StrictCSSProperties & {
   [Q in CSSPseudoClasses]?: StrictCSSProperties;
@@ -25,5 +30,11 @@ export type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | 
     ? ApplySchemaValue<TSchema, TKey, TPseudoKey>
     : TKey extends CSSPseudoClasses
     ? ApplySchema<TObject[TKey], TSchema, TKey>
-    : ApplySchema<TObject[TKey], TSchema>;
+    : TKey extends `@${string}` | CSSPseudoElements
+    ? ApplySchema<TObject[TKey], TSchema>
+    : never;
+};
+
+export type ApplySchemaMap<TStylesMap, TSchema> = {
+  [P in keyof TStylesMap]: ApplySchema<TStylesMap[P], TSchema>;
 };

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -38,7 +38,7 @@ export type ApplySchemaValue<
 /**
  * Recursively maps over object properties to resolve them to either a {@link TSchema}
  * value if present, else fallback to its value from {@link StrictCSSProperties}. If
- * the property isn't a known CSS property its value will be resolved to `never`.
+ * the property isn't a known property its value will be resolved to `never`.
  */
 export type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | '' = ''> = {
   [TKey in keyof TObject]?: TKey extends keyof StrictCSSProperties

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -5,6 +5,11 @@ import type {
   CSSPseudos,
 } from '../types';
 
+/**
+ * This is the shape of the generic object that `createStrictAPI()` takes.
+ * It's deliberately a subset of `AllowedStyles` and does not take at rules
+ * and pseudo elements.
+ */
 export type CompiledSchemaShape = StrictCSSProperties & {
   [Q in CSSPseudoClasses]?: StrictCSSProperties;
 };
@@ -18,21 +23,39 @@ export type ApplySchemaValue<
   TKey extends keyof StrictCSSProperties,
   TPseudoKey extends CSSPseudoClasses | ''
 > = TKey extends keyof TSchema
-  ? TPseudoKey extends keyof TSchema
+  ? // TKey is a valid property on the schema
+    TPseudoKey extends keyof TSchema
     ? TKey extends keyof TSchema[TPseudoKey]
-      ? TSchema[TPseudoKey][TKey]
-      : TSchema[TKey]
-    : TSchema[TKey]
-  : StrictCSSProperties[TKey];
+      ? // We found a more specific value under TPseudoKey.
+        TSchema[TPseudoKey][TKey]
+      : // Did not found anything specific, use the top level TSchema value.
+        TSchema[TKey]
+    : // Did not found anything specific, use the top level TSchema value.
+      TSchema[TKey]
+  : // TKey wasn't found on the schema, fallback to the CSS property value
+    StrictCSSProperties[TKey];
 
+/**
+ * Recursively maps over object properties to resolve them to either a {@link TSchema}
+ * value if present, else fallback to its value from {@link StrictCSSProperties}. If
+ * the property isn't a known CSS property its value will be resolved to `never`.
+ */
 export type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | '' = ''> = {
   [TKey in keyof TObject]?: TKey extends keyof StrictCSSProperties
-    ? ApplySchemaValue<TSchema, TKey, TPseudoKey>
+    ? // TKey is a valid CSS property, try to resolve its value.
+      ApplySchemaValue<TSchema, TKey, TPseudoKey>
     : TKey extends CSSPseudoClasses
-    ? ApplySchema<TObject[TKey], TSchema, TKey>
+    ? // TKey is a valid pseudo class, recursively resolve its child properties
+      // while passing down the parent pseudo key to resolve any specific schema types.
+      ApplySchema<TObject[TKey], TSchema, TKey>
     : TKey extends `@${string}` | CSSPseudoElements
-    ? ApplySchema<TObject[TKey], TSchema>
-    : never;
+    ? // TKey is either an at rule or a pseudo element, either way we don't care about
+      // passing down the key so we recursively resolve its child properties starting at
+      // the base schema, treating it as if it's not inside an object.
+      ApplySchema<TObject[TKey], TSchema>
+    : // Fallback case, did not find a valid CSS property, at rule, or pseudo.
+      // Resolve the value to `never` which will end up being a type violation.
+      never;
 };
 
 export type ApplySchemaMap<TStylesMap, TSchema> = {

--- a/packages/react/src/css/index.ts
+++ b/packages/react/src/css/index.ts
@@ -9,6 +9,8 @@ import { createSetupError } from '../utils/error';
  * Create styles that are statically typed and useable with other Compiled APIs.
  * For further details [read the documentation](https://compiledcssinjs.com/docs/api-css).
  *
+ * This API does not currently work with XCSS prop.
+ *
  * ### Style with objects
  *
  * @example

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -35,14 +35,7 @@ export type CssFunction<TProps = unknown> =
   | boolean // Something like `false && styles`
   | undefined; // Something like `undefined && styles`
 
-/*
- * This list of pseudo-classes and pseudo-elements are from csstype
- * but with & added to the front. Compiled supports both &-ful
- * and &-less forms and both will target the current element
- * (`&:hover` <==> `:hover`), however we force the use of the
- * &-ful form for consistency with the nested spec for new APIs.
- */
-export type CSSPseudos =
+export type CSSPseudoElements =
   | '&::after'
   | '&::backdrop'
   | '&::before'
@@ -56,7 +49,9 @@ export type CSSPseudos =
   | '&::selection'
   | '&::spelling-error'
   | '&::target-text'
-  | '&::view-transition'
+  | '&::view-transition';
+
+export type CSSPseudoClasses =
   | '&:active'
   | '&:autofill'
   | '&:blank'
@@ -93,6 +88,15 @@ export type CSSPseudos =
   | '&:user-valid'
   | '&:valid'
   | '&:visited';
+
+/*
+ * This list of pseudo-classes and pseudo-elements are from csstype
+ * but with & added to the front. Compiled supports both &-ful
+ * and &-less forms and both will target the current element
+ * (`&:hover` <==> `:hover`), however we force the use of the
+ * &-ful form for consistency with the nested spec for new APIs.
+ */
+export type CSSPseudos = CSSPseudoElements | CSSPseudoClasses;
 
 /**
  * The XCSSProp must be given all known available properties even

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -12,7 +12,9 @@ type XCSSValue<
   TPseudoKey extends CSSPseudoClasses | ''
 > = {
   [Q in keyof StrictCSSProperties]: Q extends TStyleDecl
-    ? CompiledPropertyDeclarationReference | ApplySchemaValue<TSchema, Q, TPseudoKey>
+    ?
+        | (CompiledPropertyDeclarationReference & ApplySchemaValue<TSchema, Q, TPseudoKey>)
+        | ApplySchemaValue<TSchema, Q, TPseudoKey>
     : never;
 };
 
@@ -57,7 +59,7 @@ type CompiledPropertyDeclarationReference = {
 export type CompiledStyles<TObject> = {
   [Q in keyof TObject]: TObject[Q] extends Record<string, unknown>
     ? CompiledStyles<TObject[Q]>
-    : CompiledPropertyDeclarationReference;
+    : CompiledPropertyDeclarationReference & TObject[Q];
 };
 
 /**

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -12,9 +12,7 @@ type XCSSValue<
   TPseudoKey extends CSSPseudoClasses | ''
 > = {
   [Q in keyof StrictCSSProperties]: Q extends TStyleDecl
-    ?
-        | (CompiledPropertyDeclarationReference & ApplySchemaValue<TSchema, Q, TPseudoKey>)
-        | ApplySchemaValue<TSchema, Q, TPseudoKey>
+    ? ApplySchemaValue<TSchema, Q, TPseudoKey>
     : never;
 };
 

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -1,27 +1,30 @@
 import type * as CSS from 'csstype';
 
+import type { ApplySchemaValue } from '../create-strict-api/types';
 import { ac } from '../runtime';
-import type { CSSPseudos, CSSProperties, StrictCSSProperties } from '../types';
+import type { CSSPseudos, CSSPseudoClasses, CSSProperties, StrictCSSProperties } from '../types';
 
 type MarkAsRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
-type XCSSItem<TStyleDecl extends keyof CSSProperties, TSchema> = {
-  [Q in keyof CSSProperties]: Q extends TStyleDecl
-    ?
-        | CompiledPropertyDeclarationReference
-        | (Q extends keyof TSchema ? TSchema[Q] : CSSProperties[Q])
+type XCSSValue<
+  TStyleDecl extends keyof CSSProperties,
+  TSchema,
+  TPseudoKey extends CSSPseudoClasses | ''
+> = {
+  [Q in keyof StrictCSSProperties]: Q extends TStyleDecl
+    ? CompiledPropertyDeclarationReference | ApplySchemaValue<TSchema, Q, TPseudoKey>
     : never;
 };
 
-type XCSSPseudos<
-  TAllowedProperties extends keyof CSSProperties,
+type XCSSPseudo<
+  TAllowedProperties extends keyof StrictCSSProperties,
   TAllowedPseudos extends CSSPseudos,
   TRequiredProperties extends { requiredProperties: TAllowedProperties },
   TSchema
 > = {
   [Q in CSSPseudos]?: Q extends TAllowedPseudos
     ? MarkAsRequired<
-        XCSSItem<TAllowedProperties, Q extends keyof TSchema ? TSchema[Q] : object>,
+        XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''>,
         TRequiredProperties['requiredProperties']
       >
     : never;
@@ -134,7 +137,7 @@ export type XCSSAllPseudos = CSSPseudos;
  * To concatenate and conditonally apply styles use the {@link cssMap} {@link cx} functions.
  */
 export type XCSSProp<
-  TAllowedProperties extends keyof CSSProperties,
+  TAllowedProperties extends keyof StrictCSSProperties,
   TAllowedPseudos extends CSSPseudos,
   TRequiredProperties extends {
     requiredProperties: TAllowedProperties;
@@ -143,7 +146,7 @@ export type XCSSProp<
 > = Internal$XCSSProp<TAllowedProperties, TAllowedPseudos, object, TRequiredProperties>;
 
 export type Internal$XCSSProp<
-  TAllowedProperties extends keyof CSSProperties,
+  TAllowedProperties extends keyof StrictCSSProperties,
   TAllowedPseudos extends CSSPseudos,
   TSchema,
   TRequiredProperties extends {
@@ -152,11 +155,11 @@ export type Internal$XCSSProp<
   }
 > =
   | (MarkAsRequired<
-      XCSSItem<TAllowedProperties, TSchema>,
+      XCSSValue<TAllowedProperties, TSchema, ''>,
       TRequiredProperties['requiredProperties']
     > &
       MarkAsRequired<
-        XCSSPseudos<TAllowedProperties, TAllowedPseudos, TRequiredProperties, TSchema>,
+        XCSSPseudo<TAllowedProperties, TAllowedPseudos, TRequiredProperties, TSchema>,
         TRequiredProperties['requiredPseudos']
       > &
       BlockedRules)


### PR DESCRIPTION
This pull request refactors the types in and around the `createStrictAPI()` to fix a few bugs and underlying architectural issues. To prevent scope creeping the PR I haven't implemented nested styles for the strict API (e.g. hover inside an after pseudo) which may cause for another refactor. We can tackle that at a later date.

This is to be merged before https://github.com/atlassian-labs/compiled/pull/1634 which then will build ontop of this one.

**Background**

Previously defining the schema came with a lot of redundant work. For every pseudo that you wanted to explicitly type you would have to define it, and then all of the base types again, like so:

```tsx
interface Schema {
  background: 'var(--bg)';
  color: 'var(--color)';
  '&:hover': {
    background: 'var(--bg)';
    color: 'var(--color-hovered)';
  }
}

createStrictAPI<Schema>();
```

If you missed a value / didn't type every pseudo it would fallback to the CSSProperties value (from `csstype`). This was mostly unexpected. So for example right now `:hover` has been typed, but nothing else has. So it wouldn't benefit from the schema types.

With this refactor it now always falls back to the top level types if not defined, meaning it's more expected and safe for everyone and you only need to type the values you want to explicitly support.

```diff
interface Schema {
  background: 'var(--bg)';
  color: 'var(--color)';
  '&:hover': {
-    background: 'var(--bg)';
    color: 'var(--color-hovered)';
  }
}

createStrictAPI<Schema>();
```

Dive into the pull request and check out my annotations for more information.

**Extra notes**

- I've raised this bug for some odd type behaviour noticed during this PR https://github.com/atlassian-labs/compiled/issues/1639

---

- [x] Test for type edge cases
- [x] Get a review for @kylorhall-atlassian
- [x] Resolve https://github.com/atlassian-labs/compiled/pull/1636#discussion_r1512014348
- [x] Resolve https://github.com/atlassian-labs/compiled/pull/1636#discussion_r1511969832