### PR TITLE
Update documentation for all `@compiled/` packages

### DIFF
--- a/website/packages/docs/src/index.html
+++ b/website/packages/docs/src/index.html
@@ -1,11 +1,7 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width" />
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
     <title>Docs | Compiled CSS-in-JS</title>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400&family=Roboto:wght@300;500&display=swap"
-      rel="stylesheet" />
     <script async src="https://cdn.splitbee.io/sb.js"></script>
   </head>
   <body></body>

--- a/website/packages/docs/src/pages/atomic-css.mdx
+++ b/website/packages/docs/src/pages/atomic-css.mdx
@@ -104,29 +104,29 @@ but they share the same atomic rule,
 what happens?
 
 ```jsx
-<div
-  css={css`
-    :hover {
-      color: blue;
-    }
-    :active {
-      color: red;
-    }
-  `}
-/>
+const styles = css({
+  '&:hover': {
+    color: 'blue',
+  },
+  '&:active': {
+    color: 'red',
+  },
+});
+
+<div css={styles} />;
 ```
 
 ```jsx
-<div
-  css={css`
-    :active {
-      color: red;
-    }
-    :hover {
-      color: blue;
-    }
-  `}
-/>
+const styles = css({
+  '&:active': {
+    color: 'red',
+  },
+  '&:hover': {
+    color: 'blue',
+  },
+});
+
+<div css={styles} />;
 ```
 
 The simple answer is it depends which component renders first!

