### PR TITLE
EXAMPLE: Allow explicit value-blocking in `xcss` prop.

### DIFF
--- a/.changeset/tricky-poems-greet.md
+++ b/.changeset/tricky-poems-greet.md
@@ -1,0 +1,37 @@
+---
+'@compiled/react': minor
+---
+
+Types for `createStrictAPI` have been refactored to improve type inference and expectations.
+
+Previously defining the schema came with a lot of redundant work. For every pseudo that you wanted to type you would have to define it, and then all of the base types again, like so:
+
+```ts
+interface Schema {
+  background: 'var(--bg)';
+  color: 'var(--color)';
+  '&:hover': {
+    background: 'var(--bg)';
+    color: 'var(--color-hovered)';
+  };
+}
+
+createStrictAPI<Schema>();
+```
+
+If you missed a value / didn't type every possible pseudo it would fallback to the CSSProperties value from csstype. This was mostly unexpected. So for example right now `&:hover` has been typed, but no other pseudo. So it nothing else would benefit from the schema types.
+
+With this refactor it now always falls back to the top level types if not defined, meaning you only need to type the values you want to explicitly support. In the previous example we're now able to remove the `background` property as it's the same as the top one. All pseudos are now typed as well.
+
+```diff
+interface Schema {
+  background: 'var(--bg)';
+  color: 'var(--color)';
+  '&:hover': {
+-    background: 'var(--bg)';
+    color: 'var(--color-hovered)';
+  };
+}
+
+createStrictAPI<Schema>();
+```

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
@@ -1,3 +1,5 @@
+/* eslint-disable prefer-const */
+import type { CompiledAPI } from '../../index';
 import { createStrictAPI } from '../../index';
 
 type Color = 'var(--ds-text)';
@@ -29,6 +31,11 @@ interface StrictAPI extends Properties {
   '&:active': PressedProperties;
 }
 
-const { css, XCSSProp, cssMap, cx } = createStrictAPI<StrictAPI>();
+let css: CompiledAPI<StrictAPI>['css'];
+let cssMap: CompiledAPI<StrictAPI>['cssMap'];
+let cx: CompiledAPI<StrictAPI>['cx'];
+let XCSSProp: CompiledAPI<StrictAPI>['XCSSProp'];
+
+({ css, cssMap, cx, XCSSProp } = createStrictAPI<StrictAPI>());
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-const */
-import type { CompiledAPI } from '../../index';
 import { createStrictAPI } from '../../index';
 
 type Color = 'var(--ds-text)';
@@ -31,11 +29,6 @@ interface StrictAPI extends Properties {
   '&:active': PressedProperties;
 }
 
-let css: CompiledAPI<StrictAPI>['css'];
-let cssMap: CompiledAPI<StrictAPI>['cssMap'];
-let cx: CompiledAPI<StrictAPI>['cx'];
-let XCSSProp: CompiledAPI<StrictAPI>['XCSSProp'];
-
-({ css, cssMap, cx, XCSSProp } = createStrictAPI<StrictAPI>());
+const { css, cssMap, cx, XCSSProp } = createStrictAPI<StrictAPI>();
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
@@ -6,18 +6,20 @@ type ColorPressed = 'var(--ds-text-pressed)';
 type Background = 'var(--ds-bold)' | 'var(--ds-success)';
 type BackgroundHovered = 'var(--ds-bold-hovered)' | 'var(--ds-success-hovered)';
 type BackgroundPressed = 'var(--ds-bold-pressed)' | 'var(--ds-success-pressed)';
+type Space = 'var(--ds-space-050)' | 'var(--ds-space-0)';
 
 interface Properties {
   color: Color;
   backgroundColor: Background;
+  padding: Space;
 }
 
