### PR TITLE
Allow `ax()` to handle non-string classnames when collected.

### DIFF
--- a/.changeset/modern-olives-chew.md
+++ b/.changeset/modern-olives-chew.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Allows `ax()` class collection to handle outputs from `cx()` functions.

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime/ax.js",
-      "limit": "195B",
+      "limit": "240B",
       "import": "ax"
     },
     {

--- a/packages/react/src/runtime/__tests__/ax.test.ts
+++ b/packages/react/src/runtime/__tests__/ax.test.ts
@@ -1,4 +1,9 @@
+import { AtomicGroups } from '../ac';
 import ax from '../ax';
+
+const atomicMap = new Map();
+atomicMap.set('_aaaa', '_aaaabbbb');
+atomicMap.set('_bbbb', '_bbbbcccc');
 
 describe('ax', () => {
   const isEnabled: boolean = (() => false)();
@@ -49,6 +54,17 @@ describe('ax', () => {
       'should ignore non atomic declarations when atomic declarations exist',
       ['hello_there', 'hello_world', '_aaaabbbb'],
       'hello_there hello_world _aaaabbbb',
+    ],
+    [
+      'should handle a nested AtomicGroups class',
+      ['_aaaaaaaa', new AtomicGroups(atomicMap)],
+      '_aaaabbbb _bbbbcccc',
+    ],
+    [
+      'should handle a flat, nested array',
+      // We don't directly handle array-like collected classes (they shouldn't exist with types), but it's easy to solve for
+      ['_aaaabbbb', ['_bbbbaaaa', '_bbbbcccc'] as any],
+      '_aaaabbbb _bbbbcccc',
     ],
   ])('%s', (_, params, result) => {
     expect(result).toEqual(ax(params));

--- a/packages/react/src/runtime/ac.ts
+++ b/packages/react/src/runtime/ac.ts
@@ -18,14 +18,14 @@ const cache = new Map();
  * `ac` returns an instance of AtomicGroups. The instance holds the knowledge of Atomic Group so we can chain `ac`.
  * e.g. <div className={ax([ax(['_aaaa_b']), '_aaaa_c'])} />
  */
-class AtomicGroups {
+export class AtomicGroups {
   values: Map<string, string>;
   constructor(values: Map<string, string>) {
     // An object stores the relation between Atomic group and actual class name
     // e.g. { "aaaa": "a" } `aaaa` is the Atomic group and `a` is the actual class name
     this.values = values;
   }
-  toString() {
+  toString(): string {
     let str = '';
 
     for (const [, value] of this.values) {

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -1,4 +1,4 @@
-import { AtomicGroups } from './ac';
+import type { AtomicGroups } from './ac';
 
 const UNDERSCORE_UNICODE = 95;
 
@@ -52,11 +52,10 @@ export default function ax(
     if (typeof cls === 'string') {
       groups = cls.split(' ');
     } else if (Array.isArray(cls)) {
-      groups = cls;
-    } else if (cls instanceof AtomicGroups) {
-      groups = cls.toString().split(' ');
+      groups = cls; // NOTE: Not really a valid scenario, so we don't deeply recurse or handle this properly
     } else {
-      // NOTE: Could throw an error here to help understand that this is collecting invalid styles.
+      // NOTE: Could throw an error here if this isn't our `AtomicGroups` to help understand that this is collecting invalid styles.
+      groups = String(cls).split(' ');
     }
 
     for (let x = 0; x < groups.length; x++) {

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -1,3 +1,5 @@
+import { AtomicGroups } from './ac';
+
 const UNDERSCORE_UNICODE = 95;
 
 /**
@@ -27,8 +29,13 @@ const ATOMIC_GROUP_LENGTH = 5;
  *
  * @param classes
  */
-export default function ax(classNames: (string | undefined | null | false)[]): string | undefined {
-  if (classNames.length <= 1 && (!classNames[0] || classNames[0].indexOf(' ') === -1)) {
+export default function ax(
+  classNames: (string | undefined | null | false | AtomicGroups)[]
+): string | undefined {
+  if (
+    classNames.length <= 1 &&
+    (!classNames[0] || (typeof classNames[0] === 'string' && classNames[0].indexOf(' ') === -1))
+  ) {
     // short circuit if there's no custom class names.
     return classNames[0] || undefined;
   }
@@ -41,7 +48,16 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
       continue;
     }
 
-    const groups = cls.split(' ');
+    let groups: string[] = [];
+    if (typeof cls === 'string') {
+      groups = cls.split(' ');
+    } else if (Array.isArray(cls)) {
+      groups = cls;
+    } else if (cls instanceof AtomicGroups) {
+      groups = cls.toString().split(' ');
+    } else {
+      // NOTE: Could throw an error here to help understand that this is collecting invalid styles.
+    }
 
     for (let x = 0; x < groups.length; x++) {
       const atomic = groups[x];


### PR DESCRIPTION

I want to allow our `ax()` collection to better handle arbitrary values.  The example being passing using our pass-through styles with `cssMap` like `<Component xcss={cx(…)} />` or `<Component xcss={[…]} />` results in `ax` capturing things like this:
```tsx
[
  '_1bah1yb4',
  undefined,
  ['_16jlkb7n', undefined],
  AtomicGroups {
    values: Map(2) { '_1bsb' => '_1bsb1osq', '_16jl' => '_16jlkb7n' }
  }
]
```

I don't know if it's the best way to handle this, but internally we've just been invoking `toString()` via a wrapper, and we're trying to get to native Compiled.  Makes sense (and works) to me!

### PR checklist

I have...

- [x] Updated or added applicable tests
- [x] Chosen to not document this.
