### PR TITLE
Update most of Compiled documentation to reflect current recommendations

### DIFF
--- a/website/packages/docs/src/pages/api-class-names.mdx
+++ b/website/packages/docs/src/pages/api-class-names.mdx
@@ -1,12 +1,15 @@
 ---
-section: 5-API
-order: 3
-name: Class Names
+section: 6-Deprecated API
+order: 11
+name: '[Deprecated] ClassNames'
 ---
 
 import { ClassNamesObj, ClassNamesDynamic, ClassNamesComposition } from '../examples/class-names';
 
-# Class Names
+# \[Deprecated\] ClassNames
+
+> **Deprecated**<br />
+> We do not recommend using `ClassNames` or the `className` prop in any code. Please use [`css`](/api-css-prop) or [`cssMap`](/api-cssmap) instead.
 
 Use a component where styles are not necessarily used on a JSX element.
 

--- a/website/packages/docs/src/pages/api-css-prop.mdx
+++ b/website/packages/docs/src/pages/api-css-prop.mdx
@@ -1,29 +1,25 @@
 ---
 section: 5-API
 order: 1
-name: CSS prop
+name: css prop
 ---
 
-import {
-  CssPropObj,
-  CssPropString,
-  CssPropDynamic,
-  CssPropCompositionCorrect,
-  CssPropCompositionIncorrect,
-  CssPropCompositionNoStyle,
-  CssPropConditionalRules,
-} from '../examples/css-prop';
+import { CssPropConditionalRules, CssPropDynamic, CssPropObj } from '../examples/css-prop';
 
-# CSS prop
+# css prop
 
 Using a `css` function call on a `css` prop is the preferred way to apply styles to a JSX element. This is enabled when a JSX pragma is defined, and the JSX element takes a `className` prop.
 
-We use a syntax similar to Emotion's `css` prop, but we wrap the style object in a `css` function call.
+We use a syntax similar to Emotion's `css` prop, but we wrap the style object in a `css` function call. Using the `css` function call allows us to apply type checking, and it makes it clear that the styles should be applied by Compiled (and not a different CSS-in-JS library).
+
+> **Only use `css` with Compiled APIs**<br />
+> The return value of the `css` function call at runtime is `null` and can only be passed to the `css` prop, or used with other Compiled APIs.
 
 <CssPropObj />
 
