### PR TITLE
Add additional type exports

### DIFF
--- a/.changeset/empty-bags-remember.md
+++ b/.changeset/empty-bags-remember.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+added additional type exports to support other ts moduleResolution methods

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,10 +4,17 @@ import type { CompiledJSX } from './jsx/jsx-local-namespace';
 
 export { ClassNames } from './class-names';
 export { createStrictAPI } from './create-strict-api';
+export type {
+  PseudosDeclarations,
+  MediaQueries,
+  AllowedStyles,
+  ApplySchema,
+  ApplySchemaMap,
+} from './create-strict-api/types';
 export { default as css } from './css';
 export { default as cssMap } from './css-map';
 export { keyframes } from './keyframes';
-export { styled } from './styled';
+export { styled, StyledProps } from './styled';
 export type {
   CSSProperties,
   CSSProps,
@@ -16,7 +23,14 @@ export type {
   CssType,
   StrictCSSProperties,
 } from './types';
-export { type XCSSAllProperties, type XCSSAllPseudos, type XCSSProp, cx } from './xcss-prop';
+export {
+  type XCSSAllProperties,
+  type XCSSAllPseudos,
+  type XCSSProp,
+  type CompiledStyles,
+  type Internal$XCSSProp,
+  cx,
+} from './xcss-prop';
 
 // Pass through the (classic) jsx runtime.
 // Compiled currently doesn't define its own and uses this purely to enable a local jsx namespace.


### PR DESCRIPTION
Currently when using moduleResolutions such as `node16`, `nodenext` or `bundler` with `declaration: true` there are quite a few typescript errors present, as shown below

<img width="1060" alt="image" src="https://github.com/atlassian-labs/compiled/assets/33076858/7c2b3c63-8860-4e9d-832a-c6d976d4f205">

I created a minimum reproduction repo to demonstrate this [here](https://github.com/mitch1995/compiled-react-module-resolution-bundler/tree/master). 

**Steps to reproduce:**
1. `npx create-react-app my-app --template typescript`
2. add dependency for `@compiled/react` (0.17.0)
3. Update `tsconfig.json` to have `moduleResolution: Bundler` and `delcaration: true`
4. Create a file using imports from `@compiled/react` like `styled` and `createStrictAPI` and you will experience type errors