### PR TITLE
Replace increase specificity selector as JSDOM breaks with `#\\9`.

### DIFF
--- a/.changeset/sour-parents-look.md
+++ b/.changeset/sour-parents-look.md
@@ -1,0 +1,7 @@
+---
+'@compiled/utils': minor
+'@compiled/jest': minor
+'@compiled/css': minor
+---
+
+Update the increaseSpecificity selector to play nicely with jsdom.

--- a/.changeset/sour-parents-look.md
+++ b/.changeset/sour-parents-look.md
@@ -1,6 +1,6 @@
 ---
 '@compiled/utils': minor
-'@compiled/jest': minor
+'@compiled/jest': patch
 '@compiled/css': minor
 ---
 

--- a/.changeset/tender-panthers-flow.md
+++ b/.changeset/tender-panthers-flow.md
@@ -1,0 +1,5 @@
+---
+'@compiled/jest': patch
+---
+
+Fix toHaveCompiledCss increasedSpecificity comparison with a target

--- a/packages/css/src/__tests__/transform.test.ts
+++ b/packages/css/src/__tests__/transform.test.ts
@@ -469,15 +469,15 @@ describe('#css-transform', () => {
       const { sheets: actual } = transformCss(styles, { increaseSpecificity: true });
 
       expect(actual.join('\n')).toMatchInlineSnapshot(`
-        "._ca0qftgi:not(#\\9){padding-top:8px}
-        ._u5f3ftgi:not(#\\9){padding-right:8px}
-        ._n3tdftgi:not(#\\9){padding-bottom:8px}
-        ._19bvftgi:not(#\\9){padding-left:8px}
-        ._syaz5scu:not(#\\9){color:red}
-        ._1kt9o5oc:not(#\\9):before{content:var(--hello-world)}
-        ._eid3ftgi:not(#\\9):before{margin-right:8px}
-        ._is0632ev:not(#\\9):before{color:pink}
-        ._14rn5scu:not(#\\9):after{color:red}"
+        "._ca0qftgi:not(#\\#){padding-top:8px}
+        ._u5f3ftgi:not(#\\#){padding-right:8px}
+        ._n3tdftgi:not(#\\#){padding-bottom:8px}
+        ._19bvftgi:not(#\\#){padding-left:8px}
+        ._syaz5scu:not(#\\#){color:red}
+        ._1kt9o5oc:not(#\\#):before{content:var(--hello-world)}
+        ._eid3ftgi:not(#\\#):before{margin-right:8px}
+        ._is0632ev:not(#\\#):before{color:pink}
+        ._14rn5scu:not(#\\#):after{color:red}"
       `);
     });
 
@@ -490,9 +490,9 @@ describe('#css-transform', () => {
       const { sheets: actual } = transformCss(styles, { increaseSpecificity: true });
 
       expect(actual.join('\n')).toMatchInlineSnapshot(`
-        "div ._kqan5scu:not(#\\9){color:red}
-        div:hover ._12hc5scu:not(#\\9){color:red}
-        div ._wntz5scu:not(#\\9):hover{color:red}"
+        "div ._kqan5scu:not(#\\#){color:red}
+        div:hover ._12hc5scu:not(#\\#){color:red}
+        div ._wntz5scu:not(#\\#):hover{color:red}"
       `);
     });
   });