-interface HoveredProperties extends Omit<Properties, 'backgroundColor' | 'color'> {
+interface HoveredProperties {
   color: ColorHovered;
   backgroundColor: BackgroundHovered;
 }
 
-interface PressedProperties extends Omit<Properties, 'backgroundColor' | 'color'> {
+interface PressedProperties {
   color: ColorPressed;
   backgroundColor: BackgroundPressed;
 }
@@ -25,8 +27,6 @@ interface PressedProperties extends Omit<Properties, 'backgroundColor' | 'color'
 interface StrictAPI extends Properties {
   '&:hover': HoveredProperties;
   '&:active': PressedProperties;
-  '&::before': Properties;
-  '&::after': Properties;
 }
 
 const { css, XCSSProp, cssMap, cx } = createStrictAPI<StrictAPI>();

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -1,6 +1,8 @@
+/* eslint-disable prefer-const */
+import type { CompiledAPI } from '../../index';
 import { createStrictAPI } from '../../index';
 
-const { css, XCSSProp, cssMap, cx } = createStrictAPI<{
+interface API {
   '&:hover': {
     color: 'var(--ds-text-hover)';
     background: 'var(--ds-surface-hover)' | 'var(--ds-surface-sunken-hover)';
@@ -8,6 +10,13 @@ const { css, XCSSProp, cssMap, cx } = createStrictAPI<{
   color: 'var(--ds-text)';
   background: 'var(--ds-surface)' | 'var(--ds-surface-sunken)';
   bkgrnd: 'red' | 'green';
-}>();
+}
+
+let css: CompiledAPI<API>['css'];
+let cssMap: CompiledAPI<API>['cssMap'];
+let cx: CompiledAPI<API>['cx'];
+let XCSSProp: CompiledAPI<API>['XCSSProp'];
+
+({ css, XCSSProp, cssMap, cx } = createStrictAPI<API>());
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -1,5 +1,3 @@
-/* eslint-disable prefer-const */
-import type { CompiledAPI } from '../../index';
 import { createStrictAPI } from '../../index';
 
 interface API {
@@ -12,11 +10,6 @@ interface API {
   bkgrnd: 'red' | 'green';
 }
 
-let css: CompiledAPI<API>['css'];
-let cssMap: CompiledAPI<API>['cssMap'];
-let cx: CompiledAPI<API>['cx'];
-let XCSSProp: CompiledAPI<API>['XCSSProp'];
-
-({ css, XCSSProp, cssMap, cx } = createStrictAPI<API>());
+const { css, XCSSProp, cssMap, cx } = createStrictAPI<API>();
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api.ts
@@ -1,6 +1,6 @@
 import { createStrictAPI } from '../../index';
 
-interface API {
+export interface CompiledStrictAPI {
   '&:hover': {
     color: 'var(--ds-text-hover)';
     background: 'var(--ds-surface-hover)' | 'var(--ds-surface-sunken-hover)';
@@ -10,6 +10,6 @@ interface API {
   bkgrnd: 'red' | 'green';
 }
 
-const { css, XCSSProp, cssMap, cx } = createStrictAPI<API>();
+const { css, XCSSProp, cssMap, cx } = createStrictAPI<CompiledStrictAPI>();
 
 export { css, XCSSProp, cssMap, cx };

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -162,15 +162,15 @@ describe('createStrictAPI()', () => {
             backgroundColor: '',
             '&:hover': {
               // @ts-expect-error — Type '""' is not assignable to type ...
-              color: '',
+              color: 'var(--ds-text)',
               // @ts-expect-error — Type '""' is not assignable to type ...
-              backgroundColor: '',
+              backgroundColor: 'var(--ds-success)',
             },
             '&:active': {
               // @ts-expect-error — Type '""' is not assignable to type ...
-              color: '',
+              color: 'var(--ds-text)',
               // @ts-expect-error — Type '""' is not assignable to type ...
-              backgroundColor: '',
+              backgroundColor: 'var(--ds-success)',
             },
             '&::before': {
               // @ts-expect-error — Type '""' is not assignable to type ...

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -59,6 +59,13 @@ describe('createStrictAPI()', () => {
 
   describe('type violations', () => {
     it('should violate types for css()', () => {
+      css({
+        color: 'var(--ds-text)',
+        '&:hover': {
+          color: 'var(--ds-text-hovered)',
+        },
+      });
+
       const styles = css({
         // @ts-expect-error — Type '""' is not assignable to type ...
         color: '',
@@ -99,7 +106,7 @@ describe('createStrictAPI()', () => {
       const styles = cssMap({
         primary: {
           // @ts-expect-error — Type '""' is not assignable to type ...
-          color: 's',
+          color: '',
           // @ts-expect-error — Type '""' is not assignable to type ...
           backgroundColor: '',
           '&:hover': {
@@ -188,21 +195,31 @@ describe('createStrictAPI()', () => {
   describe('type success', () => {
     it('should pass type check for css()', () => {
       const styles = css({
+        // @ts-expect-error — should be a value from the schema
+        padding: '10px',
         color: 'var(--ds-text)',
         backgroundColor: 'var(--ds-bold)',
         '&:hover': {
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
           color: 'var(--ds-text-hovered)',
           backgroundColor: 'var(--ds-bold-hovered)',
         },
         '&:active': {
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
           color: 'var(--ds-text-pressed)',
           backgroundColor: 'var(--ds-bold-pressed)',
         },
         '&::before': {
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
           color: 'var(--ds-text)',
           backgroundColor: 'var(--ds-bold)',
         },
         '&::after': {
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
           color: 'var(--ds-text)',
           backgroundColor: 'var(--ds-bold)',
         },
@@ -218,19 +235,30 @@ describe('createStrictAPI()', () => {
         primary: {
           color: 'var(--ds-text)',
           backgroundColor: 'var(--ds-bold)',
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
           '&:hover': {
+            accentColor: 'red',
+            // @ts-expect-error — should be a value from the schema
+            padding: '10px',
             color: 'var(--ds-text-hovered)',
             backgroundColor: 'var(--ds-bold-hovered)',
           },
           '&:active': {
+            // @ts-expect-error — should be a value from the schema
+            padding: '10px',
             color: 'var(--ds-text-pressed)',
             backgroundColor: 'var(--ds-bold-pressed)',
           },
           '&::before': {
+            // @ts-expect-error — should be a value from the schema
+            padding: '10px',
             color: 'var(--ds-text)',
             backgroundColor: 'var(--ds-bold)',
           },
           '&::after': {
+            // @ts-expect-error — should be a value from the schema
+            padding: '10px',
             color: 'var(--ds-text)',
             backgroundColor: 'var(--ds-bold)',
           },

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -146,7 +146,7 @@ describe('createStrictAPI()', () => {
           accentColor: 'red',
           all: 'inherit',
           '&:hover': { color: 'var(--ds-text-hover)' },
-          '&:invalid': { color: 'orange' },
+          '&:invalid': { color: 'var(--ds-text)' },
         },
       });
 
@@ -275,8 +275,8 @@ describe('createStrictAPI()', () => {
       function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', never>> }) {
         return <button data-testid="button" className={xcss} />;
       }
-
       const styles = cssMap({ bg: { background: 'var(--ds-surface)' } });
+
       const { getByTestId } = render(<Button xcss={styles.bg} />);
 
       expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
@@ -302,7 +302,6 @@ describe('createStrictAPI()', () => {
       function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', '&:hover'>> }) {
         return <button data-testid="button" className={xcss} />;
       }
-
       const styles = cssMap({
         primary: {
           background: 'var(--ds-surface)',

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -347,10 +347,12 @@ describe('createStrictAPI()', () => {
     it('should error with values not in the strict `CompiledAPI`', () => {
       function Button({
         xcss,
+        testId,
       }: {
+        testId: string;
         xcss: ReturnType<typeof XCSSProp<'background' | 'color', '&:hover'>>;
       }) {
-        return <button data-testid="button" className={xcss} />;
+        return <button data-testid={testId} className={xcss} />;
       }
 
       const styles = cssMap({
@@ -363,13 +365,19 @@ describe('createStrictAPI()', () => {
       });
 
       const { getByTestId } = render(
-        <Button
-          // @ts-expect-error -- Errors because `color` conflicts with the `XCSSProp` schema–`color` should be a css variable.
-          xcss={styles.primary}
-        />
+        <>
+          <Button testId="button-1" xcss={styles.primary} />
+          <Button
+            testId="button-2"
+            xcss={{
+              // @ts-expect-error -- This is not in the `createStrictAPI` schema—this should be a css variable.
+              color: 'red',
+            }}
+          />
+        </>
       );
 
-      expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
+      expect(getByTestId('button-1')).toHaveCompiledCss('background', 'var(--ds-surface)');
     });
 
     it('should error with properties not in the `XCSSProp`', () => {

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -519,12 +519,16 @@ describe('createStrictAPI()', () => {
       function Button({ xcss }: { xcss: ReturnType<typeof XCSSProp<'background', '&:hover'>> }) {
         return <button data-testid="button" className={xcss} />;
       }
-      const styles = cssMap({
+
+      // Split into two to have proper ts errors
+      const stylesOne = cssMap({
         primary: {
           // @ts-expect-error -- Fails because `foo` is not assignable to our CSSProperties whatsoever.
           foo: 'bar',
           background: 'var(--ds-surface)',
         },
+      });
+      const stylesTwo = cssMap({
         hover: {
           '&:hover': {
             // @ts-expect-error -- Fails because `foo` is not assignable to our CSSProperties whatsoever.
@@ -534,7 +538,7 @@ describe('createStrictAPI()', () => {
         },
       });
 
-      const { getByTestId } = render(<Button xcss={cx(styles.primary, styles.hover)} />);
+      const { getByTestId } = render(<Button xcss={cx(stylesOne.primary, stylesTwo.hover)} />);
 
       expect(getByTestId('button')).toHaveCompiledCss('background', 'var(--ds-surface)');
     });

--- a/packages/react/src/create-strict-api/__tests__/index.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/index.test.tsx
@@ -394,12 +394,12 @@ describe('createStrictAPI()', () => {
           />
           <Button
             testId="button-invalid-strict"
-            // @ts-expect-error -- TODO: This should conflict, but when `cssMap` conflicts, it gets a different type (this has `ApplySchema`, not the raw object), so this doesn't error?  Weird…
+            // @ts-expect-error -- This should conflict, but when `cssMap` conflicts, it gets a different type (this has `ApplySchema`, not the raw object), so this doesn't error?  Weird…
             xcss={stylesInvalid.primary}
           />
           <Button
             testId="button-invalid-strict-cx"
-            // @ts-expect-error -- TODO: This should conflict, but when `cssMap` conflicts, it gets a different type (this has `ApplySchema`, not the raw object), so this doesn't error?  Weird…
+            // @ts-expect-error -- This should conflict, but when `cssMap` conflicts, it gets a different type (this has `ApplySchema`, not the raw object), so this doesn't error?  Weird…
             xcss={cx(stylesInvalid.primary, stylesValid.primary)}
           />
           <Button testId="button-valid" xcss={stylesValid.primary} />

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -2,7 +2,7 @@ import type { StrictCSSProperties, CSSPseudos } from '../types';
 import { createStrictSetupError } from '../utils/error';
 import { type CompiledStyles, cx, type Internal$XCSSProp } from '../xcss-prop';
 
-import type { AllowedStyles, ApplySchema, CompiledSchemaShape } from './types';
+import type { AllowedStyles, ApplySchema, ApplySchemaMap, CompiledSchemaShape } from './types';
 
 export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
   /**
@@ -20,7 +20,9 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    * <div css={redText} />
    * ```
    */
-  css<TStyles extends AllowedStyles>(styles: ApplySchema<TStyles, TSchema>): StrictCSSProperties;
+  css<TStyles extends ApplySchema<TStyles, TSchema>>(
+    styles: AllowedStyles & TStyles
+  ): CompiledStyles<TStyles>;
   /**
    * ## CSS Map
    *
@@ -37,9 +39,9 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    * <div css={styles.solid} />
    * ```
    */
-  cssMap<TStylesMap extends Record<string, AllowedStyles>>(styles: {
-    [P in keyof TStylesMap]: ApplySchema<TStylesMap[P], TSchema>;
-  }): {
+  cssMap<TStylesMap extends ApplySchemaMap<TStylesMap, TSchema>>(
+    styles: Record<string, AllowedStyles> & TStylesMap
+  ): {
     readonly [P in keyof TStylesMap]: CompiledStyles<TStylesMap[P]>;
   };
   /**

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -2,9 +2,9 @@ import type { StrictCSSProperties, CSSPseudos } from '../types';
 import { createStrictSetupError } from '../utils/error';
 import { type CompiledStyles, cx, type Internal$XCSSProp } from '../xcss-prop';
 
-import type { AllowedStyles, ApplySchema, CompiledSchema } from './types';
+import type { AllowedStyles, ApplySchema, CompiledSchemaShape } from './types';
 
-export interface CompiledAPI<TSchema extends CompiledSchema> {
+export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
   /**
    * ## CSS
    *
@@ -178,7 +178,7 @@ export interface CompiledAPI<TSchema extends CompiledSchema> {
  * <div css={styles} />
  * ```
  */
-export function createStrictAPI<TSchema extends CompiledSchema>(): CompiledAPI<TSchema> {
+export function createStrictAPI<TSchema extends CompiledSchemaShape>(): CompiledAPI<TSchema> {
   return {
     css() {
       throw createStrictSetupError();

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -1,34 +1,8 @@
-import type { StrictCSSProperties, CSSPseudoClasses, CSSPseudos } from '../types';
+import type { StrictCSSProperties, CSSPseudos } from '../types';
 import { createStrictSetupError } from '../utils/error';
 import { type CompiledStyles, cx, type Internal$XCSSProp } from '../xcss-prop';
 
-type CompiledSchema = StrictCSSProperties & { [Q in CSSPseudoClasses]?: StrictCSSProperties };
-
-type AllowedStyles = StrictCSSProperties & PseudosDeclarations;
-
-type PseudosDeclarations = {
-  [Q in CSSPseudos]?: StrictCSSProperties;
-};
-
-type ApplySchemaValue<
-  TSchema,
-  TKey extends keyof StrictCSSProperties,
-  TPseudoKey extends CSSPseudoClasses | ''
-> = TKey extends keyof TSchema
-  ? TPseudoKey extends keyof TSchema
-    ? TKey extends keyof TSchema[TPseudoKey]
-      ? TSchema[TPseudoKey][TKey]
-      : TSchema[TKey]
-    : TSchema[TKey]
-  : StrictCSSProperties[TKey];
-
-type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | '' = ''> = {
-  [TKey in keyof TObject]?: TKey extends keyof StrictCSSProperties
-    ? ApplySchemaValue<TSchema, TKey, TPseudoKey>
-    : TKey extends CSSPseudoClasses
-    ? ApplySchema<TObject[TKey], TSchema, TKey>
-    : ApplySchema<TObject[TKey], TSchema>;
-};
+import type { AllowedStyles, ApplySchema, CompiledSchema } from './types';
 
 export interface CompiledAPI<TSchema extends CompiledSchema> {
   /**

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -128,8 +128,9 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
     TRequiredProperties extends {
       requiredProperties: TAllowedProperties;
       requiredPseudos: TAllowedPseudos;
-    } = never
-  >(): Internal$XCSSProp<TAllowedProperties, TAllowedPseudos, TSchema, TRequiredProperties>;
+    } = never,
+    CustomTSchema extends CompiledSchemaShape = TSchema
+  >(): Internal$XCSSProp<TAllowedProperties, TAllowedPseudos, CustomTSchema, TRequiredProperties>;
 }
 
 /**

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -39,7 +39,10 @@ export interface CompiledAPI<TSchema extends CompiledSchemaShape> {
    * <div css={styles.solid} />
    * ```
    */
-  cssMap<TStylesMap extends ApplySchemaMap<TStylesMap, TSchema>>(
+  cssMap<
+    TObject extends Record<string, AllowedStyles>,
+    TStylesMap extends ApplySchemaMap<TObject, TSchema>
+  >(
     styles: Record<string, AllowedStyles> & TStylesMap
   ): {
     readonly [P in keyof TStylesMap]: CompiledStyles<TStylesMap[P]>;

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -1,6 +1,6 @@
 import type { StrictCSSProperties, CSSPseudoClasses, CSSPseudos } from '../types';
 
-export type CompiledSchema = StrictCSSProperties & {
+export type CompiledSchemaShape = StrictCSSProperties & {
   [Q in CSSPseudoClasses]?: StrictCSSProperties;
 };
 

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -1,0 +1,29 @@
+import type { StrictCSSProperties, CSSPseudoClasses, CSSPseudos } from '../types';
+
+export type CompiledSchema = StrictCSSProperties & {
+  [Q in CSSPseudoClasses]?: StrictCSSProperties;
+};
+
+export type PseudosDeclarations = { [Q in CSSPseudos]?: StrictCSSProperties };
+
+export type AllowedStyles = StrictCSSProperties & PseudosDeclarations;
+
+export type ApplySchemaValue<
+  TSchema,
+  TKey extends keyof StrictCSSProperties,
+  TPseudoKey extends CSSPseudoClasses | ''
+> = TKey extends keyof TSchema
+  ? TPseudoKey extends keyof TSchema
+    ? TKey extends keyof TSchema[TPseudoKey]
+      ? TSchema[TPseudoKey][TKey]
+      : TSchema[TKey]
+    : TSchema[TKey]
+  : StrictCSSProperties[TKey];
+
+export type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | '' = ''> = {
+  [TKey in keyof TObject]?: TKey extends keyof StrictCSSProperties
+    ? ApplySchemaValue<TSchema, TKey, TPseudoKey>
+    : TKey extends CSSPseudoClasses
+    ? ApplySchema<TObject[TKey], TSchema, TKey>
+    : ApplySchema<TObject[TKey], TSchema>;
+};

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -1,4 +1,9 @@
-import type { StrictCSSProperties, CSSPseudoClasses, CSSPseudos } from '../types';
+import type {
+  StrictCSSProperties,
+  CSSPseudoClasses,
+  CSSPseudoElements,
+  CSSPseudos,
+} from '../types';
 
 export type CompiledSchemaShape = StrictCSSProperties & {
   [Q in CSSPseudoClasses]?: StrictCSSProperties;
@@ -25,5 +30,11 @@ export type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | 
     ? ApplySchemaValue<TSchema, TKey, TPseudoKey>
     : TKey extends CSSPseudoClasses
     ? ApplySchema<TObject[TKey], TSchema, TKey>
-    : ApplySchema<TObject[TKey], TSchema>;
+    : TKey extends `@${string}` | CSSPseudoElements
+    ? ApplySchema<TObject[TKey], TSchema>
+    : never;
+};
+
+export type ApplySchemaMap<TStylesMap, TSchema> = {
+  [P in keyof TStylesMap]: ApplySchema<TStylesMap[P], TSchema>;
 };

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -38,7 +38,7 @@ export type ApplySchemaValue<
 /**
  * Recursively maps over object properties to resolve them to either a {@link TSchema}
  * value if present, else fallback to its value from {@link StrictCSSProperties}. If
- * the property isn't a known CSS property its value will be resolved to `never`.
+ * the property isn't a known property its value will be resolved to `never`.
  */
 export type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | '' = ''> = {
   [TKey in keyof TObject]?: TKey extends keyof StrictCSSProperties

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -5,6 +5,11 @@ import type {
   CSSPseudos,
 } from '../types';
 
+/**
+ * This is the shape of the generic object that `createStrictAPI()` takes.
+ * It's deliberately a subset of `AllowedStyles` and does not take at rules
+ * and pseudo elements.
+ */
 export type CompiledSchemaShape = StrictCSSProperties & {
   [Q in CSSPseudoClasses]?: StrictCSSProperties;
 };
@@ -18,21 +23,39 @@ export type ApplySchemaValue<
   TKey extends keyof StrictCSSProperties,
   TPseudoKey extends CSSPseudoClasses | ''
 > = TKey extends keyof TSchema
-  ? TPseudoKey extends keyof TSchema
+  ? // TKey is a valid property on the schema
+    TPseudoKey extends keyof TSchema
     ? TKey extends keyof TSchema[TPseudoKey]
-      ? TSchema[TPseudoKey][TKey]
-      : TSchema[TKey]
-    : TSchema[TKey]
-  : StrictCSSProperties[TKey];
+      ? // We found a more specific value under TPseudoKey.
+        TSchema[TPseudoKey][TKey]
+      : // Did not found anything specific, use the top level TSchema value.
+        TSchema[TKey]
+    : // Did not found anything specific, use the top level TSchema value.
+      TSchema[TKey]
+  : // TKey wasn't found on the schema, fallback to the CSS property value
+    StrictCSSProperties[TKey];
 
+/**
+ * Recursively maps over object properties to resolve them to either a {@link TSchema}
+ * value if present, else fallback to its value from {@link StrictCSSProperties}. If
+ * the property isn't a known CSS property its value will be resolved to `never`.
+ */
 export type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | '' = ''> = {
   [TKey in keyof TObject]?: TKey extends keyof StrictCSSProperties
-    ? ApplySchemaValue<TSchema, TKey, TPseudoKey>
+    ? // TKey is a valid CSS property, try to resolve its value.
+      ApplySchemaValue<TSchema, TKey, TPseudoKey>
     : TKey extends CSSPseudoClasses
-    ? ApplySchema<TObject[TKey], TSchema, TKey>
+    ? // TKey is a valid pseudo class, recursively resolve its child properties
+      // while passing down the parent pseudo key to resolve any specific schema types.
+      ApplySchema<TObject[TKey], TSchema, TKey>
     : TKey extends `@${string}` | CSSPseudoElements
-    ? ApplySchema<TObject[TKey], TSchema>
-    : never;
+    ? // TKey is either an at rule or a pseudo element, either way we don't care about
+      // passing down the key so we recursively resolve its child properties starting at
+      // the base schema, treating it as if it's not inside an object.
+      ApplySchema<TObject[TKey], TSchema>
+    : // Fallback case, did not find a valid CSS property, at rule, or pseudo.
+      // Resolve the value to `never` which will end up being a type violation.
+      never;
 };
 
 export type ApplySchemaMap<TStylesMap, TSchema> = {

--- a/packages/react/src/jsx/jsx-local-namespace.ts
+++ b/packages/react/src/jsx/jsx-local-namespace.ts
@@ -1,4 +1,4 @@
-import type { CssFunction } from '../types';
+import type { CssFunction, CompiledPropertyDeclarationReference } from '../types';
 
 type WithConditionalCSSProp<TProps> = 'className' extends keyof TProps
   ? string extends TProps['className' & keyof TProps]
@@ -80,7 +80,11 @@ export namespace CompiledJSX {
        * The class name prop now can be given the output of xcss prop from `@compiled/react`.
        */
       className?: string | Record<string, any> | null | false;
-      css?: CssFunction<void> | CssFunction<void>[];
+      css?:
+        | CssFunction<void>
+        | CssFunction<void>[]
+        | (CssFunction<void> & CompiledPropertyDeclarationReference)
+        | (CssFunction<void> & CompiledPropertyDeclarationReference)[];
     };
   };
 }

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -111,3 +111,7 @@ export type CSSProperties = Readonly<CSS.Properties<string | number>>;
  * vendor and obsolete properties.
  */
 export type StrictCSSProperties = Readonly<CSS.StandardProperties & CSS.SvgProperties>;
+
+export interface CompiledPropertyDeclarationReference {
+  ['__COMPILED_PROPERTY_DECLARATION_REFERENCE_DO_NOT_WRITE_DIRECTLY__']: true;
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -35,14 +35,7 @@ export type CssFunction<TProps = unknown> =
   | boolean // Something like `false && styles`
   | undefined; // Something like `undefined && styles`
 
-/*
- * This list of pseudo-classes and pseudo-elements are from csstype
- * but with & added to the front. Compiled supports both &-ful
- * and &-less forms and both will target the current element
- * (`&:hover` <==> `:hover`), however we force the use of the
- * &-ful form for consistency with the nested spec for new APIs.
- */
-export type CSSPseudos =
+export type CSSPseudoElements =
   | '&::after'
   | '&::backdrop'
   | '&::before'
@@ -56,7 +49,9 @@ export type CSSPseudos =
   | '&::selection'
   | '&::spelling-error'
   | '&::target-text'
-  | '&::view-transition'
+  | '&::view-transition';
+
+export type CSSPseudoClasses =
   | '&:active'
   | '&:autofill'
   | '&:blank'
@@ -93,6 +88,15 @@ export type CSSPseudos =
   | '&:user-valid'
   | '&:valid'
   | '&:visited';
+
+/*
+ * This list of pseudo-classes and pseudo-elements are from csstype
+ * but with & added to the front. Compiled supports both &-ful
+ * and &-less forms and both will target the current element
+ * (`&:hover` <==> `:hover`), however we force the use of the
+ * &-ful form for consistency with the nested spec for new APIs.
+ */
+export type CSSPseudos = CSSPseudoElements | CSSPseudoClasses;
 
 /**
  * The XCSSProp must be given all known available properties even

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -2,7 +2,13 @@ import type * as CSS from 'csstype';
 
 import type { ApplySchemaValue } from '../create-strict-api/types';
 import { ac } from '../runtime';
-import type { CSSPseudos, CSSPseudoClasses, CSSProperties, StrictCSSProperties } from '../types';
+import type {
+  CSSPseudos,
+  CSSPseudoClasses,
+  CSSProperties,
+  StrictCSSProperties,
+  CompiledPropertyDeclarationReference,
+} from '../types';
 
 type MarkAsRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
@@ -45,10 +51,6 @@ type BlockedRules = {
    */
   [Q in CSS.AtRules]?: never;
 };
-
-interface CompiledPropertyDeclarationReference {
-  ['__COMPILED_PROPERTY_DECLARATION_REFERENCE_DO_NOT_WRITE_DIRECTLY__']: true;
-}
 
 /**
  * Used to mark styles that have been flushed through an API as being generated

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -1,27 +1,30 @@
 import type * as CSS from 'csstype';
 
+import type { ApplySchemaValue } from '../create-strict-api/types';
 import { ac } from '../runtime';
-import type { CSSPseudos, CSSProperties, StrictCSSProperties } from '../types';
+import type { CSSPseudos, CSSPseudoClasses, CSSProperties, StrictCSSProperties } from '../types';
 
 type MarkAsRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
-type XCSSItem<TStyleDecl extends keyof CSSProperties, TSchema> = {
-  [Q in keyof CSSProperties]: Q extends TStyleDecl
-    ?
-        | CompiledPropertyDeclarationReference
-        | (Q extends keyof TSchema ? TSchema[Q] : CSSProperties[Q])
+type XCSSValue<
+  TStyleDecl extends keyof CSSProperties,
+  TSchema,
+  TPseudoKey extends CSSPseudoClasses | ''
+> = {
+  [Q in keyof StrictCSSProperties]: Q extends TStyleDecl
+    ? CompiledPropertyDeclarationReference | ApplySchemaValue<TSchema, Q, TPseudoKey>
     : never;
 };
 
-type XCSSPseudos<
-  TAllowedProperties extends keyof CSSProperties,
+type XCSSPseudo<
+  TAllowedProperties extends keyof StrictCSSProperties,
   TAllowedPseudos extends CSSPseudos,
   TRequiredProperties extends { requiredProperties: TAllowedProperties },
   TSchema
 > = {
   [Q in CSSPseudos]?: Q extends TAllowedPseudos
     ? MarkAsRequired<
-        XCSSItem<TAllowedProperties, Q extends keyof TSchema ? TSchema[Q] : object>,
+        XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''>,
         TRequiredProperties['requiredProperties']
       >
     : never;
@@ -134,7 +137,7 @@ export type XCSSAllPseudos = CSSPseudos;
  * To concatenate and conditonally apply styles use the {@link cssMap} {@link cx} functions.
  */
 export type XCSSProp<
-  TAllowedProperties extends keyof CSSProperties,
+  TAllowedProperties extends keyof StrictCSSProperties,
   TAllowedPseudos extends CSSPseudos,
   TRequiredProperties extends {
     requiredProperties: TAllowedProperties;
@@ -143,7 +146,7 @@ export type XCSSProp<
 > = Internal$XCSSProp<TAllowedProperties, TAllowedPseudos, object, TRequiredProperties>;
 
 export type Internal$XCSSProp<
-  TAllowedProperties extends keyof CSSProperties,
+  TAllowedProperties extends keyof StrictCSSProperties,
   TAllowedPseudos extends CSSPseudos,
   TSchema,
   TRequiredProperties extends {
@@ -152,11 +155,11 @@ export type Internal$XCSSProp<
   }
 > =
   | (MarkAsRequired<
-      XCSSItem<TAllowedProperties, TSchema>,
+      XCSSValue<TAllowedProperties, TSchema, ''>,
       TRequiredProperties['requiredProperties']
     > &
       MarkAsRequired<
-        XCSSPseudos<TAllowedProperties, TAllowedPseudos, TRequiredProperties, TSchema>,
+        XCSSPseudo<TAllowedProperties, TAllowedPseudos, TRequiredProperties, TSchema>,
         TRequiredProperties['requiredPseudos']
       > &
       BlockedRules)

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -12,7 +12,7 @@ type XCSSValue<
   TPseudoKey extends CSSPseudoClasses | ''
 > = {
   [Q in keyof StrictCSSProperties]: Q extends TStyleDecl
-    ? CompiledPropertyDeclarationReference | ApplySchemaValue<TSchema, Q, TPseudoKey>
+    ? ApplySchemaValue<TSchema, Q, TPseudoKey>
     : never;
 };
 
@@ -23,10 +23,11 @@ type XCSSPseudo<
   TSchema
 > = {
   [Q in CSSPseudos]?: Q extends TAllowedPseudos
-    ? MarkAsRequired<
-        XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''>,
-        TRequiredProperties['requiredProperties']
-      >
+    ? XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''> &
+        MarkAsRequired<
+          XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''>,
+          TRequiredProperties['requiredProperties']
+        >
     : never;
 };
 
@@ -45,9 +46,9 @@ type BlockedRules = {
   [Q in CSS.AtRules]?: never;
 };
 
-type CompiledPropertyDeclarationReference = {
+interface CompiledPropertyDeclarationReference {
   ['__COMPILED_PROPERTY_DECLARATION_REFERENCE_DO_NOT_WRITE_DIRECTLY__']: true;
-};
+}
 
 /**
  * Used to mark styles that have been flushed through an API as being generated
@@ -57,8 +58,8 @@ type CompiledPropertyDeclarationReference = {
 export type CompiledStyles<TObject> = {
   [Q in keyof TObject]: TObject[Q] extends Record<string, unknown>
     ? CompiledStyles<TObject[Q]>
-    : CompiledPropertyDeclarationReference;
-};
+    : TObject[Q];
+} & CompiledPropertyDeclarationReference;
 
 /**
  * Please think twice before using this type, you're better off declaring explicitly
@@ -162,7 +163,8 @@ export type Internal$XCSSProp<
         XCSSPseudo<TAllowedProperties, TAllowedPseudos, TRequiredProperties, TSchema>,
         TRequiredProperties['requiredPseudos']
       > &
-      BlockedRules)
+      BlockedRules &
+      CompiledPropertyDeclarationReference)
   | false
   | null
   | undefined;


### PR DESCRIPTION
_[example for @itsdouges to review into https://github.com/atlassian-labs/compiled/pull/1636]_

We don't actually need the generic value for this to be valuable, this should block it so an `@compiled/react.cssMap` with conflicting values is disallowed, but also can allow prop-level restrictions (if we want).

This is by moving `CompiledPropertyDeclarationReference` to not be optional as that object seemingly messed something up as `| CompiledPropertyDeclarationReference` was always "truthy" (if that makes sense).

However, this removes the functionality for inline `xcss` and requires a `cssMap` or future `css`(?) to exist..which is probably fine.

---

This has one remaining scenario not erroring (if I fixed the other inline `xcss={{ … }}` object tests), but it does error somewhere in the stack, and this is because a cssMap-level type error is typed differently than a non-erroring cssMap?