### PR TITLE
Remove the invariant to fail on an empty cssMap object for easier iterative development.

### DIFF
--- a/.changeset/dry-ghosts-brake.md
+++ b/.changeset/dry-ghosts-brake.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Remove the invariant to fail on an empty cssMap object for easier iterative development.

--- a/packages/babel-plugin/src/css-map/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/css-map/__tests__/index.test.ts
@@ -29,6 +29,22 @@ describe('css map basic functionality', () => {
     );
   });
 
+  it('should transform css map even with an empty object', () => {
+    const actual = transform(`
+        import { css, cssMap } from '@compiled/react';
+
+        const styles = cssMap({
+          danger: {},
+          success: {
+            color: 'green',
+            backgroundColor: 'green'
+          }
+        });
+      `);
+
+    expect(actual).toInclude('const styles={danger:"",success:"_syazbf54 _bfhkbf54"};');
+  });
+
   it('should error out if variants are not defined at the top-most scope of the module.', () => {
     expect(() => {
       transform(`
@@ -53,7 +69,7 @@ describe('css map basic functionality', () => {
     expect(() => {
       transform(`
         import { cssMap } from '@compiled/react';
-  
+
         const styles = cssMap(${styles}, ${styles})
       `);
     }).toThrow(ErrorMessages.NUMBER_OF_ARGUMENT);
@@ -63,7 +79,7 @@ describe('css map basic functionality', () => {
     expect(() => {
       transform(`
         import { cssMap } from '@compiled/react';
-  
+
         const styles = cssMap('color: red')
       `);
     }).toThrow(ErrorMessages.ARGUMENT_TYPE);
@@ -91,18 +107,6 @@ describe('css map basic functionality', () => {
         });
       `);
     }).toThrow(ErrorMessages.NO_OBJECT_METHOD);
-  });
-
-  it('should error out if empty object passed to variant', () => {
-    expect(() => {
-      transform(`
-        import { css, cssMap } from '@compiled/react';
-
-        const styles = cssMap({
-          danger: {}
-        });
-      `);
-    }).toThrow(ErrorMessages.EMPTY_VARIANT_OBJECT);
   });
 
   it('should error out if variant object is dynamic', () => {

--- a/packages/babel-plugin/src/css-map/process-selectors.ts
+++ b/packages/babel-plugin/src/css-map/process-selectors.ts
@@ -114,14 +114,6 @@ export const mergeExtendedSelectorsIntoProperties = (
   const mergedProperties: t.ObjectProperty[] = [];
   const addedSelectors: Set<string> = new Set();
 
-  if (variantStyles.properties.length === 0) {
-    throw buildCodeFrameError(
-      createErrorMessage(ErrorMessages.EMPTY_VARIANT_OBJECT),
-      variantStyles,
-      meta.parentPath
-    );
-  }
-
   for (const property of [...variantStyles.properties, ...extendedSelectors]) {
     // Covered by @compiled/eslint-plugin rule already,
     // this is just to make the type checker happy

--- a/packages/babel-plugin/src/utils/css-map.ts
+++ b/packages/babel-plugin/src/utils/css-map.ts
@@ -80,7 +80,6 @@ export enum ErrorMessages {
   NO_SPREAD_ELEMENT = 'Spread element is not supported in CSS Map.',
   NO_OBJECT_METHOD = 'Object method is not supported in CSS Map.',
   STATIC_VARIANT_OBJECT = 'The variant object must be statically defined.',
-  EMPTY_VARIANT_OBJECT = 'The variant object must not be empty.',
   DUPLICATE_AT_RULE = 'Cannot declare an at-rule more than once in CSS Map.',
   DUPLICATE_SELECTOR = 'Cannot declare a selector more than once in CSS Map.',
   DUPLICATE_SELECTORS_BLOCK = 'Duplicate `selectors` key found in cssMap; expected either zero `selectors` keys or one.',


### PR DESCRIPTION
I personally noticed this wasn't breaking in local development, but was blocking in CI, and given we don't have any type checking around it, I wonder if the error is of any value?

Just figured I'd drop a PR to validate if there's a reason.