--- a/website/packages/docs/src/pages/installation.mdx
+++ b/website/packages/docs/src/pages/installation.mdx
@@ -16,7 +16,27 @@ Then configure your bundler of choice or use [Babel](https://babeljs.io) directl
 
 ## Installation methods
 
+### (Recommended) Parcel
+
+Install the [Parcel v2](https://v2.parceljs.org) configuration.
+
+```bash
+npm install @compiled/parcel-config --save-dev
+```
+
+Add the compiled preset to your [Parcel config](https://parceljs.org/features/plugins/).
+
+```json
+{
+  "extends": ["@parcel/config-default", "@compiled/parcel-config"]
+}
+```
+
+See the [configuration package docs](/pkg-parcel-config) for configuration options.
+
 ### Webpack
+
+> We recommend Parcel, as this will be more performant, and it aligns with the Atlassian recommended tech stack.
 
 Install the [Webpack](https://webpack.js.org/) loader.
 
@@ -51,24 +71,6 @@ If you're shipping an app, you'll also be interested in CSS extraction.
 Read the [Webpack CSS extraction](/css-extraction-webpack) for a step-by-step guide.
 
 See the [loader package docs](/pkg-webpack-loader) for configuration options.
-
-### Parcel
-
-Install the [Parcel v2](https://v2.parceljs.org) configuration.
-
-```bash
-npm install @compiled/parcel-config --save-dev
-```
-
-Add the compiled preset to your [Parcel config](https://parceljs.org/features/plugins/).
-
-```json
-{
-  "extends": ["@parcel/config-default", "@compiled/parcel-config"]
-}
-```
-
-See the [configuration package docs](/pkg-parcel-config) for configuration options.
 
 ### Babel
 

--- a/website/packages/docs/src/pages/media-queries-and-other-at-rules.mdx
+++ b/website/packages/docs/src/pages/media-queries-and-other-at-rules.mdx
@@ -1,9 +1,9 @@
 ---
 section: 50-Guides
-name: Media queries and other at-rules
+name: Media queries, other at-rules
 ---
 
-# Media queries and other at-rules
+# Media queries, other at-rules
 
 Media queries and other at-rules (e.g. `@layer` and `@supports`) are sorted based on a simplified version of the mobile-first sorting algorithm used by the [`sort-css-media-queries`](https://github.com/olehdutchenko/sort-css-media-queries/) library.
 

--- a/website/packages/docs/src/pages/pkg-babel-plugin-strip-runtime.mdx
+++ b/website/packages/docs/src/pages/pkg-babel-plugin-strip-runtime.mdx
@@ -29,20 +29,15 @@ Configure in your Babel config.
 }
 ```
 
-### onFoundStyleRules: (rules: string[]) => void
-
-Will callback at the end of a file pass with all found style rules.
-
-### compiledRequireExclude: boolean
+#### compiledRequireExclude
 
 When set will prevent additional require (one import per rule) in the bundle and add style rules to meta data.
 This could be used when enabling style sheet extraction in a different configuration for SSR.
 
-Defaults to `false`.
+- Type: `boolean`
+- Default: `false`
 
-### extractStylesToDirectory
-
-extractStylesToDirectory?: \{ source: string; dest: string \};
+#### extractStylesToDirectory
 
 When set, extracts styles to an external CSS file. This is beneficial for building platform components that are to be published on NPM.
 
@@ -50,8 +45,10 @@ Example of useage:
 
 Given the below folder structure:
 
+```
 - src
   - index.jsx
+```
 
 ```js
 // src/index.jsx
@@ -72,9 +69,11 @@ Set the source folder and output folder relative to the root project path.
 
 It extracts the CSS sheet to a seperate file.
 
+```
 - dist
   - index.js
   - index.compiled.css
+```
 
 ```js
 // src/index.jsx
@@ -91,10 +90,17 @@ const Component = () =>
   );
 ```
 
-### sortAtRules: boolean
+- Type: `{ source: string; dest: string }`
+
+#### styleSheetPath
+
+An internal option used by other Compiled plugins. Don't use this!
+
+#### sortAtRules
 
 Whether to sort at-rules, including media queries.
 
 See [here](/media-queries-and-other-at-rules) for more information.
 
-Defaults to `true`.
+- Type: `boolean`
+- Default: `true`

--- a/website/packages/docs/src/pages/pkg-babel-plugin-strip-runtime.mdx
+++ b/website/packages/docs/src/pages/pkg-babel-plugin-strip-runtime.mdx
@@ -41,7 +41,7 @@ This could be used when enabling style sheet extraction in a different configura
 
 When set, extracts styles to an external CSS file. This is beneficial for building platform components that are to be published on NPM.
 
-Example of useage:
+Example of usage:
 
 Given the below folder structure:
 
@@ -91,6 +91,7 @@ const Component = () =>
 ```
 
 - Type: `{ source: string; dest: string }`
+- Default: `undefined`
 
 #### styleSheetPath
 

--- a/website/packages/docs/src/pages/pkg-babel-plugin.mdx
+++ b/website/packages/docs/src/pages/pkg-babel-plugin.mdx
@@ -41,14 +41,33 @@ Configure in your Babel config.
 }
 ```
 
-### importReact: boolean
+If you choose to configure Compiled through Webpack or Parcel (recommended), you can pass options for `@compiled/babel-plugin` through those configurations. See [`@compiled/webpack-loader`](/pkg-webpack-loader) and [`@compiled/parcel-config`](/pkg-parcel-config) for more information.
 
-Will import React into the module if it is not found.
-When using `@babel/preset-react` with the [automatic runtime](https://babeljs.io/docs/en/babel-preset-react#react-automatic-runtime) this is not needed and can be set to `false`.
+`@compiled/babel-plugin` supports the following options:
 
-Defaults to `true`.
+- `addComponentName`
+- `cache`
+- `classNameCompressionMap`
+- `extensions`
+- `importReact`
+- `importSources`
+- `increaseSpecificity`
+- `nonce`
+- `onIncludedFiles`
+- `optimizeCss`
+- `parserBabelPlugins`
+- `processXcss`
+- `resolver`
+- `sortAtRules`
 
-### cache: boolean | 'single-pass'
+#### addComponentName
+
+Add the component name as a class name to the DOM in non-production environments, if `styled` is used.
+
+- Type: `boolean`
+- Default: `false`
+
+#### cache
 
 Will cache the result of statically evaluated imports.
 
@@ -56,26 +75,84 @@ Will cache the result of statically evaluated imports.
 - `'single-pass'` will cache for a single pass of a file
 - `false` turns caching off
 
-Defaults to `true`.
+* Type: `boolean | 'single-pass'`
+* Default: `true`
 
-### optimizeCss: boolean
+#### classNameCompressionMap
 
-Will run additional cssnano plugins to normalize CSS during build.
+Don't use this!
 
-Defaults to `true`.
+An internal and experimental option used to compress class names.
 
-### onIncludedFiles: (files: string[]) => void
+Note that in `@compiled/webpack-loader` and `@compiled/parcel-config`, `classNameCompressionMap` requires `extract` to be true as well.
 
-Will callback at the end of a file pass with all imported files that were statically evaluated into the file.
+#### extensions
 
-### addComponentName: boolean
+Extensions that we should consider code. We use these to identify if a file should be parsed.
 
-Add the component name as class name to DOM in non-production environment if styled is used.
+- Type: `string[]`
+- Default: `['.js', '.jsx', '.ts', '.tsx']`
 
-Default to `false`
+#### importReact
 
-### importSources: string[]
+Will import React into the module if it is not found.
+When using `@babel/preset-react` with the [automatic runtime](https://babeljs.io/docs/en/babel-preset-react#react-automatic-runtime) this is not needed and can be set to `false`.
+
+- Type: `boolean`
+- Default: `true`
+
+#### importSources
 
 Additional libraries that should be parsed as though they were `@compiled/react` imports.
 
 Specifying this is important if you are using Compiled APIs through another package using the `createStrictAPI` function.
+
+- Type: `string[]`
+- Default: `undefined`
+
+#### increaseSpecificity
+
+An experimental option that increases the specificity of all generated Compiled classes. Don't use this!
+
+#### nonce
+
+[Security nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) that will be applied to inline style elements if defined.
+
+- Type: `string`
+- Default: `false`
+
+#### onIncludedFiles
+
+An internal option. Callback fired at the end of the file pass when files have been included in the transformation.
+
+- Type: `(files: string[]) => void`
+- Default: `undefined`
+
+#### optimizeCss
+
+Will run additional `cssnano` plugins to normalize CSS during the build.
+
+- Type: `boolean`
+- Default: `true`
+
+#### parserBabelPlugins
+
+Babel parser plugins to be used when parsing the source code. Define these to enable extra babel parsers (for example, typescript).
+See the [babel docs](https://babeljs.io/docs/en/plugins/#syntax-plugins) for more context.
+
+Usually, you will set this option through [`@compiled/parcel-config`] or [`@compiled/webpack-loader`](/webpack-loader) -- see there for examples.
+
+#### processXcss
+
+An option we are only using internally. Don't use!
+
+#### resolver
+
+A custom resolver used to statically evaluate import declarations, specified as either an object or module path. If this is an object, it should contain a `resolveSync` function with the following type signature: `(context: string, request: string) => string`.
+
+- Type: `string | Resolver`
+- Default: `undefined`
+
+#### sortAtRules
+
+Unused.

--- a/website/packages/docs/src/pages/pkg-eslint-plugin.mdx
+++ b/website/packages/docs/src/pages/pkg-eslint-plugin.mdx
@@ -32,4 +32,4 @@ export default [
 
 ## Rules
 
-See [here](https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin) for a list of rules in `@compiled/eslint-plugin`.
+See [here](https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin) for a non-exhaustive list of rules in `@compiled/eslint-plugin`.

--- a/website/packages/docs/src/pages/pkg-parcel-config.mdx
+++ b/website/packages/docs/src/pages/pkg-parcel-config.mdx
@@ -35,14 +35,136 @@ Configure using any of the following at the root of your project.
 }
 ```
 
-### importReact: boolean
+Through the Compiled configuration file (e.g. `.compiledcssrc`), you can set options for any of our Parcel plugins (`@compiled/parcel-transformer` and `@compiled/parcel-optimizer`), as well as for the underlying `@compiled/babel-plugin`. This page will focus on the options that are unique to `@compiled/parcel-transformer` and `@compiled/parcel-optimizer`.
 
-Will import React into the module if it is not found.
-When using `@babel/preset-react` with the [automatic runtime](https://babeljs.io/docs/en/babel-preset-react#react-automatic-runtime) this is not needed and can be set to `false`.
+### Options used by Compiled Parcel plugins
 
-Defaults to `true`.
+`@compiled/parcel-transformer` accepts the following options:
 
-### transformerBabelPlugins: PluginItem[]
+- `classNameCompressionMapFilePath`
+- `extensions`
+- `extract`
+- `extractFromDistributedCode`
+- `inlineCss`
+- `parserBabelPlugins`
+- `resolve`
+- `sortAtRules`
+- `ssr`
+- `styleSheetPath`
+- `transformerBabelPlugins`
+
+#### classNameCompressionMapFilePath
+
+Don't use this!
+
+This is an alternative to `classNameCompressionMap`, where instead of providing the compression map itself, you can provide a file path to the compression map. If both are provided, `classNameCompressionMap` will take precedence over `classNameCompressionMapFilePath`.
+
+Note that this is enabled only if `extract` is set to `true`.
+
+#### extensions
+
+Extensions that we should consider to be code. We use these to identify if a file should be parsed.
+
+If set, the value of `extensions` will be used in two places:
+
+1. If `resolver` is not set, then `extensions` will be passed to the default resolver, `enhanced-resolver`.
+2. This is also passed to `@compiled/babel-plugin` under the hood.
+
+- Type: `string[]`
+- Default: none, but note that `enhanced-resolver` and `@compiled/babel-plugin` have their own different defaults when the `extensions` option is not set.
+
+#### extract
+
+Enables `@compiled/babel-plugin-strip-runtime`, i.e. the stylesheet extraction feature. When enabled, Compiled react components will be removed and the css will be extracted into a single CSS stylesheet.
+
+The stylesheet extraction feature is disabled on local development due to a [known issue](https://github.com/atlassian-labs/compiled/issues/1306).
+
+- Type: `boolean`
+- Default: `false`
+
+#### extractFromDistributedCode
+
+Unused.
+
+#### extractStylesToDirectory
+
+When set, extracts styles to an external CSS file. Requires `extract` to be set to `true` as well. This is passed directly to `@compiled/babel-plugin-strip-runtime` -- see the [`@compiled/babel-plugin-strip-runtime` documentation](/pkg-babel-plugin-strip-runtime#extractstylestodirectory) for more information.
+
+- Type: `{ source: string; dest: string }`
+- Default: `undefined`
+
+#### inlineCss
+
+Indicates whether CSS content is inlined in HTML or served as a external .css file when the stylesheet extraction is enabled.
+
+- Type: `boolean`
+- Default: `false`
+
+#### parserBabelPlugins
+
+Babel parser plugins to be used when parsing the source code. Define these to enable extra babel parsers (for example, typescript).
+See the [babel docs](https://babeljs.io/docs/en/plugins/#syntax-plugins) for more context.
+
+Example usage:
+
+```json
+// .compiledcssrc
+{
+  "parserBabelPlugins": ["typescript"]
+}
+```
+
+This is also passed to `@compiled/babel-plugin` under the hood.
+
+- Type: `ParserPlugin[]`
+- Default: `undefined`
+
+#### \[Deprecated\] resolve
+
+If `resolver` is not provided, `resolve` specifies options that should be passed to the default resolver (`enhanced-resolver`). The resolver is used to statically evaluate import declarations.
+
+Example usage:
+
+```json
+// .compiledcssrc
+{
+  "resolve": {
+    "mainFields": ["module:es2019", "browser", "module", "main"]
+  }
+}
+```
+
+See [enhanced-resolver docs](https://github.com/webpack/enhanced-resolve#resolver-options) for more options.
+
+- Type: `ResolveOptions`
+- Default: `undefined`
+
+#### sortAtRules
+
+Whether to sort at-rules, including media queries.
+
+See [here](/media-queries-and-other-at-rules) for more information.
+
+- Type: `boolean`
+- Default: `true`
+
+### \[Obsolete\] ssr
+
+> This is hardcoded to `true` now.
+
+To be used in conjunction with `extract: true` when having a different configuration for SSR.
+
+When set to true, `ssr` will prevent additional require (one import per rule) in the bundle during style sheet extraction.
+
+This is equivalent to setting `compiledRequireExclude` in `@compiled/babel-plugin-strip-runtime`.
+
+- Type: `boolean`
+
+#### \[Obsolete\] styleSheetPath
+
+Unused. In the past, this was an internal option passed to `@compiled/babel-plugin-strip-runtime`. Don't use this!
+
+### transformerBabelPlugins
 
 Babel transformer plugins to be applied to transformed files before the Compiled evaluation.
 
@@ -66,96 +188,20 @@ Example usage:
 }
 ```
 
-Defaults to none.
+- Type: `PluginItem[]`
+- Default: `undefined`
 
-### parserBabelPlugins: ParserPlugin[]
+### Options used by `@compiled/babel-plugin`
 
-Babel parser plugins to be used when parsing the source code. Define these to enable extra babel parsers (for example, typescript).
-See the [babel docs](https://babeljs.io/docs/en/plugins/#syntax-plugins) for more context.
+The following options are passed directly to `@compiled/babel-plugin`:
 
-Example usage:
+- `addComponentName`
+- `classNameCompressionMap`
+- `importReact`
+- `importSources`
+- `optimizeCss`
+- `resolver`
 
-```json
-// .compiledcssrc
-{
-  "parserBabelPlugins": ["typescript"]
-}
-```
+Passing other `@compiled/babel-plugin` options not listed above will also work, but have not been tested.
 
-Defaults to none.
-
-### extract: boolean
-
-Enables the stylesheet extraction feature. When enabled, Compiled react components will be removed and the css will be extracted into a single CSS stylesheet.
-
-The stylesheet extraction feature is disabled on local development due to [known issue](https://github.com/atlassian-labs/compiled/issues/1306).
-
-Defaults to `false`.
-
-### ssr: boolean
-
-To be used in conjunction with `extract: true` when having a different configuration for SSR.
-When set will prevent additional require (one import per rule) in the bundle during style sheet extraction.
-
-Defaults to `false`.
-
-### nonce: string
-
-[Security nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) that will be applied to inline style elements if defined.
-
-Defaults to `false`.
-
-### extensions: string[]
-
-Extensions that we should consider code. We use these to identify if a file should be parsed.
-
-Defaults to `['.js', '.jsx', '.ts', '.tsx']`.
-
-### inlineCss: boolean
-
-Indicates whether CSS content is inlined in HTML or served as a external .css file when the styleshset extraction is enabled.
-
-Defaults to `false`.
-
-### resolve: ResolveOptions
-
-Override the default `resolve` used by @compiled/babel-plugin, which is used to statically evaluate import declarations.
-
-Example usage:
-
-```json
-// .compiledcssrc
-{
-  "resolve": {
-    "mainFields": ["module:es2019", "browser", "module", "main"]
-  }
-}
-```
-
-See [enhanced-resolver docs](https://github.com/webpack/enhanced-resolve#resolver-options) for more options.
-
-Defaults to none.
-
-### sortAtRules: boolean
-
-Whether to sort at-rules, including media queries.
-
-See [here](/media-queries-and-other-at-rules) for more information.
-
-Defaults to `true`.
-
-### addComponentName: boolean
-
-Add the component name as class name to DOM in non-production environment if styled is used.
-
-Default to `false`
-
-### extractStylesToDirectory?: \{ source: string; dest: string \};
-
-When set, extracts styles to an external CSS file. Read [babel-plugin-strip-runtime](/pkg-babel-plugin-strip-runtime#extractstylestodirectory) for more information.
-
-### importSources: string[]
-
-Additional libraries that should be parsed as though they were `@compiled/react` imports. This is passed directly to `@compiled/babel-plugin`.
-
-Specifying this is important if you are using Compiled APIs through another package using the `createStrictAPI` function.
+To avoid repetition, we have not included the descriptions here. Please refer to the [`@compiled/babel-plugin` documentation](/pkg-babel-plugin) for more information.

--- a/website/packages/docs/src/pages/pkg-react.mdx
+++ b/website/packages/docs/src/pages/pkg-react.mdx
@@ -11,6 +11,7 @@ import { Lozenge, HorizontalStack } from '@compiled/website-ui';
 <HorizontalStack gap={0.5} spacing={2}>
   <Lozenge>React 16</Lozenge>
   <Lozenge>React 17</Lozenge>
+  <Lozenge>React 18</Lozenge>
 </HorizontalStack>
 
 The primary entrypoint package for Compiled that provides familiar APIs to style your app.
@@ -21,38 +22,58 @@ npm install @compiled/react
 
 ## CSS prop
 
-Use [CSS prop](/api-css-prop) to style a JSX element.
+Use the [CSS prop](/api-css-prop) in conjunction with our `css` function call to style a JSX element.
 
 ```jsx
 /** @jsxImportSource @compiled/react */
 import { css } from '@compiled/react';
 
-<div
-  css={{
-    fontSize: 12,
-    ...(isPrimary && {
-      color: 'blue',
-    }),
-  }}
-/>;
+const baseStyles = css({
+  fontSize: '12px',
+});
 
-<div
-  css={css`
-    font-size: 12px;
-  `}
-/>;
+const primaryStyles = css({
+  color: 'blue',
+});
 
-<div
-  css={[
-    css`
-      font-size: 12px;
-    `,
-    isPrimary && { color: 'blue' },
-  ]}
-/>;
+const Component2 = <div css={styles} />;
+
+const Component3 = <div css={[styles, isPrimary && primaryStyles]} />;
 ```
 
-## Styled
+## CSS Map
+
+Use [`cssMap`](/api-cssmap) to define a map consisting of named CSS rules that can be statically typed and useable with other Compiled APIs.
+
+```jsx
+import { cssMap } from '@compiled/react';
+
+const borderStyleMap = cssMap({
+  none: { borderStyle: 'none' },
+  solid: { borderStyle: 'solid' },
+});
+```
+
+## Keyframes
+
+Use [`keyframes`](/api-keyframes) to define keyframes to be used in a [CSS animation](https://developer.mozilla.org/en-US/docs/Web/CSS/animation).
+
+```jsx
+import { keyframes } from '@compiled/react';
+
+const fadeOut = keyframes({
+  from: {
+    opacity: 1,
+  },
+  to: {
+    opacity: 0,
+  },
+});
+```
+
+## Deprecated APIs
+
+### \[Deprecated\] Styled
 
 Use [styled](/api-styled) to create a component that styles a JSX element which comes with built-in behavior such as `ref` and `as` prop support.
 
@@ -84,7 +105,7 @@ styled.div(
 );
 ```
 
-## Class names
+### \[Deprecated\] ClassNames
 
 Use [ClassNames](/api-class-names) for when styles are not necessarily used on a JSX element.
 
@@ -124,60 +145,4 @@ import { css, ClassNames } from '@compiled/react';
     })
   }
 </ClassNames>;
-```
-
-## CSS
-
-Use [`css`](/api-css-prop) to define styles that can be statically typed and useable with other Compiled APIs.
-
-```jsx
-import { css } from '@compiled/react';
-
-const blackText = css({
-  color: 'black',
-});
-
-const blackText = css`
-  color: black;
-`;
-```
-
-## CSS Map
-
-Use [`css`](/api-cssmap) to define a map consisting of named CSS rules that can be statically typed and useable with other Compiled APIs.
-
-```jsx
-import { cssMap } from '@compiled/react';
-
-const borderStyleMap = cssMap({
-  none: { borderStyle: 'none' },
-  solid: { borderStyle: 'solid' },
-});
-```
-
-## Keyframes
-
-Use [`keyframes`](/api-keyframes) to define keyframes to be used in a [CSS animation](https://developer.mozilla.org/en-US/docs/Web/CSS/animation).
-
-```jsx
-import { keyframes } from '@compiled/react';
-
-const fadeOut = keyframes({
-  from: {
-    opacity: 1,
-  },
-  to: {
-    opacity: 0,
-  },
-});
-
-const fadeOut = keyframes`
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
-`;
 ```

--- a/website/packages/docs/src/pages/pkg-react.mdx
+++ b/website/packages/docs/src/pages/pkg-react.mdx
@@ -52,6 +52,10 @@ const borderStyleMap = cssMap({
   none: { borderStyle: 'none' },
   solid: { borderStyle: 'solid' },
 });
+
+const Component = ({ appearance, children }) => (
+  <div css={borderStyleMap[props.appearance]}>{children}</div>
+);
 ```
 
 ## Keyframes

--- a/website/packages/docs/src/pages/pkg-webpack-loader.mdx
+++ b/website/packages/docs/src/pages/pkg-webpack-loader.mdx
@@ -47,61 +47,123 @@ module.exports = {
 };
 ```
 
-### importReact: boolean
+### Options used by `@compiled/webpack-loader`
 
-Will import React into the module if it is not found.
-When using `@babel/preset-react` with the [automatic runtime](https://babeljs.io/docs/en/babel-preset-react#react-automatic-runtime) this is not needed and can be set to `false`.
+`@compiled/webpack-loader` accepts the following options:
 
-Defaults to `true`.
+- `bake`
+- `extensions`
+- `extract`
+- `extractStylesToDirectory`
+- `parserBabelPlugins`
+- `resolve`
+- `ssr`
+- `transformerBabelPlugins`
 
-### importSources: string[]
+#### bake
 
-Additional libraries that should be parsed as though they were `@compiled/react` imports. This is passed directly to `@compiled/babel-plugin`.
+Turns on `@compiled/babel-plugin`.
 
-Specifying this is important if you are using Compiled APIs through another package using the `createStrictAPI` function.
+- Type: `boolean`
+- Default: `true`
 
-### extract: boolean
+#### extensions
 
-Enables extracting all styles to an atomic style sheet,
-to be used in conjunction with `CompiledExtractPlugin`.
-Read the [Webpack CSS extraction](/css-extraction-webpack) guide for help.
+Extensions that we should consider to be code. We use these to identify if a file should be parsed.
 
-Defaults to `false`.
+If set, the value of `extensions` will be used in two places:
 
-### bake: boolean
+1. If `resolver` is not set, then `extensions` will be passed to the default resolver, `enhanced-resolver`.
+2. This is also passed to `@compiled/babel-plugin` under the hood.
 
-Enables baking your styles into JavaScript.
+- Type: `string[]`
+- Default: none, but note that `enhanced-resolver` and `@compiled/babel-plugin` have their own different defaults when the `extensions` option is not set.
 
-Defaults to `true`.
+#### extract
 
-### optimizeCss: boolean
+Enables extracting all styles to an atomic style sheet. This enables `@compiled/babel-plugin-strip-runtime` under the hood.
 
-Will run additional cssnano plugins to normalize CSS during build.
+You should use this in conjunction with `CompiledExtractPlugin`. Read the [Webpack CSS extraction](/css-extraction-webpack) guide for help.
 
-Defaults to `true`.
+- Type: `boolean`
+- Default: `false`
 
-### addComponentName: boolean
+#### extractStylesToDirectory
 
-Add the component name as class name to DOM in non-production environment if styled is used.
+When set, extracts styles to an external CSS file. Read [babel-plugin-strip-runtime](/pkg-babel-plugin-strip-runtime) for more information.
 
-Default to `false`
+- Type: `{ source: string; dest: string }`
+- Default: `undefined`
 
-### sortAtRules: boolean
+#### parserBabelPlugins
 
-Whether to sort at-rules, including media queries.
+Babel parser plugins to be used when parsing the source code. Define these to enable extra babel parsers (for example, typescript).
+See the [babel docs](https://babeljs.io/docs/en/plugins/#syntax-plugins) for more context.
 
-See [here](/media-queries-and-other-at-rules) for more information.
+Example usage:
 
-Defaults to `true`.
+```js
+// webpack.config.js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: [
+          { loader: 'babel-loader' },
+          {
+            loader: '@compiled/webpack-loader',
+            options: {
+              parserBabelPlugins: ['typescript'],
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+```
 
-### ssr: boolean
+This is also passed to `@compiled/babel-plugin` under the hood.
+
+- Type: `ParserPlugin[]`
+- Default: `['typescript', 'jsx']`
+
+#### \[Deprecated\] resolve
+
+If `resolver` is not provided, `resolve` specifies options that should be passed to the default resolver (`enhanced-resolver`). The resolver is used to statically evaluate import declarations.
+
+This has been superseded by `resolver`; you should use that instead!
+
+Example usage:
+
+```json
+options: {
+  // ...
+  "resolve": {
+    "mainFields": ["module:es2019", "browser", "module", "main"]
+  }
+}
+```
+
+See [enhanced-resolver docs](https://github.com/webpack/enhanced-resolve#resolver-options) for more options.
+
+- Type: `ResolveOptions`
+- Default: `undefined`
+
+#### ssr
 
 To be used in conjunction with `extract: true` when having a different configuration for SSR.
-When set will prevent additional require (one import per rule) in the bundle during style sheet extraction.
 
-Defaults to `false`.
+When set to true, `ssr` will prevent additional require (one import per rule) in the bundle during style sheet extraction.
 
-### transformerBabelPlugins: PluginItem[]
+This is equivalent to setting `compiledRequireExclude` in `@compiled/babel-plugin-strip-runtime`.
+
+- Type: `boolean`
+- Default: `false`
+
+#### transformerBabelPlugins
 
 Babel transformer plugins to be applied to transformed files before the Compiled evaluation.
 
@@ -141,41 +203,22 @@ module.exports = {
 };
 ```
 
-Defaults to none.
+- Type: `PluginItem[]`
+- Default: `[]`
 
-### parserBabelPlugins: ParserPlugin[]
+### Options passed to `@compiled/babel-plugin`
 
-Babel parser plugins to be used when parsing the source code. Define these to enable extra babel parsers (for example, typescript).
-See the [babel docs](https://babeljs.io/docs/en/plugins/#syntax-plugins) for more context.
+`@compiled/webpack-loader` also accepts the following options. These are not used in the loader itself, but instead they are passed directly to the underlying `@compiled/babel-plugin`.
 
-Example usage:
+- `addComponentName`
+- `classNameCompressionMap`
+- `importReact`
+- `importSources`
+- `nonce`
+- `optimizeCss`
+- `resolver`
 
-```js
-// webpack.config.js
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: [
-          { loader: 'babel-loader' },
-          {
-            loader: '@compiled/webpack-loader',
-            options: {
-              parserBabelPlugins: ['typescript'],
-            },
-          },
-        ],
-      },
-    ],
-  },
-};
-```
-
-### extractStylesToDirectory?: \{ source: string; dest: string \};
-
-When set, extracts styles to an external CSS file. Read [babel-plugin-strip-runtime](/pkg-babel-plugin-strip-runtime) for more information.
+To avoid repetition, we have not included the descriptions here. Please refer to the [`@compiled/babel-plugin` documentation](/pkg-babel-plugin) for more information.
 
 ## CompiledExtractPlugin
 
@@ -190,7 +233,9 @@ module.exports = {
 };
 ```
 
-### nodeModulesTest: Condition
+### Options
+
+#### nodeModulesTest
 
 As a performance optimization you can test paths to include by [passing a webpack condition](https://webpack.js.org/configuration/module/#condition) to the plugin.
 
@@ -200,7 +245,10 @@ new CompiledExtractPlugin({
 });
 ```
 
-### nodeModulesInclude: Condition
+- Type: `Condition`
+- Default: `undefined`
+
+#### nodeModulesInclude
 
 As a performance optimization you can include paths by [passing a webpack condition](https://webpack.js.org/configuration/module/#condition) to the plugin.
 
@@ -210,7 +258,10 @@ new CompiledExtractPlugin({
 });
 ```
 
-### nodeModulesExclude: Condition
+- Type: `Condition`
+- Default: `undefined`
+
+#### nodeModulesExclude
 
 As a performance optimization you can exclude paths by [passing a webpack condition](https://webpack.js.org/configuration/module/#condition) to the plugin.
 
@@ -220,7 +271,10 @@ new CompiledExtractPlugin({
 });
 ```
 
-### cacheGroupExclude: boolean
+- Type: `Condition`
+- Default: `undefined`
+
+#### cacheGroupExclude: boolean
 
 To be used in conjunction with `extract: true` when having a different configuration for SSR.
 This will prevent the additional `cacheGroup` chunk to be created during style sheet extraction; compiled-css files should be only generated in the client-side.
@@ -230,3 +284,15 @@ new CompiledExtractPlugin({
   cacheGroupExclude: true,
 });
 ```
+
+- Type: `boolean`
+- Default: `undefined`
+
+#### sortAtRules
+
+Whether to sort at-rules, including media queries.
+
+See [here](/media-queries-and-other-at-rules) for more information.
+
+- Type: `boolean`
+- Default: `true`

--- a/website/packages/landing/src/index.html
+++ b/website/packages/landing/src/index.html
@@ -1,11 +1,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width" />
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
     <title>Compiled | Compile time CSS-in-JS for React</title>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@400&family=Roboto:wght@300;500&display=swap"
-      rel="stylesheet" />
     <script async src="https://cdn.splitbee.io/sb.js"></script>
   </head>
   <body>

--- a/website/packages/ui/global.css
+++ b/website/packages/ui/global.css
@@ -1,7 +1,7 @@
 body {
   margin: 0;
   padding: 0;
-  font-size: 2.5rem;
+  font-size: 2rem;
   line-height: 1.4;
   min-height: 100vh;
   position: relative;

--- a/website/packages/ui/src/components/anchor.tsx
+++ b/website/packages/ui/src/components/anchor.tsx
@@ -28,6 +28,7 @@ export const Anchor = ({ children }: { children: string | string[] }): JSX.Eleme
   const context = useContext(AnchorContext);
   const ref = useRef<HTMLElement | null>(null);
 
+  console.log(children);
   const id = (
     typeof children === 'string'
       ? [children.trim().split(' ').join('-')]
@@ -40,10 +41,11 @@ export const Anchor = ({ children }: { children: string | string[] }): JSX.Eleme
     .toLowerCase();
 
   useEffect(() => {
-    context.listen(ref.current);
+    const currentRef = ref.current;
+    context.listen(currentRef);
 
     return () => {
-      context.unlisten(ref.current);
+      context.unlisten(currentRef);
     };
   }, [context, id]);
 

--- a/website/packages/ui/src/components/anchor.tsx
+++ b/website/packages/ui/src/components/anchor.tsx
@@ -28,7 +28,6 @@ export const Anchor = ({ children }: { children: string | string[] }): JSX.Eleme
   const context = useContext(AnchorContext);
   const ref = useRef<HTMLElement | null>(null);
 
-  console.log(children);
   const id = (
     typeof children === 'string'
       ? [children.trim().split(' ').join('-')]

--- a/website/packages/ui/src/components/heading.tsx
+++ b/website/packages/ui/src/components/heading.tsx
@@ -25,10 +25,10 @@ export const Heading = ({ children, style, ...props }: HeadingProps): JSX.Elemen
       className={props.className}
       style={style}
       css={`
-        font-family: 'Noto Sans', sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+          'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
         font-weight: 500;
         margin: 0;
-        opacity: 0.9;
         word-break: break-word;
 
         ::before {
@@ -72,8 +72,7 @@ export const Heading = ({ children, style, ...props }: HeadingProps): JSX.Elemen
         }
 
         [data-look='h200']& {
-          font-size: 36px;
-          line-height: 44px;
+          font-size: 5rem;
           padding: 0.05px 0;
 
           ::before {
@@ -86,8 +85,7 @@ export const Heading = ({ children, style, ...props }: HeadingProps): JSX.Elemen
         }
 
         [data-look='h300']& {
-          font-size: 24px;
-          line-height: 32px;
+          font-size: 3.5rem;
           padding: 0.05px 0;
           letter-spacing: 0.3px;
 
@@ -101,8 +99,7 @@ export const Heading = ({ children, style, ...props }: HeadingProps): JSX.Elemen
         }
 
         [data-look='h600']& {
-          font-size: 20px;
-          line-height: 24px;
+          font-size: 2.75rem;
           padding: 0.05px 0;
           letter-spacing: 0.3px;
 
@@ -116,11 +113,9 @@ export const Heading = ({ children, style, ...props }: HeadingProps): JSX.Elemen
         }
 
         [data-look='h400']& {
-          font-size: 14px;
-          line-height: 20px;
+          font-size: 2.5rem;
           padding: 0.05px 0;
-          text-transform: uppercase;
-          letter-spacing: 1px;
+          letter-spacing: 0.75px;
           color: #7a869a;
 
           ::before {
@@ -133,8 +128,7 @@ export const Heading = ({ children, style, ...props }: HeadingProps): JSX.Elemen
         }
 
         [data-look='h500']& {
-          font-size: 12px;
-          line-height: 18px;
+          font-size: 1.5rem;
           padding: 0.05px 0;
           text-transform: uppercase;
           letter-spacing: 1px;

--- a/website/packages/ui/src/components/mdx-components.tsx
+++ b/website/packages/ui/src/components/mdx-components.tsx
@@ -39,7 +39,7 @@ const Code = styled.code`
 `;
 
 const P = styled.p`
-  margin: 4rem 0;
+  margin: 3rem 0;
 `;
 
 export const mdxComponents: MDXProviderComponentsProp = {

--- a/website/packages/ui/src/components/text.tsx
+++ b/website/packages/ui/src/components/text.tsx
@@ -27,7 +27,7 @@ export function Text({
         weight === 'regular' && `font-weight: 300;`,
         weight === 'bold' && `font-weight: 500;`,
         `
-          font-family: 'Roboto', sans-serif;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
           padding-top: 0.05px;
           padding-bottom: 0.05px;
 
@@ -44,8 +44,7 @@ export function Text({
           }
 
           &[data-variant='reading'] {
-            font-size: 20px;
-            line-height: 30px;
+            line-height: 1.6em;
 
             ::before {
               margin-top: -0.3834em;


### PR DESCRIPTION
Follow-up to https://github.com/atlassian-labs/compiled/pull/1687 and https://github.com/atlassian-labs/compiled/pull/1688

Click this link to see how the website looks: https://deploy-preview-1689--compiled-css-in-js.netlify.app/

Main change:

* **Update documentation for all `@compiled/` packages** so that the options listed are actually accurate
  * There's a few options that aren't used anymore - I've noted them as such in the website. We may fix this in https://github.com/atlassian-labs/compiled/issues/1690 if we get time
  * For options that are used in both `@compiled/babel-plugin`and `@compiled/webpack-loader` / `@compiled/parcel-*`, I've tried my best to de-duplicate them for a single source of truth
  * Other issues discovered while working on this:
    * https://github.com/atlassian-labs/compiled/issues/1691
    * https://github.com/atlassian-labs/compiled/issues/1692

Below are the other changes I've made. I recommend looking at the commit-by-commit:

* Update "Atomic CSS" page to use object styles, not tagged template strings
* Update `@compiled/react` documentation to explicitly deprecate `styled` and `ClassName` APIs, and make `css`/`cssMap`/`keyframes` more prominent
* Update fonts and font sizes to fit more text on a page (and because Roboto belongs in the early 2010s imo)
  * This is a quick hack to make it more readable; I'm not a professional designer, so it's not the most bang-up job. Please be nice 😆 
  * This also substantially helps readability for the other changes in this PR
  * If we have more time, we can consider (1) migrating the docs to a centralised platform or (2) redesigning the website entirely.
* Change the "Installation" page to recommend Parcel over Webpack
* Update title of 'Media queries and other at rules' to more easily fit the sidebar