### PR TITLE
Add `ElementType` to the global compiled JSX namespace

### DIFF
--- a/.changeset/plenty-olives-act.md
+++ b/.changeset/plenty-olives-act.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Add `ElementType` to the global compiled JSX namespace

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -39,6 +39,7 @@ export const jsx = createElement;
 export namespace jsx {
   export namespace JSX {
     export type Element = CompiledJSX.Element;
+    export type ElementType = CompiledJSX.ElementType;
     export type ElementClass = CompiledJSX.ElementClass;
     export type ElementAttributesProperty = CompiledJSX.ElementAttributesProperty;
     export type ElementChildrenAttribute = CompiledJSX.ElementChildrenAttribute;


### PR DESCRIPTION
Follow up PR to PR #1617. 

This PR adds `ElementType` the global compiled JSX namespace, as right now it's only available in the automatic jsx namespace.