-> **Don't worry about the pragma**<br />
-> For a streamlined developer experience, set up Babel and TypeScript to [add the JSX pragma automatically](/installation#ensuring-babel-and-typescript-work-with-compiled). Alternatively, install the `jsx-pragma` rule from the [ESLint plugin](/pkg-eslint-plugin) and never forget it again.
+## Using composition to combine styles
+
+Read [composition](/composition) for more information around composing styles together.
 
 ## Conditional rules
 

--- a/website/packages/docs/src/pages/api-css-prop.mdx
+++ b/website/packages/docs/src/pages/api-css-prop.mdx
@@ -1,7 +1,7 @@
 ---
 section: 5-API
 order: 1
-name: CSS Prop
+name: CSS prop
 ---
 
 import {
@@ -14,62 +14,32 @@ import {
   CssPropConditionalRules,
 } from '../examples/css-prop';
 
-# CSS Prop
+# CSS prop
 
-Style a JSX element,
-enabled when a JSX pragma is defined and the JSX element also takes a `className` prop.
+Using a `css` function call on a `css` prop is the preferred way to apply styles to a JSX element. This is enabled when a JSX pragma is defined, and the JSX element takes a `className` prop.
+
+We use a syntax similar to Emotion's `css` prop, but we wrap the style object in a `css` function call.
 
 <CssPropObj />
 
 > **Don't worry about the pragma**<br />
-> For a streamlined developer experience install the `jsx-pragma` rule from the [ESLint plugin](/pkg-eslint-plugin) and never forget it again.
-
-## Template literal rules
-
-Write your styles as a template literal.
-Use the [`css`](/api-css) import for better syntax highlighting.
-
-<CssPropString />
-
-Although template literal is supported, we recommend using object style instead of template literal.
+> For a streamlined developer experience, set up Babel and TypeScript to [add the JSX pragma automatically](/installation#ensuring-babel-and-typescript-work-with-compiled). Alternatively, install the `jsx-pragma` rule from the [ESLint plugin](/pkg-eslint-plugin) and never forget it again.
 
 ## Conditional rules
 
-Conditionally apply [CSS rules](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps/How_CSS_is_structured#Selectors).
+Conditionally apply [CSS rules](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps/How_CSS_is_structured#Selectors) by passing an array to the `css` prop. The last styles applied in the array wins.
 
 <CssPropConditionalRules />
 
-## Dynamic declarations
+## Dynamic styling and props
 
-Change a [CSS declaration](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps/How_CSS_is_structured#Properties_and_values) at runtime,
-powered by [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
+We no longer recommend passing dynamic styling or props to Compiled, as they can be tricky for other Atlassian tooling to statically analyse.
+
+Instead, we recommend you:
+
+- First, determine whether you truly need the styles to be dynamic. Many cases of dynamic styling can be rewritten as conditional rules or [`cssMap` usages](/api-cssmap).
+- If you absolutely need to use dynamic styling, you can pass dynamic styling to the `style` prop. Check out the [UI Styling Standard](https://atlassian.design/components/eslint-plugin-ui-styling-standard/migration-guide) for more details.
+
+In the past, this was how to write dynamic styles with Compiled:
 
 <CssPropDynamic />
-
-## Composition gotchas
-
-Compiled will try to generate the smallest amount of code possible.
-When composing styles ensure to explicitly define both a `className` and `style` prop.
-
-Here the `className` and `style` props are both defined so styling works correctly.
-
-<CssPropCompositionCorrect />
-
-The next few example show what happens if you don't do this.
-
-### Spread pops
-
-The overflow `props` are spread onto the element so the composed styles are not applied.
-
-Statically defining them fixes this.
-
-<CssPropCompositionIncorrect />
-
-### Missing style
-
-The `style` prop is missing so the CSS variables used to power dynamic declarations aren't set.
-In this case instead it receives the `body` color value instead of pink.
-
-Statically defining the style prop fixes this.
-
-<CssPropCompositionNoStyle />

--- a/website/packages/docs/src/pages/api-css.mdx
+++ b/website/packages/docs/src/pages/api-css.mdx
@@ -1,22 +1,9 @@
 ---
 section: 5-API
-order: 10
-name: CSS
+order: 13
+name: '[Archived] CSS'
 ---
 
 # CSS
 
-Define styles that can be statically typed and useable with other Compiled APIs.
-
-> **Opaque styles**<br/>
-> The return value of `css` at runtime is `null` and can only be used with other Compiled APIs.
-
-```jsx
-const redText = css({
-  color: 'red',
-});
-
-<div css={redText} />;
-```
-
-Read [composition](/composition) for more information around composing styles together.
+The contents of this page have been merged into the [css prop](/api-css-prop) documentation. Check it out!

--- a/website/packages/docs/src/pages/api-css.mdx
+++ b/website/packages/docs/src/pages/api-css.mdx
@@ -1,6 +1,6 @@
 ---
 section: 5-API
-order: 99
+order: 10
 name: CSS
 ---
 

--- a/website/packages/docs/src/pages/api-cssmap.mdx
+++ b/website/packages/docs/src/pages/api-cssmap.mdx
@@ -1,15 +1,15 @@
 ---
 section: 5-API
 order: 10
-name: CSS Map
+name: cssMap
 ---
 
-# CSS Map
+# cssMap
 
 Define a map consisting of named CSS rules that can be statically typed and useable with other Compiled APIs.
 
-> **Can only be used with other Compiled APIs**<br />
-> The `cssMap` function returns an object at runtime, which contains classnames as its values and variant names as its keys. These can only be used in conjunction with other Compiled APIs.
+> **Only use `cssMap` with Compiled APIs**<br />
+> The `cssMap` function returns an object at runtime, which contains class names as its values and variant names as its keys. These can only be used in conjunction with other Compiled APIs.
 
 ```jsx
 import { cssMap } from '@compiled/react';
@@ -97,7 +97,7 @@ const borderStyleMap = cssMap({
 
 ### At-rules (`@media` queries, `@supports`, `@page`, etc.)
 
-With `cssMap`, you can specify media queries by splitting the `@media` part and the rest of the media query into two, just like with the [`vanilla-extract`](https://vanilla-extract.style/documentation/styling/#media-queries) library. `@media` becomes the key, and the value is an object that contains the remainder of your media query. This allows you to more easily find your media queries in one place.
+With `cssMap`, you can also specify media queries and most other at-rules (`@supports`, `@page`, etc.) directly in the variant object. Media queries, and the styles inside them, will also be strongly typed.
 
 See below for an example:
 
@@ -106,28 +106,22 @@ const myMap = cssMap({
   danger: {
     color: 'red',
     // The generated CSS will be
-    // @media (min-width: 500px) { ... }
-    // @media (max-width: 800px) { ... }
-    '@media': {
-      '(min-width: 500px)': {
-        fontSize: '1.5em',
-      },
-      '(max-width: 800px)': {
-        fontSize: '1.8em',
-      },
+    '@media (min-width: 500px)': {
+      fontSize: '1.5em',
+    },
+    '@media (max-width: 800px)': {
+      fontSize: '1.8em',
     },
   },
   success: {
     color: 'green',
-    '@media': {
-      // You can specify different media queries
-      // for another variant if you want.
-      '(min-width: 400px)': {
-        fontSize: '1.3em',
-      },
-      '(min-width: 900px)': {
-        fontSize: '1.5em',
-      },
+    // You can specify different media queries
+    // for another variant if you want.
+    '@media (min-width: 400px)': {
+      fontSize: '1.3em',
+    },
+    '@media (min-width: 900px)': {
+      fontSize: '1.5em',
     },
     '&:hover': {
       color: '#8f8',
@@ -136,7 +130,7 @@ const myMap = cssMap({
 });
 ```
 
-This applies to other at-rules as well (CSS rules that start with an `@` sign), including `@support`, `@container`, and so on.
+Previously you would specify media queries by splitting the `@media` part and the rest of the media query into two, just like with the [`vanilla-extract`](https://vanilla-extract.style/documentation/styling/#media-queries) library. We no longer recommend this as it is inconsistent with other Compiled APIs, and our type checking now works without the need for splitting media queries into two.
 
 ### Nested selectors and advanced selectors
 
@@ -149,10 +143,8 @@ However, if you really need to use nested selectors, this can be done through th
 const myMap = cssMap({
   danger: {
     color: 'red',
-    '@media': {
-      '(min-width: 100px)': {
-        fontSize: '1.5em',
-      },
+    '@media (min-width: 100px)': {
+      fontSize: '1.5em',
     },
     '&:hover': {
       color: 'pink',
@@ -169,10 +161,8 @@ const myMap = cssMap({
   },
   success: {
     color: 'green',
-    '@media': {
-      '(min-width: 100px)': {
-        fontSize: '1.3em',
-      },
+    '@media (min-width: 100px)': {
+      fontSize: '1.3em',
     },
     '&:hover': {
       color: '#8f8',
@@ -188,7 +178,7 @@ const myMap = cssMap({
 
 ## Composing styles
 
-`cssMap` can be composed with other styles that are specified through the [css API](/api-css).
+`cssMap` can be composed with other styles that are specified through the [css API](/api-css-prop).
 
 ```jsx
 import { css, cssMap } from '@compiled/react';

--- a/website/packages/docs/src/pages/api-cssmap.mdx
+++ b/website/packages/docs/src/pages/api-cssmap.mdx
@@ -1,6 +1,6 @@
 ---
 section: 5-API
-order: 99
+order: 10
 name: CSS Map
 ---
 

--- a/website/packages/docs/src/pages/api-keyframes.mdx
+++ b/website/packages/docs/src/pages/api-keyframes.mdx
@@ -1,6 +1,6 @@
 ---
 section: 5-API
-order: 99
+order: 10
 name: Keyframes
 ---
 

--- a/website/packages/docs/src/pages/api-keyframes.mdx
+++ b/website/packages/docs/src/pages/api-keyframes.mdx
@@ -1,7 +1,7 @@
 ---
 section: 5-API
 order: 10
-name: Keyframes
+name: keyframes
 ---
 
 # Keyframes
@@ -21,15 +21,9 @@ const fadeOut = keyframes({
   },
 });
 
-const fadeOut = keyframes`
-  from {
-    opacity: 1;
-  }
+const animationStyles = css({
+  animation: `${fadeOut} 2s`,
+});
 
-  to {
-    opacity: 0;
-  }
-`;
-
-<div css={{ animation: `${fadeOut} 2s` }} />;
+const FadeOut = <div css={animationStyles}>I am fading out!</div>;
 ```

--- a/website/packages/docs/src/pages/api-styled.mdx
+++ b/website/packages/docs/src/pages/api-styled.mdx
@@ -1,6 +1,6 @@
 ---
 section: 5-API
-order: 2
+order: 10
 name: Styled
 ---
 

--- a/website/packages/docs/src/pages/api-styled.mdx
+++ b/website/packages/docs/src/pages/api-styled.mdx
@@ -1,7 +1,7 @@
 ---
-section: 5-API
+section: 6-Deprecated API
 order: 10
-name: Styled
+name: '[Deprecated] styled'
 ---
 
 import {
@@ -13,16 +13,20 @@ import {
   StyledComposition,
 } from '../examples/styled';
 
-# Styled
+# \[Deprecated\] styled
+
+> **Deprecated**<br />
+> We no longer recommend using `styled` prop in new code, and we support this only to make migration from `styled-components` possible. Please use [`css`](/api-css-prop) or [`cssMap`](/api-cssmap) instead.<br /><br />
+> If you use the recommended [UI Styling Standard ESLint plugin](https://atlassian.design/components/eslint-plugin-ui-styling-standard/no-styled/usage), this will be enforced for you.
 
 Create a component that styles a JSX element which comes with built-in behavior such as `ref` and `as` prop support.
 
 <StyledObj />
 
-> **Tagged template expressions** <br /> Tagged template expressions are supported but call expression syntax is preferred.
+> **Tagged template expressions** <br /> Tagged template expressions are supported but using object styles is preferred.
 > See the
-> [no-styled-tagged-template-expression eslint rule](https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/no-styled-tagged-template-expression)
-> for more details.
+> [no-styled-tagged-template-expression ESLint rule](https://atlassian.design/components/eslint-plugin-design-system/no-styled-tagged-template-expression/usage) in the UI
+> Styling Standard for more details.
 
 ## Dynamic declarations
 
@@ -49,7 +53,7 @@ but `$color` is not.
 
 <StyledTransientProps />
 
-## The as prop
+## The `as` prop
 
 The `as` prop is useful when wanting to change the markup during runtime to something else,
 such as from a `<h1>` element to a `<span>`.
@@ -59,7 +63,7 @@ such as from a `<h1>` element to a `<span>`.
 ## Composing components
 
 Wrapping an already defined component enables you to pass styles to it.
-Here the `BlueText` styles take presedence over `RedText`.
+Here the `BlueText` styles take precedence over `RedText`.
 
 <StyledComposition />
 
@@ -68,8 +72,8 @@ Here the `BlueText` styles take presedence over `RedText`.
 
 ## TypeScript
 
-Type support comes out of the box so you'll have a great time using Compiled with TypeScript,
-any interpolation will have access to the props defined in the tagged template generic.
+Type support comes out of the box, so you'll have a great time using Compiled with TypeScript.
+Any interpolation will have access to the props defined in the tagged template generic.
 
 ```jsx
 import { styled } from '@compiled/react';

--- a/website/packages/docs/src/pages/atomic-css.mdx
+++ b/website/packages/docs/src/pages/atomic-css.mdx
@@ -1,7 +1,7 @@
 ---
 section: 50-Guides
 name: Atomic CSS
-order: 99
+order: 20
 ---
 
 # Atomic CSS

--- a/website/packages/docs/src/pages/deprecated-features.mdx
+++ b/website/packages/docs/src/pages/deprecated-features.mdx
@@ -1,7 +1,7 @@
 ---
-section: 5-API
-name: Deprecated features
-order: 10
+section: 6-Deprecated API
+name: Other deprecated features
+order: 12
 ---
 
 import {
@@ -12,7 +12,7 @@ import {
   CssPropCompositionNoStyle,
 } from '../examples/css-prop';
 
-# Deprecated features
+# Other deprecated features
 
 There are features that Compiled supports, but we now discourage for performance reasons.
 

--- a/website/packages/docs/src/pages/deprecated-features.mdx
+++ b/website/packages/docs/src/pages/deprecated-features.mdx
@@ -1,12 +1,34 @@
 ---
 section: 5-API
 name: Deprecated features
-order: 4
+order: 10
 ---
+
+import {
+  CssPropObj,
+  CssPropString,
+  CssPropCompositionCorrect,
+  CssPropCompositionIncorrect,
+  CssPropCompositionNoStyle,
+} from '../examples/css-prop';
 
 # Deprecated features
 
 There are features that Compiled supports, but we now discourage for performance reasons.
+
+## Template literals
+
+Compiled supports writing styles as a template literal on our `styled` and `css` APIs.
+
+We now recommend using style objects instead of template literals, due to better type safety and syntax validation when using object styles.
+
+Before:
+
+<CssPropString />
+
+After:
+
+<CssPropObj />
 
 ## Nested rules
 
@@ -50,3 +72,11 @@ const linkStyles = css({ textDecoration: 'none' });
   </div>
 </div>;
 ```
+
+## Passing `css` prop to JSX elements with `css` prop
+
+We support passing a `css` prop to components that you create with Compiled. However, this is not recommended as it can be tricky to statically determine which styles are applied at runtime.
+
+<CssPropCompositionCorrect />
+
+Note that both `className` and `style` props need to be explicitly given for this to work. (Spread props such as `<div {...props} css={{ ... }} />` may not be enough.) If not, the styles will not be applied correctly.

--- a/website/packages/docs/src/pages/deprecated-features.mdx
+++ b/website/packages/docs/src/pages/deprecated-features.mdx
@@ -1,0 +1,52 @@
+---
+section: 5-API
+name: Deprecated features
+order: 4
+---
+
+# Deprecated features
+
+There are features that Compiled supports, but we now discourage for performance reasons.
+
+## Nested rules
+
+Like many other CSS-in-JS libraries, Compiled supports nested rules.
+
+**Use with caution.** Nested selectors will create bloat in the stylesheet through bespoke selectors that are never de-duplicated with other usages elsewhere in the codebase, defeating the purpose and benefits of [atomic CSS](/atomic-css).
+
+```jsx
+import { css } from '@compiled/react';
+
+const styles = css({
+  margin: '0 auto',
+  div: {
+    color: 'red',
+    fontSize: '12px',
+    a: {
+      textDecoration: 'none',
+    },
+  },
+});
+
+<div css={styles}>
+  <div>
+    <a>My link</a>
+  </div>
+</div>;
+```
+
+Instead, we recommend assigning styles directly to the elements to which they apply.
+
+```jsx
+import { css } from '@compiled/react';
+
+const outerStyles = css({ margin: '0 auto' });
+const innerStyles = css({ color: 'red', fontSize: '12px' });
+const linkStyles = css({ textDecoration: 'none' });
+
+<div css={outerStyles}>
+  <div css={innerStyles}>
+    <a css={linkStyles}>My link</a>
+  </div>
+</div>;
+```

--- a/website/packages/docs/src/pages/deprecated-features.mdx
+++ b/website/packages/docs/src/pages/deprecated-features.mdx
@@ -5,11 +5,11 @@ order: 12
 ---
 
 import {
-  CssPropObj,
-  CssPropString,
   CssPropCompositionCorrect,
   CssPropCompositionIncorrect,
   CssPropCompositionNoStyle,
+  CssPropObj,
+  CssPropString,
 } from '../examples/css-prop';
 
 # Other deprecated features

--- a/website/packages/docs/src/pages/installation.mdx
+++ b/website/packages/docs/src/pages/installation.mdx
@@ -95,6 +95,12 @@ Make sure this is defined after other plugins so it runs first.
 
 See the [plugin package docs](/pkg-babel-plugin) for configuration options.
 
+## Installing the UI Styling Standard plugin
+
+We recommend using Compiled with the [UI Styling Standard ESLint plugin](https://atlassian.design/components/eslint-plugin-ui-styling-standard/overview). This plugin ensures that the styles you write are performant, idiomatic, and easier to maintain.
+
+Note that using this plugin will be a requirement for frontend developers at Atlassian.
+
 ## Ensuring Babel and TypeScript work with Compiled
 
 To [use the `css` prop](/writing-css), you may need to update your TypeScript and Babel configuration so that those libraries are aware of Compiled.
@@ -141,7 +147,7 @@ In your [Babel configuration](https://babeljs.io/docs/babel-plugin-transform-rea
 }
 ```
 
-If you don't want to set this globally, and instead want to set this on a per-file basis, you can use `/** @jsxImportSource @compiled/react */`:
+If you don't want to set this globally, and instead want to set this on a per-file basis, you can use `/** @jsxImportSource @compiled/react */`. You can use this in conjunction with the `jsx-pragma` rule from our [ESLint plugin](/pkg-eslint-plugin) to have this added for you automatically.
 
 ```tsx
 /** @jsxImportSource @compiled/react */
@@ -193,7 +199,7 @@ In your [Babel configuration](https://babeljs.io/docs/babel-plugin-transform-rea
 }
 ```
 
-If you don't want to set this globally, and instead want to set this on a per-file basis, you can use `/** @jsx jsx */`, as well as `/** @jsxFrag React.Fragment */` if needed:
+If you don't want to set this globally, and instead want to set this on a per-file basis, you can use `/** @jsx jsx */`, as well as `/** @jsxFrag React.Fragment */` if needed. You can use this in conjunction with the `jsx-pragma` rule from our [ESLint plugin](/pkg-eslint-plugin) to have `/** @jsx jsx */` added for you automatically.
 
 ```tsx
 /** @jsx jsx */

--- a/website/packages/docs/src/pages/installation.mdx
+++ b/website/packages/docs/src/pages/installation.mdx
@@ -14,7 +14,9 @@ npm install @compiled/react
 
 Then configure your bundler of choice or use [Babel](https://babeljs.io) directly.
 
-## Webpack
+## Installation methods
+
+### Webpack
 
 Install the [Webpack](https://webpack.js.org/) loader.
 
@@ -45,12 +47,12 @@ module.exports = {
 };
 ```
 
-If you're shipping an app you'll also be interested in CSS extraction,
-read the [Webpack CSS extraction](/css-extraction-webpack) for a step-by-step guide.
+If you're shipping an app, you'll also be interested in CSS extraction.
+Read the [Webpack CSS extraction](/css-extraction-webpack) for a step-by-step guide.
 
 See the [loader package docs](/pkg-webpack-loader) for configuration options.
 
-## Parcel
+### Parcel
 
 Install the [Parcel v2](https://v2.parceljs.org) configuration.
 
@@ -68,7 +70,7 @@ Add the compiled preset to your [Parcel config](https://parceljs.org/features/pl
 
 See the [configuration package docs](/pkg-parcel-config) for configuration options.
 
-## Babel
+### Babel
 
 > **Local development** <br />
 > When developing locally its advised to use a bundler instead of Babel directly for improved developer experience.
@@ -92,3 +94,111 @@ Make sure this is defined after other plugins so it runs first.
 ```
 
 See the [plugin package docs](/pkg-babel-plugin) for configuration options.
+
+## Ensuring Babel and TypeScript work with Compiled
+
+To [use the `css` prop](/writing-css), you may need to update your TypeScript and Babel configuration so that those libraries are aware of Compiled.
+
+There are two supported options you can take to set this up: automatic JSX pragma, or the classic JSX pragma. We recommend the automatic JSX pragma if you're not sure.
+
+### Automatic JSX pragma
+
+This requires TypeScript 4.1 or higher. In your [TypeScript configuration](https://www.typescriptlang.org/docs/handbook/jsx.html#configuring-jsx):
+
+```json
+// tsconfig.json
+
+{
+  "compilerOptions": {
+    // ...
+    "jsx": "react-jsx",
+    "jsxImportSource": "@compiled/react"
+  }
+}
+```
+
+In your [Babel configuration](https://babeljs.io/docs/babel-plugin-transform-react-jsx):
+
+```json
+// babel.config.json
+
+{
+  "presets": [
+    // ...
+  ],
+  "plugins": [
+    // ...
+    [
+      // You can also set these options on @babel/preset-react
+      // directly.
+      "@babel/plugin-transform-react-jsx",
+      {
+        "runtime": "automatic",
+        "importSource": "@compiled/react"
+      }
+    ]
+  ]
+}
+```
+
+If you don't want to set this globally, and instead want to set this on a per-file basis, you can use `/** @jsxImportSource @compiled/react */`:
+
+```tsx
+/** @jsxImportSource @compiled/react */
+import { css } from '@compiled/react';
+
+const someStyles = css({ /* ... */ });
+const Button = <button css={someStyles}>Button text</Button>;
+```
+
+### Classic JSX pragma
+
+In your [TypeScript configuration](https://www.typescriptlang.org/docs/handbook/jsx.html#configuring-jsx):
+
+```json
+// tsconfig.json
+
+{
+  "compilerOptions": {
+    // ...
+    "jsx": "react",
+    "jsxFactory": "jsx",
+    "jsxFragmentFactory": "React.Fragment"
+  }
+}
+```
+
+In your [Babel configuration](https://babeljs.io/docs/babel-plugin-transform-react-jsx):
+
+```json
+// babel.config.json
+
+{
+  "presets": [
+    // ...
+  ],
+  "plugins": [
+    // ...
+    [
+      // You can also set these options on @babel/preset-react
+      // directly.
+      "@babel/plugin-transform-react-jsx",
+      {
+        "runtime": "classic",
+        "pragma": "jsx",
+        "pragmaFrag": "React.Fragment"
+      }
+    ]
+  ]
+}
+```
+
+If you don't want to set this globally, and instead want to set this on a per-file basis, you can use `/** @jsx jsx */`, as well as `/** @jsxFrag React.Fragment */` if needed:
+
+```tsx
+/** @jsx jsx */
+import { css, jsx } from '@compiled/react';
+
+const someStyles = css({ /* ... */ });
+const Button = <button css={someStyles}>Button text</Button>;
+```

--- a/website/packages/docs/src/pages/pkg-react.mdx
+++ b/website/packages/docs/src/pages/pkg-react.mdx
@@ -128,7 +128,7 @@ import { css, ClassNames } from '@compiled/react';
 
 ## CSS
 
-Use [`css`](/api-css) to define styles that can be statically typed and useable with other Compiled APIs.
+Use [`css`](/api-css-prop) to define styles that can be statically typed and useable with other Compiled APIs.
 
 ```jsx
 import { css } from '@compiled/react';

--- a/website/packages/docs/src/pages/writing-css.mdx
+++ b/website/packages/docs/src/pages/writing-css.mdx
@@ -6,125 +6,86 @@ order: 4
 
 # Writing CSS
 
-Write CSS using object styles and objects with any of the APIs available with Compiled.
+Write CSS using objects and objects with the `css` and `cssMap` APIs in Compiled.
 
-```jsx
-import { styled } from '@compiled/react';
-
-const Button = styled.button({
-  fontSize: '10px',
-  fontWeight: '500',
-  borderRadius: '3px',
-  border: '1px solid blue',
-});
-```
-
-## Features
-
-Compiled comes with extra features above standard [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS).
-
-### Nested rules
-
-Nest CSS rules within each other.
-
-```jsx
+```tsx
+import type { ReactNode } from 'react';
 import { css } from '@compiled/react';
 
-<div
-  css={css({
-    margin: '0 auto',
-    div: {
-      color: 'red',
-      fontSize: 12,
-      a: {
-        textDecoration: 'none',
-      },
-    },
-  })}>
-  <div>
-    <a />
-  </div>
-</div>;
+type CardProps = {
+  children: ReactNode;
+};
+
+const cardStyles = css({
+  backgroundColor: 'blue',
+  boxShadow: token('elevation.shadow.raised'),
+  padding: token('space.100'),
+});
+
+const Card = ({ children }: CardProps) => <div css={cardStyles}>{children}</div>;
 ```
 
-Use with caution.
-One of the promises of [atomic CSS](/atomic-css) is reducing the amount of styles,
-however more selectors are created when nested.
+Atlassian employees should use [Atlassian Design System tokens](https://atlassian.design/tokens/design-tokens) instead of plain string values.
 
-To create less CSS rules assign styles directly to the elements instead.
+Depending on your configuration, you might need `/** @jsxImportSource @compiled/react */` or `/** @jsx jsx */` at the start of your file -- see [Installation](/installation) for more details.
+
+## Writing pseudo-selectors
+
+The `&` character references the parent selector(s). If there is no parent selector, it references the element that the `css`/`cssMap`/`styled` function call is applied on.
+
+We can use this to define pseudo-selectors and pseudo-elements. In the example below, the two selectors (textarea and input) both alter the color on the `:hover` pseudo selector.
 
 ```jsx
-<div css={css({ margin: '0 auto' })}>
-  <div css={css({ color: 'red', fontSize: 12 })}>
-    <a css={css({ textDecoration: 'none' })} />
-  </div>
-</div>
+const styles = css({
+  color: '#a7a7a7',
+  '&:hover': {
+    color: '#000',
+  },
+});
+
+const CustomBox = () => <div css={styles}>Custom box</div>;
 ```
 
-### Nesting selector
+is processed into:
 
-The `&` character references the parent selector(s).
-In the example below the two selectors (textarea and input) both alter the color on the `:hover` pseudo selector.
-
-```jsx
-<div
-  css={css({
-    'textarea, input': {
-      color: '#a7a7a7',
-      '&:hover': {
-        color: '#000',
-      },
-    },
-  })}
-/>
+```tsx
+const CustomBox = () => <div className="_syazswos _30l3r3uz">Custom box</div>;
 ```
-
-Becomes:
 
 ```css
-textarea,
-input {
+._syazswos {
   color: #a7a7a7;
 }
-textarea:hover,
-input:hover {
+._30l3r3uz:hover {
   color: #000;
 }
 ```
 
-Both `textarea` and `input` have a hover selector.
+We recommend only using this on the current element, to minimise superfluous styles being generated in the stylesheet. For example, `&:hover` and `&::after` are okay, but `&:hover div` or `div &:hover` are not.
 
-### Dangling pseudos
+## Writing more complex components
 
-These rules are transformed to receive a nesting selector.
+See the [UI Styling Standard migration guide](https://atlassian.design/components/eslint-plugin-ui-styling-standard/migration-guide) for a detailed guide on how to write your styles in Compiled.
 
-```jsx
-<div
-  css={css({
-    ':before': {
-      content: 'Hello',
-    },
-  })}
-/>
+## Vendor prefixing
+
+[Auto-prefixing](https://github.com/postcss/autoprefixer) CSS declarations enables us to ignore slight browser differences and instead concentrate on the experiences we're developing.
+
+If we had this style:
+
+```tsx
+const styles = css({
+  userSelect: 'none',
+});
 ```
 
-Becomes:
-
-```css
-&:before {
-  content: 'Hello';
-}
-```
-
-### Vendor prefixing
-
-[Autoprefixing](https://github.com/postcss/autoprefixer) CSS declarations enables us to ignore slight browser differences and instead concentrate on the experiences we're developing.
+Compiled will first convert it into this CSS:
 
 ```css
 user-select: none;
 ```
 
-Becomes:
+It will then add auto-prefixes, as necessary:
 
 ```css
 -webkit-user-select: none;

--- a/website/packages/examples/src/css-prop-conditional-rules.tsx
+++ b/website/packages/examples/src/css-prop-conditional-rules.tsx
@@ -7,25 +7,24 @@ type LozengeProps = {
   primary: boolean;
 };
 
-export const Lozenge = (props: LozengeProps): JSX.Element => (
-  <span
-    css={[
-      props.primary &&
-        css({
-          border: '3px solid pink',
-          color: 'pink',
-        }),
-      !props.primary &&
-        css({
-          border: '3px solid blue',
-          color: 'blue',
-        }),
-      css({
-        padding: '4px 8px',
-        fontWeight: 600,
-        borderRadius: 3,
-      }),
-    ]}>
-    {props.children}
-  </span>
+const primaryStyles = css({
+  border: '3px solid pink',
+  color: 'pink',
+});
+
+const notPrimaryStyles = css({
+  border: '3px solid blue',
+  color: 'blue',
+});
+
+const moreStyles = css({
+  // any styles here will override what is in
+  // primaryStyles and notPrimaryStyles
+  padding: '4px 8px',
+  fontWeight: 600,
+  borderRadius: 3,
+});
+
+export const Lozenge = ({ children, primary }: LozengeProps): JSX.Element => (
+  <span css={[primary && primaryStyles, !primary && notPrimaryStyles, moreStyles]}>{children}</span>
 );

--- a/website/packages/examples/src/css-prop-obj.tsx
+++ b/website/packages/examples/src/css-prop-obj.tsx
@@ -6,13 +6,12 @@ type EmphasisTextProps = {
   children: ReactNode;
 };
 
-export const EmphasisText = (props: EmphasisTextProps): JSX.Element => (
-  <span
-    css={css({
-      color: '#00b8d9',
-      textTransform: 'uppercase',
-      fontWeight: 700,
-    })}>
-    {props.children}
-  </span>
+const styles = css({
+  color: '#00b8d9',
+  textTransform: 'uppercase',
+  fontWeight: 700,
+});
+
+export const EmphasisText = ({ children }: EmphasisTextProps): JSX.Element => (
+  <span css={styles}>{children}</span>
 );

--- a/website/packages/ui/src/layout/root.tsx
+++ b/website/packages/ui/src/layout/root.tsx
@@ -1,4 +1,4 @@
-/** @jsxAutomaticRuntime @compiled/react */
+/** @jsxImportSource @compiled/react */
 import { styled } from '@compiled/react';
 import React, { Fragment, useState, useEffect } from 'react';
 


### PR DESCRIPTION
Follow-up to https://github.com/atlassian-labs/compiled/pull/1687

Update most of the Compiled documentation so that it matches our current recommendations (e.g. object styles > template strings) and [the UI Styling Standard recommendations](https://atlassian.design/components/eslint-plugin-ui-styling-standard/overview).

Sections changed as part of this PR:

<img width="471" alt="Screenshot 2024-07-12 at 11 29 30" src="https://github.com/user-attachments/assets/9b681933-ac1e-47c0-be2c-a7c5fa3b1ea6">

See the individual commits for a detailed breakdown of changes - reading commit-by commit will likely be far easier to review. Summary of most notable commits:

* Update 'Writing CSS' and 'Installation', move some sections into new 'Deprecated features' section
* Update CSS prop page and deprecated syntax page:
  - move template literals to deprecated page
  - discourage dynamic styles
  - move outdated composition syntax to deprecated page
* Update documentation for Compiled APIs
  - Deprecate styled and ClassNames
  - Merge CSS page into CSS prop
  - Update cssMap to use flat `@media` query syntax, not the nested one that DST will remove support for
  - Move details about the `jsx-pragma` ESLint rule to the "JSX pragma" section of the Installation page

