### PR TITLE
Document @emotion/core types not working with Compiled

### DIFF
--- a/website/packages/docs/src/index.html
+++ b/website/packages/docs/src/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <meta name="viewport" content="width=device-width" />
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />

--- a/website/packages/docs/src/pages/issues-with-emotion.mdx
+++ b/website/packages/docs/src/pages/issues-with-emotion.mdx
@@ -1,0 +1,49 @@
+---
+section: 3-Migration
+name: Known issues with Emotion
+---
+
+# Known issues with Emotion
+
+While Compiled has a very similar API to Emotion, there are some known issues specific to Emotion that you may need to address.
+
+For Compiled limitations not specific to migrating from Emotion, see our [limitations](/limitations) page.
+
+## `@emotion/core` types are not compatible with Compiled
+
+Emotion v10 (`@emotion/core`) extends the global interfaces for the `css` prop, causing the `css` prop to only work with Emotion, and not `styled-components` or Compiled. As a result, you may run into `Type 'CSSProps<unknown>' is not assignable to type 'InterpolationWithTheme<any>'.` errors.
+
+To fix this, we recommend:
+
+- Upgrading to [Emotion v11](https://emotion.sh/docs/emotion-11) (`@emotion/react`) before migrating to Compiled. This involves removing `@emotion/core` (v10 API) and replacing it with `@emotion/react` (v11 API). Emotion v11 uses types that do not conflict with Compiled, as long as Emotion and Compiled components are not defined in the same file.
+- If you cannot remove `@emotion/core` from your repository, you may be able to apply a patch similiar to the one below. You may need to change the patch manually for it to work for your specific version.
+
+```diff
+diff --git a/node_modules/@emotion/core/types/index.d.ts b/node_modules/@emotion/core/types/index.d.ts
+index 123456..abcdef 100644
+--- a/node_modules/@emotion/core/types/index.d.ts
++++ b/node_modules/@emotion/core/types/index.d.ts
+@@ -78,22 +78,3 @@ export interface ClassNamesProps<Theme> {
+ export function ClassNames<Theme = any>(
+   props: ClassNamesProps<Theme>
+ ): ReactElement
+-
+-declare module 'react' {
+-  interface DOMAttributes<T> {
+-    css?: InterpolationWithTheme<any>
+-  }
+-}
+-
+-declare global {
+-  namespace JSX {
+-    /**
+-     * Do we need to modify `LibraryManagedAttributes` too,
+-     * to make `className` props optional when `css` props is specified?
+-     */
+-
+-    interface IntrinsicAttributes {
+-      css?: InterpolationWithTheme<any>
+-    }
+-  }
+-}
+```

--- a/website/packages/docs/src/pages/media-queries-and-other-at-rules.mdx
+++ b/website/packages/docs/src/pages/media-queries-and-other-at-rules.mdx
@@ -1,5 +1,6 @@
 ---
 section: 50-Guides
+name: Media queries and other at-rules
 ---
 
 # Media queries and other at-rules

--- a/website/packages/docs/src/pages/migrating.mdx
+++ b/website/packages/docs/src/pages/migrating.mdx
@@ -1,9 +1,10 @@
 ---
-section: 1-Getting started
-name: Migrating to Compiled
+order: 1
+section: 3-Migration
+name: How to migrate to Compiled?
 ---
 
-# Migrating to Compiled
+# How to migrate to Compiled?
 
 Follow the [installation](/installation) instructions before continuing.
 
@@ -17,7 +18,7 @@ Replace the imports with `@compiled/react`.
 ```
 
 There exists a [codemod](/pkg-codemods#styled-components-to-compiled) to streamline this.
-For features that aren't available due to the compile time nature of the library read [limitations](/limitations).
+For features that aren't available due to the compile-time nature of the library, read our [limitations](/limitations).
 
 ## Emotion
 
@@ -49,4 +50,7 @@ Replace the imports with `@compiled/react`.
 ```
 
 There exists a [codemod](/pkg-codemods#emotion-to-compiled) to streamline this.
-For features that aren't available due to the compile time nature of the library read [limitations](/limitations).
+
+For features that aren't available due to the compile-time nature of the library, read our [limitations](/limitations).
+
+For Emotion-specific issues you may run into, see [Migrating from Emotion](/migrating-from-emotion).


### PR DESCRIPTION
This is part of a week-long project to improve our external documentation.

`@emotion/core` types being incompatible with Compiled is a very common question in our internal help channel, with this being asked about across six separate occasions. In a help channel that typically gets one to two questions a week, that is a lot!

(Atlassians: see the "2024.07 - Inno Week: Improving public-facing Compiled documentation" document for more details)

I've added a new page that specifically addresses how to fix this issue. It's named "Known issues with Emotion" with the hope that (1) if we run into other issues with Emotion, we can extend the document further; and (2) in the future, we can move more internal documentation on to our external website.

Deploy link: https://deploy-preview-1687--compiled-css-in-js.netlify.app/docs/issues-with-emotion