### PR TITLE
Fix CSS variables casing

### DIFF
--- a/.changeset/empty-maps-retire.md
+++ b/.changeset/empty-maps-retire.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Fixes the parsing of custom properties (CSS variables) names in object syntax. The casing is now preserved instead of being converted to kebab-case.

--- a/.changeset/six-rivers-carry.md
+++ b/.changeset/six-rivers-carry.md
@@ -1,0 +1,14 @@
+---
+'@compiled/babel-plugin-strip-runtime': patch
+'@compiled/parcel-transformer': patch
+'@compiled/parcel-optimizer': patch
+'@compiled/webpack-loader': patch
+'@compiled/eslint-plugin': patch
+'@compiled/babel-plugin': patch
+'@compiled/codemods': patch
+'@compiled/utils': patch
+'@compiled/jest': patch
+'@compiled/css': patch
+---
+
+Fixes the parsing of custom properties (CSS variables) names in object syntax. The casing is now preserved instead of being converted to kebab-case.

--- a/packages/babel-plugin/src/__tests__/css-builder.test.ts
+++ b/packages/babel-plugin/src/__tests__/css-builder.test.ts
@@ -1,6 +1,24 @@
 import { transform } from '../test-utils';
 
 describe('css builder', () => {
+  it('should convert CSS properties to kebab-case', () => {
+    const actual = transform(`
+      import '@compiled/react';
+      <div css={{ backgroundColor: 'red' }} />
+    `);
+
+    expect(actual).toInclude('background-color:red');
+  });
+
+  it('should preserve custom property value casing', () => {
+    const actual = transform(`
+      import '@compiled/react';
+      <div css={{ '--panelColor': 'red', '--PANEL_WIDTH': 280 }} />
+    `);
+
+    expect(actual).toIncludeMultiple(['--panelColor:red', '--PANEL_WIDTH:280px']);
+  });
+
   it('should keep nested unconditional css together', () => {
     const actual = transform(`
       import '@compiled/react';

--- a/packages/babel-plugin/src/__tests__/css-builder.test.ts
+++ b/packages/babel-plugin/src/__tests__/css-builder.test.ts
@@ -1,7 +1,7 @@
 import { transform } from '../test-utils';
 
 describe('css builder', () => {
-  it('should convert CSS properties to kebab-case', () => {
+  it('should convert css properties to kebab-case with css prop', () => {
     const actual = transform(`
       import '@compiled/react';
       <div css={{ backgroundColor: 'red' }} />
@@ -10,13 +10,96 @@ describe('css builder', () => {
     expect(actual).toInclude('background-color:red');
   });
 
-  it('should preserve custom property value casing', () => {
+  it('should convert css properties to kebab-case with styled function', () => {
     const actual = transform(`
-      import '@compiled/react';
-      <div css={{ '--panelColor': 'red', '--PANEL_WIDTH': 280 }} />
+      import { styled } from '@compiled/react';
+      const MyDiv = styled.div({
+        backgroundColor: 'red'
+      });
+      <MyDiv />
     `);
 
-    expect(actual).toIncludeMultiple(['--panelColor:red', '--PANEL_WIDTH:280px']);
+    expect(actual).toInclude('background-color:red');
+  });
+
+  it('should convert css properties to kebab-case with css func and css map', () => {
+    const actual = transform(`
+    import { css, cssMap } from '@compiled/react';
+      const styles = cssMap({
+        danger: {
+          backgroundColor: 'red'
+        },
+        success: {
+          backgroundColor: 'green'
+        }
+      });
+      <div>
+        <div css={styles.danger} />
+        <div css={styles.success} />
+      </div>
+    `);
+
+    expect(actual).toIncludeMultiple(['background-color:red', 'background-color:green']);
+  });
+
+  it('should preserve custom property name casing with css prop', () => {
+    const actual = transform(`
+      import '@compiled/react';
+      <div css={{
+        '--panelColor': 'red',
+        '--panel-height': '600px',
+        '--PANEL_WIDTH': 280,
+       }} />
+    `);
+
+    expect(actual).toIncludeMultiple([
+      '--panelColor:red',
+      '--panel-height:600px',
+      '--PANEL_WIDTH:280px',
+    ]);
+  });
+
+  it('should preserve custom property name casing with styled function', () => {
+    const actual = transform(`
+      import { styled } from '@compiled/react';
+      const MyDiv = styled.div({
+        '--panelColor': 'red',
+        '--panel-height': '600px',
+        '--PANEL_WIDTH': 280,
+      });
+      <MyDiv />
+    `);
+
+    expect(actual).toIncludeMultiple([
+      '--panelColor:red',
+      '--panel-height:600px',
+      '--PANEL_WIDTH:280px',
+    ]);
+  });
+
+  it('should preserve custom property name casing with css func and css map', () => {
+    const actual = transform(`
+    import { css, cssMap } from '@compiled/react';
+      const styles = cssMap({
+        background: {
+          '--panelColor': 'red',
+        },
+        dimensions: {
+          '--panel-height': '600px',
+          '--PANEL_WIDTH': 280,
+        }
+      });
+      <div>
+        <div css={styles.danger} />
+        <div css={styles.success} />
+      </div>
+    `);
+
+    expect(actual).toIncludeMultiple([
+      '--panelColor:red',
+      '--panel-height:600px',
+      '--PANEL_WIDTH:280px',
+    ]);
   });
 
   it('should keep nested unconditional css together', () => {

--- a/packages/babel-plugin/src/utils/css-builders.ts
+++ b/packages/babel-plugin/src/utils/css-builders.ts
@@ -480,6 +480,8 @@ const extractKeyframes = (
   };
 };
 
+const isCustomPropertyName = (value: string): boolean => value.startsWith('--');
+
 /**
  * Extracts CSS data from an object expression node.
  *
@@ -505,7 +507,7 @@ const extractObjectExpression = (node: t.ObjectExpression, meta: Metadata): CSSO
         // We've found a string literal like: `color: 'blue'`
         css.push({
           type: 'unconditional',
-          css: `${kebabCase(key)}: ${
+          css: `${isCustomPropertyName(key) ? key : kebabCase(key)}: ${
             key === 'content' ? normalizeContentValue(propValue.value) : propValue.value
           };`,
         });
@@ -517,7 +519,10 @@ const extractObjectExpression = (node: t.ObjectExpression, meta: Metadata): CSSO
         // We've found a numeric literal like: `fontSize: 12`
         css.push({
           type: 'unconditional',
-          css: `${kebabCase(key)}: ${addUnitIfNeeded(key, propValue.value)};`,
+          css: `${isCustomPropertyName(key) ? key : kebabCase(key)}: ${addUnitIfNeeded(
+            key,
+            propValue.value
+          )};`,
         });
 
         return;


### PR DESCRIPTION
Fixes the parsing of custom properties (CSS variables) names in object syntax. The casing is now preserved instead of being converted to kebab case.