### PR TITLE
Add custom property values to loose XCSSProp

### DIFF
--- a/.changeset/chilly-pans-develop.md
+++ b/.changeset/chilly-pans-develop.md
@@ -1,0 +1,41 @@
+---
+'@compiled/react': minor
+---
+
+`XCSSProp` now accepts an object as the first generic TAllowedProperties, in addition to the existing string union type.
+This allows you to restrict both the properties and values that can be used in `xcss`:
+
+Note: when TAllowedProperties is set to an object, the required properties for XCSSProp are determined automatically (requiredProperties is set to `never`).
+
+```tsx
+import { type XCSSProp } from '@compiled/react';
+
+interface MyComponentProps {
+  // Color is accepted, and only takes the specified value. All other properties are considered violations.
+  xcss?: XCSSProp<{ color?: 'var(--ds-text-danger)' }, never>;
+
+  // Color is required, while `backgroundColor` is optional.
+  xcss?: XCSSProp<
+    {
+      color: 'var(--ds-text-danger)';
+      backgroundColor?: 'var(--ds-background-neutral)' | 'var(--ds-background-brand)';
+    },
+    never
+  >;
+
+  // Pseudos can be restricted.
+  xcss?: XCSSProp<
+    {
+      backgroundColor?: 'var(--ds-background-neutral)';
+      '&:hover': {
+        backgroundColor?: 'var(--ds-background-neutral-hovered)';
+      };
+    },
+    '&:hover'
+  >;
+}
+
+function MyComponent({ xcss }: MyComponentProps) {
+  return <div css={{ color: 'var(--ds-text-danger)' }} className={xcss} />;
+}
+```

--- a/.changeset/chilly-pans-develop.md
+++ b/.changeset/chilly-pans-develop.md
@@ -5,7 +5,7 @@
 `XCSSProp` now accepts an object as the first generic TAllowedProperties, in addition to the existing string union type.
 This allows you to restrict both the properties and values that can be used in `xcss`:
 
-Note: when TAllowedProperties is set to an object, the required properties for XCSSProp are determined automatically (requiredProperties is set to `never`).
+Note: when TAllowedProperties is set to an object, the required properties and pseudos for XCSSProp are determined automatically (requiredProperties is set to `never`).
 
 ```tsx
 import { type XCSSProp } from '@compiled/react';
@@ -23,7 +23,7 @@ interface MyComponentProps {
     never
   >;
 
-  // Pseudos can be restricted.
+  // Pseudos can have their own properties and values set.
   xcss?: XCSSProp<
     {
       backgroundColor?: 'var(--ds-background-neutral)';
@@ -31,7 +31,7 @@ interface MyComponentProps {
         backgroundColor?: 'var(--ds-background-neutral-hovered)';
       };
     },
-    '&:hover'
+    never
   >;
 }
 

--- a/packages/react/src/create-strict-api/index.ts
+++ b/packages/react/src/create-strict-api/index.ts
@@ -85,9 +85,8 @@ export interface CompiledAPI<
    * - safe style overrides
    * - inverting style declarations
    *
-   * Interverting style declarations is interesting for platform teams as
-   * it means products only pay for styles they use as they're now the ones who declare
-   * the styles!
+   * Inverting style declarations is interesting for platform teams as it means products
+   * only pay for styles they use as they're now the ones who declare the styles!
    *
    * The {@link XCSSProp} type has generics two of which must be defined — use to explicitly
    * set want you to maintain as API. Use {@link XCSSAllProperties} and {@link XCSSAllPseudos}
@@ -100,7 +99,7 @@ export interface CompiledAPI<
    *   // Color is accepted, all other properties / pseudos are considered violations.
    *   xcss?: ReturnType<typeof XCSSProp<'color', never>>;
    *
-   *   // Only backgrond color and hover pseudo is accepted.
+   *   // Only background color and hover pseudo is accepted.
    *   xcss?: ReturnType<typeof XCSSProp<'backgroundColor', '&:hover'>>;
    *
    *   // All properties are accepted, all pseudos are considered violations.
@@ -135,7 +134,7 @@ export interface CompiledAPI<
    * <Component xcss={styles.text} />
    * ```
    *