--- a/packages/css/src/plugins/__tests__/increase-specificity.test.ts
+++ b/packages/css/src/plugins/__tests__/increase-specificity.test.ts
@@ -20,7 +20,7 @@ describe('increase specicifity plugin', () => {
   it('should increase specicifity of declared classes', () => {
     const actual = transform`._foo {}`;
 
-    expect(actual).toMatchInlineSnapshot(`"._foo:not(#\\9) {}"`);
+    expect(actual).toMatchInlineSnapshot(`"._foo:not(#\\#) {}"`);
   });
 
   it('should ignore atrules', () => {
@@ -33,7 +33,7 @@ describe('increase specicifity plugin', () => {
     expect(actual).toMatchInlineSnapshot(`
       "
             @media {
-              ._foo:not(#\\9) {}
+              ._foo:not(#\\#) {}
             }
           "
     `);
@@ -66,11 +66,11 @@ describe('increase specicifity plugin', () => {
 
     expect(actual).toMatchInlineSnapshot(`
       "
-            ._foo:not(#\\9):hover {
+            ._foo:not(#\\#):hover {
               color: red;
             }
 
-            ._baz:not(#\\9)::before {
+            ._baz:not(#\\#)::before {
               content: "bar";
             }
           "

--- a/packages/css/src/plugins/increase-specificity.ts
+++ b/packages/css/src/plugins/increase-specificity.ts
@@ -11,7 +11,7 @@ const parser = selectorParser((root) => {
 });
 
 /**
- * Increase the specificity of classes generated in Compiled by appended ":not(#\\9)".
+ * Increase the specificity of classes generated in Compiled by appended ":not(#\\#)".
  * This rule should run after CSS declarations have been atomicized and should not affect
  * the original generated class name.
  *

--- a/packages/jest/src/matchers.ts
+++ b/packages/jest/src/matchers.ts
@@ -9,7 +9,7 @@ type Arg = [{ [key: string]: string }, MatchFilter?];
  * Configuring the babel plugin with `increaseSpecificity: true` will result in this being appended to the end of generated classes.
  * TODO: Use the import from `@compiled/utils`, but doing so results in a circular TS reference, so it's copy and pasted..
  */
-const INCREASE_SPECIFICITY_SELECTOR = ':not(#\\9)';
+const INCREASE_SPECIFICITY_SELECTOR = ':not(#\\#)';
 const DEFAULT_MATCH_FILTER: MatchFilter = { media: undefined, target: undefined };
 
 const kebabCase = (str: string) =>

--- a/packages/jest/src/matchers.ts
+++ b/packages/jest/src/matchers.ts
@@ -63,15 +63,17 @@ const getRules = (ast: CSS.Stylesheet, filter: MatchFilter, className: string) =
   };
 
   const allRules = getAllRules();
+
   const klass = target ? `.${className}${target}` : `.${className}`;
+  const klassIncreased = target
+    ? `.${className}${INCREASE_SPECIFICITY_SELECTOR}${target}`
+    : `.${className}${INCREASE_SPECIFICITY_SELECTOR}`;
+
   return allRules?.filter((r) => {
     if ('selectors' in r) {
       return r.selectors?.find((s) => {
         const sTrimmed = removeSpaces(s);
-        return (
-          sTrimmed === removeSpaces(klass) ||
-          sTrimmed === removeSpaces(klass + INCREASE_SPECIFICITY_SELECTOR)
-        );
+        return sTrimmed === removeSpaces(klass) || sTrimmed === removeSpaces(klassIncreased);
       });
     }
     return;

--- a/packages/utils/src/increase-specificity.ts
+++ b/packages/utils/src/increase-specificity.ts
@@ -1,4 +1,4 @@
 /**
  * Configuring the babel plugin with `increaseSpecificity: true` will result in this being appended to the end of generated classes.
  */
-export const INCREASE_SPECIFICITY_SELECTOR = ':not(#\\9)';
+export const INCREASE_SPECIFICITY_SELECTOR = ':not(#\\#)';


### PR DESCRIPTION
Without this, `jsdom` (via `nswapi`) throws an error: `SyntaxError: \8 and \9 are not allowed in strict mode.`

Refer to https://github.com/dperini/nwsapi/issues/92 for the problem statement and background.

We're instead using what stylex uses for specificity as it appears to work fine with the conflicting `jsdom` config we encountered: https://github.com/facebook/stylex/blob/c9216385d40c53612848040ab4d96ff133304203/packages/stylex/src/StyleXSheet.js#L352C16-L352C28
```diff
-._u5f3ftgi:not(#\\9){padding-right:8px}
+._u5f3ftgi:not(#\\#){padding-right:8px}
```

---

Additionally, I realize the direction of adding the increasedSpecificity selector when using a `target` option was incorrect.