### PR TITLE
Protect `@compiled/react/runtime/style-cache` better in browser distributions.

### DIFF
--- a/.changeset/shy-bees-fly.md
+++ b/.changeset/shy-bees-fly.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Protect @compiled/react/dist/browser/runtime in environments without a document defined.

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime/style-cache.js",
-      "limit": "99B",
+      "limit": "118B",
       "import": "CC",
       "ignore": [
         "react"

--- a/packages/react/src/runtime/style-cache.tsx
+++ b/packages/react/src/runtime/style-cache.tsx
@@ -11,7 +11,7 @@ import type { ProviderComponent, UseCacheHook } from './types';
  */
 const Cache: any = isServerEnvironment() ? createContext<Record<string, true> | null>(null) : {};
 
-if (!isServerEnvironment()) {
+if (!isServerEnvironment() && typeof document !== 'undefined') {
   /**
    * Iterates through all found style elements generated when server side rendering.
    *


### PR DESCRIPTION
Steps to replicate (inside of our internal repo).
1. Add Compiled to an `ssr.test.tsx` with the Atlassian SSR Jest library.
2. Run tests
3. :boom:

This is because our bundler for browser dist transform `isServerEnvironment()` with `false` inline, so if something in/correctly pulls `dist/browser/…` all server tests are skipped.  See: https://github.com/atlassian-labs/compiled/blob/9a15e7420c436ff959e67004b7c6f46bec08f606/packages/react/tsconfig.browser.json#L9

### PR checklist

I don't feel these are applicable:
- [x] ~Updated or added applicable tests~
- [x] ~Updated the documentation in `website/`~
