### PR TITLE
feat: add title attribute to Compiled style tag

### DIFF
--- a/.changeset/fluffy-lies-shake.md
+++ b/.changeset/fluffy-lies-shake.md
@@ -1,0 +1,5 @@
+---
+'@compiled/parcel-optimizer': minor
+---
+
+Add title attribute to Compiled style tag to discern with other style within the page

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ yarn test <filter> --watch
 
 Looking at tests first is generally the best way to get started.
 
-- Run a specific test file: `yarn test <filename> --watch`
+- Run a specific test file: `yarn test <filename> --watch` OR `yarn test:parcel <filename>` if the test file name ends with `parceltest.{ts,tsx}`
 - Run tests related to a package `yarn test:packageName --watch`
 - Update snapshot tests after implementing a code change: `yarn test <filter> --watch --updateSnapshot`
 

--- a/packages/parcel-optimizer/src/__tests__/optimizer.parceltest.ts
+++ b/packages/parcel-optimizer/src/__tests__/optimizer.parceltest.ts
@@ -44,7 +44,7 @@ describe('optimizer', () => {
       'utf8'
     );
 
-    const css = /<style>(.*?)<\/style>/.exec(outputHtml)?.pop();
+    const css = /<style title="compiled">(.*?)<\/style>/.exec(outputHtml)?.pop();
 
     if (!css) throw new Error('No CSS is found.');
 

--- a/packages/parcel-optimizer/src/index.ts
+++ b/packages/parcel-optimizer/src/index.ts
@@ -71,7 +71,7 @@ export default new Optimizer<ParcelOptimizerOpts, unknown>({
           .use(
             insertAt({
               selector: 'head',
-              append: '<style>' + stylesheet + '</style>',
+              append: '<style title="compiled">' + stylesheet + '</style>',
               behavior: 'inside',
             })
           )

--- a/packages/parcel-transformer-external/src/__tests__/transformer.parceltest.ts
+++ b/packages/parcel-transformer-external/src/__tests__/transformer.parceltest.ts
@@ -44,7 +44,7 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
     'utf8'
   );
 
-  const css = /<style>(.*?)<\/style>/.exec(outputHtml)?.pop();
+  const css = /<style title="compiled">(.*?)<\/style>/.exec(outputHtml)?.pop();
 
   if (!css) throw new Error('No CSS is found.');
 

--- a/packages/parcel-transformer/src/__tests__/transformer.parceltest.ts
+++ b/packages/parcel-transformer/src/__tests__/transformer.parceltest.ts
@@ -215,7 +215,7 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
     'utf8'
   );
 
-  const css = /<style>(.*?)<\/style>/.exec(outputHtml)?.pop();
+  const css = /<style title="compiled">(.*?)<\/style>/.exec(outputHtml)?.pop();
 
   if (!css) throw new Error('No CSS is found.');
 
@@ -310,7 +310,7 @@ it('transforms assets with class name compression enabled', async () => {
     'utf8'
   );
 
-  const css = /<style>(.*?)<\/style>/.exec(outputHtml)?.pop();
+  const css = /<style title="compiled">(.*?)<\/style>/.exec(outputHtml)?.pop();
 
   if (!css) throw new Error('No CSS is found.');
 


### PR DESCRIPTION
TBH, I am not sure if this is a valuable change considering [these devlop issues ](https://github.com/atlassian-labs/compiled/issues/1531). Also, we know that classes starting with `_` are usually Compiled; hence, we can just look for it.
However, it may save some keystrokes when debugging :)

----

**Dev mode**
It seems that we are having multiple style tags when extraction is not enabled, only one is getting the `title` attribute
![Screenshot 2024-03-20 at 3 22 42 pm](https://github.com/atlassian-labs/compiled/assets/14813563/0602c559-ca39-42aa-8823-683ac9b5bc60)

**VS**

**Prod mode**
We can easily discern what style is for Compiled. 
![Screenshot 2024-03-20 at 3 22 01 pm](https://github.com/atlassian-labs/compiled/assets/14813563/9a856e62-d0c9-4954-bd32-4233fad90edf)