-   * To concatenate and conditonally apply styles use the {@link cssMap} and {@link cx} functions.
+   * To concatenate and conditionally apply styles use the {@link cssMap} and {@link cx} functions.
    */
   XCSSProp<
     TAllowedProperties extends keyof StrictCSSProperties,
@@ -157,7 +156,7 @@ export interface CompiledAPI<
  * ## Create Strict API
  *
  * Returns a strict subset of Compiled APIs augmented by a type definition.
- * This API does not change Compileds build time behavior — merely augmenting
+ * This API does not change Compiled's build time behavior — merely augmenting
  * the returned API types which enforce:
  *
  * - all APIs use object types

--- a/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
@@ -267,13 +267,12 @@ describe('xcss prop', () => {
     }: {
       xcss: XCSSProp<
         {
-          color: 'color.red' | 'color.blue';
+          color: 'color.text.red' | 'color.text.blue';
         },
-        never,
-        { requiredProperties: 'color' }
+        never
       >;
       // As with standard XCSS, invalid XCSS attributes don't error
-      xcssWrong?: XCSSProp<{ color: 'color.red'; invalidCSSAttr: 'color.red' }, never>;
+      xcssWrong?: XCSSProp<{ color: 'color.text.red'; invalidCSSAttr: 'invalid' }, never>;
     }) {
       return <div className={xcss}>foo</div>;
     }
@@ -282,7 +281,7 @@ describe('xcss prop', () => {
       <>
         <CSSPropComponent
           xcss={{
-            color: 'color.red',
+            color: 'color.text.red',
           }}
         />
         <CSSPropComponent
@@ -293,10 +292,6 @@ describe('xcss prop', () => {
             backgroundColor: 'color.background',
           }}
         />
-        <CSSPropComponent
-          // @ts-expect-error - Property 'color' is missing in type '{}'.
-          xcss={{}}
-        />
       </>
     ).toBeObject();
   });
@@ -305,16 +300,27 @@ describe('xcss prop', () => {
     function CSSPropComponent({
       xcss,
     }: {
-      xcss: XCSSProp<{ color: 'color.red' | 'color.blue' }, never, { requiredProperties: 'color' }>;
+      xcss: XCSSProp<
+        { color: 'color.text.red' | 'color.text.blue'; borderColor?: 'color.border' },
+        never
+      >;
     }) {
       return <div className={xcss}>foo</div>;
     }
 
     expectTypeOf(
-      <CSSPropComponent
-        // @ts-expect-error — Property 'color' is missing in type '{}' but required in type {color: 'color.red' | 'color.blue'}.
-        xcss={{}}
-      />
+      <>
+        <CSSPropComponent
+          // @ts-expect-error — Property 'color' is missing in type '{}' but required in type {color: 'color.red' | 'color.blue'}.
+          xcss={{}}
+        />
+        <CSSPropComponent
+          xcss={{
+            color: 'color.text.red',
+            // Border color is optional
+          }}
+        />
+      </>
     ).toBeObject();
   });
 });

