### PR TITLE
pin path-to-regexp in examples

### DIFF
--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -7,6 +7,9 @@
     "start": "razzle start",
     "start:prod": "NODE_ENV=production node build/server.js"
   },
+  "resolutions": {
+    "path-to-regexp": "^0.1.10"
+  },
   "dependencies": {
     "@babel/helper-builder-react-jsx": "^7.19.0",
     "@babel/helper-builder-react-jsx-experimental": "^7.12.11",


### PR DESCRIPTION
### What is this change?

Pinning path-to-regexp to resolve vuln in examples