### PR TITLE
Allow an import of `jsx` from our internal `@atlaskit/css` package for babel plugin pragma resolutions.

### DIFF
--- a/.changeset/hip-dolls-kneel.md
+++ b/.changeset/hip-dolls-kneel.md
@@ -1,0 +1,5 @@
+---
+'@compiled/webpack-loader': minor
+---
+
+Modify the early-exit on our Webpack loader to work with `options.importSources` to properly transform other Compiled aliases.

--- a/.changeset/many-schools-do.md
+++ b/.changeset/many-schools-do.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+Allow an import of `jsx` from our internal `@atlaskit/css` package for babel plugin pragma resolutions.

--- a/packages/babel-plugin/src/__tests__/custom-import-source.test.ts
+++ b/packages/babel-plugin/src/__tests__/custom-import-source.test.ts
@@ -61,6 +61,18 @@ describe('custom import source', () => {
     expect(actual).toInclude('@compiled/react/runtime');
   });
 
+  it('should pick up an automatic pragma from a custom package import source', () => {
+    const actual = transform(
+      `
+        /** @jsxImportSource @af/compiled */
+        <div css={{ color: 'red' }} />
+      `,
+      { filename: './foo/index.js', importSources: ['@af/compiled'] }
+    );
+
+    expect(actual).toInclude('@compiled/react/runtime');
+  });
+
   it("should handle custom package sources that aren't found", () => {
     expect(() =>
       transform(

--- a/packages/babel-plugin/src/__tests__/jsx-automatic.test.ts
+++ b/packages/babel-plugin/src/__tests__/jsx-automatic.test.ts
@@ -1,7 +1,40 @@
 import { transform as transformCode } from '../test-utils';
 
 describe('jsx automatic', () => {
-  const transform = (code: string) => transformCode(code, { importReact: false });
+  const transform: typeof transformCode = (code, options) =>
+    transformCode(code, { ...options, importReact: false });
+
+  it('should work with css prop and a custom import source', () => {
+    const actual = transform(
+      `
+      import { cssMap } from '@af/compiled';
+      const styles = cssMap({ root: { color: 'blue' } });
+
+      <div css={styles.root} />
+    `,
+      { importSources: ['@af/compiled'] }
+    );
+
+    expect(actual).toMatchInlineSnapshot(`
+      "import { ax, ix, CC, CS } from "@compiled/react/runtime";
+      import { jsxs as _jsxs, jsx as _jsx } from "react/jsx-runtime";
+      const _ = "._syaz13q2{color:blue}";
+      const styles = {
+        root: "_syaz13q2",
+      };
+      _jsxs(CC, {
+        children: [
+          _jsx(CS, {
+            children: [_],
+          }),
+          _jsx("div", {
+            className: ax([styles.root]),
+          }),
+        ],
+      });
+      "
+    `);
+  });
 
   it('should work with css prop', () => {
     const actual = transform(`

--- a/packages/babel-plugin/src/babel-plugin.ts
+++ b/packages/babel-plugin/src/babel-plugin.ts
@@ -31,8 +31,7 @@ import { visitXcssPropPath } from './xcss-prop';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const packageJson = require('../package.json');
 const JSX_SOURCE_ANNOTATION_REGEX = /\*?\s*@jsxImportSource\s+([^\s]+)/;
-const COMPILED_IMPORT_SOURCE = '@compiled/react';
-const DEFAULT_IMPORT_SOURCES = [COMPILED_IMPORT_SOURCE, '@atlaskit/css'];
+const DEFAULT_IMPORT_SOURCES = ['@compiled/react', '@atlaskit/css'];
 
 let globalCache: Cache | undefined;
 
@@ -42,7 +41,7 @@ const findClassicJsxPragmaImport: Visitor<State> = {
 
     t.assertImportDeclaration(path.parent);
     // We don't care about other libraries
-    if (path.parent.source.value !== COMPILED_IMPORT_SOURCE) return;
+    if (!this.importSources.includes(path.parent.source.value)) return;
 
     if (
       (specifier.imported.type === 'StringLiteral' && specifier.imported.value === 'jsx') ||
@@ -131,7 +130,7 @@ export default declare<State>((api) => {
 
             // jsxPragmas currently only run on the top-level compiled module,
             // hence we don't interrogate this.importSources.
-            if (jsxSourceMatches && jsxSourceMatches[1] === COMPILED_IMPORT_SOURCE) {
+            if (jsxSourceMatches && this.importSources.includes(jsxSourceMatches[1])) {
               // jsxImportSource pragma found - turn on CSS prop!
               state.compiledImports = {};
               state.pragma.jsxImportSource = true;

--- a/packages/webpack-loader/src/__fixtures__/lib/other-css.ts
+++ b/packages/webpack-loader/src/__fixtures__/lib/other-css.ts
@@ -1,0 +1,1 @@
+export { css, jsx } from '@compiled/react';

--- a/packages/webpack-loader/src/__fixtures__/non-compiled-import-source.tsx
+++ b/packages/webpack-loader/src/__fixtures__/non-compiled-import-source.tsx
@@ -1,0 +1,6 @@
+/** @jsx jsx */
+// @ts-expect-error -- fake package
+import { jsx } from '@other/css';
+
+// @ts-expect-error -- fake package
+export const App = (): JSX.Element => <div css={{ margin: 0 }} />;

--- a/packages/webpack-loader/src/__tests__/test-utils.ts
+++ b/packages/webpack-loader/src/__tests__/test-utils.ts
@@ -17,6 +17,7 @@ export interface BundleOptions {
   mode: 'development' | 'production';
   resolve?: ResolveOptions;
   resolver?: string;
+  importSources?: string[];
 }
 
 export function bundle(
@@ -29,6 +30,7 @@ export function bundle(
     mode,
     resolve = {},
     resolver,
+    importSources,
   }: BundleOptions
 ): Promise<Record<string, string>> {
   const outputPath = join(__dirname, 'dist');
@@ -56,6 +58,7 @@ export function bundle(
               options: {
                 extract,
                 importReact: false,
+                importSources,
                 optimizeCss: false,
                 resolve,
                 resolver,
@@ -86,6 +89,7 @@ export function bundle(
     resolve: {
       alias: {
         'webpack-alias': join(__dirname, '..', '__fixtures__', 'lib', 'webpack-alias.ts'),
+        '@other/css': join(__dirname, '..', '__fixtures__', 'lib', 'other-css.ts'),
       },
       extensions: ['.tsx', '.ts', '.jsx', '.js'],
     },

--- a/packages/webpack-loader/src/compiled-loader.ts
+++ b/packages/webpack-loader/src/compiled-loader.ts
@@ -124,18 +124,19 @@ export default async function compiledLoader(
   code: string
 ): Promise<void> {
   const callback = this.async();
+  const { resolve, ...options } = getLoaderOptions(this);
+  const importSources = ['@compiled/react', ...(options.importSources || [])];
 
-  // Bail early if Compiled isn't in the module or we're looking at compiled runtime code
+  // Bail early if we're looking at Compiled runtime code or Compiled (via an importSource) isn't in the module
   if (
-    code.indexOf('@compiled/react') === -1 ||
-    this.resourcePath.includes('/node_modules/@compiled/react')
+    this.resourcePath.includes('/node_modules/@compiled/react') ||
+    !importSources.some((name) => code.includes(name))
   ) {
     return callback(null, code);
   }
 
   try {
     const includedFiles: string[] = [];
-    const { resolve, ...options } = getLoaderOptions(this);
 
     // Transform to an AST using the local babel config.
     const ast = await parseAsync(code, {


### PR DESCRIPTION
### What is this change?

With https://github.com/atlassian-labs/compiled/pull/1706, I missed the fact that `@compiled/babel-plugin` requires jsx to import from strictly `@compiled/react` and doesn't fully make use of `options.importSources` here either—that pull request passed in tests and one of my dev envs, but not in a real devloop.

Additionally, this configuration had to be added to `@compiled/webpack-plugin` which wraps the Babel Plugin and had a hardcoded early exit.  For context, `@compiled/parcel-plugin` already appears to have this functionality: https://github.com/atlassian-labs/compiled/blob/master/packages/parcel-transformer/src/index.ts#L94 and I believe I've manually reviewed all instances of `'@compiled/react'` being used as a string 🤞

### Why are we making this change?

To enable JSX pragmas from any imported `options.importSources` through Babel and Webpack plugins (and previously ESLint).

---

### PR checklist

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/` (this is already documented)