--- a/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
@@ -328,18 +328,21 @@ describe('xcss prop', () => {
     function CSSPropComponent({
       xcss,
     }: {
-      xcss: XCSSProp<
-        {
-          color: 'color.text.red' | 'color.text.blue';
-          borderColor?: 'color.border';
-          '&:hover': {
-            color: 'color.text.green';
-          };
-          // All pseudos are optional; optional pseudos don't work as expected currently
-          '&:active'?: object;
-        },
-        never
-      >;
+      xcss: XCSSProp<{
+        color: 'color.text.red' | 'color.text.blue';
+        borderColor?: 'color.border';
+        '&:hover': {
+          // overrides valid color values above
+          color: 'color.text.green';
+          // borderColor can still be set, restricted to values above
+        };
+        '&:focus': {
+          // setting color to `never` should prevent it from being set
+          color: never;
+        };
+        // Pseudos are already optional; optional pseudos don't work as expected
+        '&:active'?: object;
+      }>;
       xcssInvalid?: XCSSProp<
         {
           color: 'color.text.red' | 'color.text.blue';
@@ -389,6 +392,13 @@ describe('xcss prop', () => {
           color: 'invalid color',
         },
       },
+      validPseudoInvalidProperty: {
+        color: 'color.text.red',
+
+        '&:focus': {
+          color: 'color.text.red',
+        },
+      },
       invalidPseudo: {
         color: 'color.text.red',
         '&::after': {
@@ -415,7 +425,10 @@ describe('xcss prop', () => {
           // @ts-expect-error - Type '"invalid color"' is not assignable to type '"color.text.green" | undefined'.
           xcss={invalidStyles.validPseudoCompletelyInvalidValue}
         />
-
+        <CSSPropComponent
+          // @ts-expect-error - Type '"color.text.red"' is not assignable to type 'undefined'
+          xcss={invalidStyles.validPseudoInvalidProperty}
+        />
         <CSSPropComponent
           // @ts-expect-error - Type '{ color: "invalid color"; }' is not assignable to type 'undefined'
           xcss={invalidStyles.invalidPseudo}

--- a/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
@@ -260,4 +260,51 @@ describe('xcss prop', () => {
       />
     ).toBeObject();
   });
+
+  it('should accept an object with specific allowed values in TAllowedProperties', () => {
+    function CSSPropComponent({
+      xcss,
+    }: {
+      xcss: XCSSProp<{ color: 'color.red' | 'color.blue' }, never>;
+    }) {
+      return <div className={xcss}>foo</div>;
+    }
+
+    expectTypeOf(
+      <>
+        <CSSPropComponent
+          xcss={{
+            color: 'color.red',
+          }}
+        />
+        <CSSPropComponent
+          xcss={{
+            // @ts-expect-error - Type '"red"' is not assignable to type '"color.red" | "color.blue"'.
+            color: 'red',
+          }}
+        />
+        <CSSPropComponent
+          // This should ideally error because `color` isn't set, and it's a required property in the type.
+          xcss={{}}
+        />
+      </>
+    ).toBeObject();
+  });
+
+  it('should enforce required properties when TAllowedProperties set to an object', () => {
+    function CSSPropComponent({
+      xcss,
+    }: {
+      xcss: XCSSProp<{ color: 'color.red' | 'color.blue' }, never, { requiredProperties: 'color' }>;
+    }) {
+      return <div className={xcss}>foo</div>;
+    }
+
+    expectTypeOf(
+      <CSSPropComponent
+        // @ts-expect-error — Property 'color' is missing in type '{}' but required in type {color: 'color.red' | 'color.blue'}.
+        xcss={{}}
+      />
+    ).toBeObject();
+  });
 });

--- a/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
@@ -265,7 +265,15 @@ describe('xcss prop', () => {
     function CSSPropComponent({
       xcss,
     }: {
-      xcss: XCSSProp<{ color: 'color.red' | 'color.blue' }, never>;
+      xcss: XCSSProp<
+        {
+          color: 'color.red' | 'color.blue';
+        },
+        never,
+        { requiredProperties: 'color' }
+      >;
+      // As with standard XCSS, invalid XCSS attributes don't error
+      xcssWrong?: XCSSProp<{ color: 'color.red'; invalidCSSAttr: 'color.red' }, never>;
     }) {
       return <div className={xcss}>foo</div>;
     }
@@ -281,10 +289,12 @@ describe('xcss prop', () => {
           xcss={{
             // @ts-expect-error - Type '"red"' is not assignable to type '"color.red" | "color.blue"'.
             color: 'red',
+            // @ts-expect-error - Type 'string' is not assignable to type 'undefined'.
+            backgroundColor: 'color.background',
           }}
         />
         <CSSPropComponent
-          // This should ideally error because `color` isn't set, and it's a required property in the type.
+          // @ts-expect-error - Property 'color' is missing in type '{}'.
           xcss={{}}
         />
       </>

--- a/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
@@ -335,10 +335,17 @@ describe('xcss prop', () => {
           '&:hover': {
             color: 'color.text.green';
           };
-          // more specific types for optionals not supported yet
+          // All pseudos are optional; optional pseudos don't work as expected currently
           '&:active'?: object;
         },
         never
+      >;
+      xcssInvalid?: XCSSProp<
+        {
+          color: 'color.text.red' | 'color.text.blue';
+        },
+        // @ts-expect-error - Type 'string' is not assignable to type 'never'.
+        '&:hover' | '&:active'
       >;
     }) {
       return <div className={xcss}>foo</div>;
@@ -359,7 +366,11 @@ describe('xcss prop', () => {
         },
         '&:active': {
           color: 'color.text.red',
-        } as const,
+        },
+      },
+      // We don't currently support enforcing required pseudos
+      missingRequiredPseudo: {
+        color: 'color.text.red',
       },
     });
 
@@ -384,12 +395,17 @@ describe('xcss prop', () => {
           color: 'invalid color',
         },
       },
+      missingRequiredPropInPseudo: {
+        color: 'color.text.red',
+        '&:hover': {},
+      },
     });
 
     expectTypeOf(
       <>
         <CSSPropComponent xcss={validStyles.validPseudoMissingOptional} />
         <CSSPropComponent xcss={validStyles.validPseudoProvidedOptional} />
+        <CSSPropComponent xcss={validStyles.missingRequiredPseudo} />
 
         <CSSPropComponent
           // @ts-expect-error — Type '"color.text.red"' is not assignable to type '"color.text.green"'
@@ -403,6 +419,10 @@ describe('xcss prop', () => {
         <CSSPropComponent
           // @ts-expect-error - Type '{ color: "invalid color"; }' is not assignable to type 'undefined'
           xcss={invalidStyles.invalidPseudo}
+        />
+        <CSSPropComponent
+          // @ts-expect-error - Property 'color' is missing in type 'CompiledStyles<{}>' but required in type '{ readonly color: "color.text.green"; }
+          xcss={invalidStyles.missingRequiredPropInPseudo}
         />
       </>
     ).toBeObject();

--- a/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
@@ -328,21 +328,24 @@ describe('xcss prop', () => {
     function CSSPropComponent({
       xcss,
     }: {
-      xcss: XCSSProp<{
-        color: 'color.text.red' | 'color.text.blue';
-        borderColor?: 'color.border';
-        '&:hover': {
-          // overrides valid color values above
-          color: 'color.text.green';
-          // borderColor can still be set, restricted to values above
-        };
-        '&:focus': {
-          // setting color to `never` should prevent it from being set
-          color: never;
-        };
-        // Pseudos are already optional; optional pseudos don't work as expected
-        '&:active'?: object;
-      }>;
+      xcss: XCSSProp<
+        {
+          color: 'color.text.red' | 'color.text.blue';
+          borderColor?: 'color.border';
+          '&:hover': {
+            // overrides valid color values above
+            color: 'color.text.green';
+            // borderColor can still be set, restricted to values above
+          };
+          '&:focus': {
+            // setting color to `never` should prevent it from being set
+            color: never;
+          };
+          // Pseudos are already optional; optional pseudos don't work as expected
+          '&:active'?: object;
+        },
+        never
+      >;
       xcssInvalid?: XCSSProp<
         {
           color: 'color.text.red' | 'color.text.blue';

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -154,7 +154,8 @@ export type XCSSAllPseudos = CSSPseudos;
  *       // setting color to `never` prevents it from being set
  *       color: never;
  *     };
- *   }>
+ *   },
+ *   never>
  * }
  * ```
  *

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -149,13 +149,15 @@ export type XCSSAllPseudos = CSSPseudos;
  */
 export type XCSSProp<
   TAllowedProperties extends keyof StrictCSSProperties | StrictCSSProperties, // extend StrictCSSProperties with CSS vars.
-  TAllowedPseudos extends CSSPseudos,
+  TAllowedPseudos extends TAllowedProperties extends object ? never : CSSPseudos,
   TRequiredProperties extends {
     requiredProperties: TAllowedProperties extends object ? never : TAllowedProperties;
   } = never
 > = Internal$XCSSProp<
   TAllowedProperties extends object ? keyof TAllowedProperties : TAllowedProperties,
-  TAllowedPseudos,
+  TAllowedProperties extends object
+    ? Extract<keyof TAllowedProperties, CSSPseudos>
+    : TAllowedPseudos,
   string,
   TAllowedProperties extends object ? TAllowedProperties : object,
   TAllowedProperties extends object

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -99,7 +99,7 @@ export type XCSSAllPseudos = CSSPseudos;
  * - safe style overrides
  * - inverting style declarations
  *
- * Interverting style declarations is interesting for platform teams as
+ * Inverting style declarations is interesting for platform teams as
  * it means products only pay for styles they use as they're now the ones who declare
  * the styles!
  *
@@ -115,7 +115,7 @@ export type XCSSAllPseudos = CSSPseudos;
  *   // Color is accepted, all other properties / pseudos are considered violations.
  *   xcss?: XCSSProp<'color', never>;
  *
- *   // Only backgrond color and hover pseudo is accepted.
+ *   // Only background color and hover pseudo is accepted.
  *   xcss?: XCSSProp<'backgroundColor', '&:hover'>;
  *
  *   // All properties are accepted, all pseudos are considered violations.
@@ -145,19 +145,21 @@ export type XCSSAllPseudos = CSSPseudos;
  * <Component xcss={styles.text} />
  * ```
  *
- * To concatenate and conditonally apply styles use the {@link cssMap} {@link cx} functions.
+ * To concatenate and conditionally apply styles use the {@link cssMap} {@link cx} functions.
  */
 export type XCSSProp<
-  TAllowedProperties extends keyof StrictCSSProperties,
+  TAllowedProperties extends keyof StrictCSSProperties | StrictCSSProperties, // extend StrictCSSProperties with CSS vars.
   TAllowedPseudos extends CSSPseudos,
   TRequiredProperties extends {
-    requiredProperties: TAllowedProperties;
+    requiredProperties: TAllowedProperties extends string
+      ? TAllowedProperties
+      : keyof TAllowedProperties; // can we set to (keyof TAllowedProperties) and filter out the required properties?
   } = never
 > = Internal$XCSSProp<
-  TAllowedProperties,
+  TAllowedProperties extends string ? TAllowedProperties : keyof TAllowedProperties,
   TAllowedPseudos,
   string,
-  object,
+  TAllowedProperties extends string ? object : TAllowedProperties,
   TRequiredProperties,
   'loose'
 >;

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -153,7 +153,7 @@ export type XCSSProp<
   TRequiredProperties extends {
     requiredProperties: TAllowedProperties extends string
       ? TAllowedProperties
-      : keyof TAllowedProperties; // can we set to (keyof TAllowedProperties) and filter out the required properties?
+      : keyof TAllowedProperties;
   } = never
 > = Internal$XCSSProp<
   TAllowedProperties extends string ? TAllowedProperties : keyof TAllowedProperties,

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -154,7 +154,7 @@ export type XCSSProp<
     requiredProperties: TAllowedProperties extends object ? never : TAllowedProperties;
   } = never
 > = Internal$XCSSProp<
-  TAllowedProperties extends object ? keyof TAllowedProperties : TAllowedProperties,
+  TAllowedProperties extends object ? FilterPseudos<keyof TAllowedProperties> : TAllowedProperties,
   TAllowedProperties extends object
     ? Extract<keyof TAllowedProperties, CSSPseudos>
     : TAllowedPseudos,
@@ -167,6 +167,8 @@ export type XCSSProp<
     : TRequiredProperties,
   'loose'
 >;
+
+type FilterPseudos<T> = T extends CSSPseudos ? never : T;
 
 export type RequiredKeys<T extends object> = keyof {
   [K in keyof T as T extends Record<K, T[K]> ? K : never]: K;

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -103,9 +103,11 @@ export type XCSSAllPseudos = CSSPseudos;
  * it means products only pay for styles they use as they're now the ones who declare
  * the styles!
  *
- * The {@link XCSSProp} type has generics two of which must be defined — use to explicitly
- * set want you to maintain as API. Use {@link XCSSAllProperties} and {@link XCSSAllPseudos}
- * to enable all properties and pseudos.
+ * The {@link XCSSProp} type has generics, which must be defined together:
+ *
+ * The first generic defines available properties, and the second defines available pseudos;
+ * use to explicitly set want you to maintain as API.
+ * Use {@link XCSSAllProperties} and {@link XCSSAllPseudos} to enable all properties and pseudos.
  *
  * The third generic is used to declare what properties and pseudos should be required.
  *
@@ -130,6 +132,29 @@ export type XCSSAllPseudos = CSSPseudos;
  *
  * function MyComponent({ xcss }: MyComponentProps) {
  *   return <div css={{ color: 'var(--ds-text-danger)' }} className={xcss} />
+ * }
+ * ```
+ * Alternatively, you can pass an object as the sole generic, to control both the
+ * available properties/pseudos and the values each property can take.
+ * Doing this allows you to define strict types for your styles.
+ *
+ * ```tsx
+ * interface MyComponentProps {
+ *   xcss: XCSSProp<{
+ *     // Properties can be optional or required, and can have strict types
+ *     color: 'color.text.red' | 'color.text.blue';
+ *     borderColor?: 'color.border';
+ *
+ *     // Pseudos are always optional, but you can define what pseudos are valid
+ *     '&:hover': {
+ *       // Setting a value in a pseudo lets you further refine the valid values
+ *       color: 'color.text.green';
+ *     };
+ *     '&:focus': {
+ *       // setting color to `never` prevents it from being set
+ *       color: never;
+ *     };
+ *   }>
  * }
  * ```
  *

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -151,18 +151,24 @@ export type XCSSProp<
   TAllowedProperties extends keyof StrictCSSProperties | StrictCSSProperties, // extend StrictCSSProperties with CSS vars.
   TAllowedPseudos extends CSSPseudos,
   TRequiredProperties extends {
-    requiredProperties: TAllowedProperties extends string
-      ? TAllowedProperties
-      : keyof TAllowedProperties;
+    requiredProperties: TAllowedProperties extends object ? never : TAllowedProperties;
   } = never
 > = Internal$XCSSProp<
-  TAllowedProperties extends string ? TAllowedProperties : keyof TAllowedProperties,
+  TAllowedProperties extends object ? keyof TAllowedProperties : TAllowedProperties,
   TAllowedPseudos,
   string,
-  TAllowedProperties extends string ? object : TAllowedProperties,
-  TRequiredProperties,
+  TAllowedProperties extends object ? TAllowedProperties : object,
+  TAllowedProperties extends object
+    ? {
+        requiredProperties: Extract<RequiredKeys<TAllowedProperties>, keyof StrictCSSProperties>;
+      }
+    : TRequiredProperties,
   'loose'
 >;
+
+export type RequiredKeys<T extends object> = keyof {
+  [K in keyof T as T extends Record<K, T[K]> ? K : never]: K;
+};
 
 export type Internal$XCSSProp<
   TAllowedProperties extends keyof StrictCSSProperties,


### PR DESCRIPTION
Currently, the loose `XCSSProp` allows makers to type an `xcss` prop that only accepts certain CSS properties (for example, limiting a text component to only accept `color`. And `create-strict-api` allows libraries to create a restricted `XCSSProp` with limited values.

However, there's no lightweight approach for a component to customize `XCSSProp` to accept both a restricted set of properties, and restricted values. After pairing on the issue with @itsdouges , he suggested the following change!

This PR augments `XCSSProp` to accept an object as the first generic `TAllowedProperties`, in addition to the existing string union type. When TAllowedProperties is set to an object, the required properties for XCSSProp are set automatically, and so `requiredProperties` is set to `never`.