### PR TITLE
Fix 'as const' expressions causing build error

### DIFF
--- a/.changeset/ninety-houses-bake.md
+++ b/.changeset/ninety-houses-bake.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Fix 'as const' expressions causing Compiled to crash at build time

--- a/packages/babel-plugin/src/utils/traverse-expression/traverse-member-expression/traverse-access-path/evaluate-path/index.ts
+++ b/packages/babel-plugin/src/utils/traverse-expression/traverse-member-expression/traverse-access-path/evaluate-path/index.ts
@@ -13,6 +13,8 @@ export const evaluatePath = (
 ): ReturnType<typeof createResultPair> => {
   if (t.isObjectExpression(expression)) {
     return evaluateObjectPath(expression, meta, pathName);
+  } else if (t.isTSAsExpression(expression)) {
+    return evaluatePath(expression.expression, meta, pathName);
   } else if (t.isImportNamespaceSpecifier(expression)) {
     return evaluateNamespaceImportPath(expression, meta.state.file, meta, pathName);
   }


### PR DESCRIPTION
The `as const` in the following code currently causes a build error in `@compiled/babel-plugin`:

```tsx
import { css } from '@compiled/react';

const something = { large: '@media screen' } as const;
const styles = css({ [something.large]: { color: 'blue' } });
```

This is a problem because `media` from `@atlaskit/primitives/responsive` uses `as const` extensively. We would like to unblock people from using `@atlaskit/primitives/responsive` in their Compiled code, when the `@atlaskit/primitives/responsive` TypeScript source code is being consumed directly in a project.