### PR TITLE
Add the option to provide a prefix to generated class names 

### DIFF
--- a/.changeset/empty-pumpkins-grin.md
+++ b/.changeset/empty-pumpkins-grin.md
@@ -5,4 +5,4 @@
 '@compiled/css': minor
 ---
 
-Adds a new option that can be passed to the babel plugin called `hashPrefix`. Its value is used to add a prefix to generated class names.
+Adds a new option that can be passed to the babel plugin called `classHashPrefix`. Its value is used to add a prefix to the class names when generating their hashes.

--- a/.changeset/empty-pumpkins-grin.md
+++ b/.changeset/empty-pumpkins-grin.md
@@ -1,0 +1,8 @@
+---
+'@compiled/parcel-transformer': minor
+'@compiled/webpack-loader': minor
+'@compiled/babel-plugin': minor
+'@compiled/css': minor
+---
+
+Adds a new option that can be passed to the babel plugin called `hashPrefix`. Its value is used to add a prefix to generated class names.

--- a/packages/babel-plugin/src/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/__tests__/index.test.ts
@@ -205,7 +205,7 @@ describe('babel plugin', () => {
     expect(actual).toInclude('c_MyDiv');
   });
 
-  it.only('should add a prefix to style hash hashPrefix is present', () => {
+  it('should add a prefix to style hash hashPrefix is present', () => {
     const actual = transform(
       `
       import { styled } from '@compiled/react';
@@ -220,7 +220,7 @@ describe('babel plugin', () => {
     expect(actual).toInclude('myprefix');
   });
 
-  it.only('should throw if a given hashPrefix is not a valid css identifier', () => {
+  it('should throw if a given hashPrefix is not a valid css identifier', () => {
     expect(() => {
       transform(
         `

--- a/packages/babel-plugin/src/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/__tests__/index.test.ts
@@ -205,6 +205,36 @@ describe('babel plugin', () => {
     expect(actual).toInclude('c_MyDiv');
   });
 
+  it.only('should add a prefix to style hash hashPrefix is present', () => {
+    const actual = transform(
+      `
+      import { styled } from '@compiled/react';
+
+      const MyDiv = styled.div\`
+        font-size: 12px;
+      \`;
+    `,
+      { hashPrefix: 'myprefix' }
+    );
+
+    expect(actual).toInclude('myprefix');
+  });
+
+  it.only('should throw if a given hashPrefix is not a valid css identifier', () => {
+    expect(() => {
+      transform(
+        `
+        import { styled } from '@compiled/react';
+
+        const MyDiv = styled.div\`
+          font-size: 12px;
+        \`;
+        `,
+        { hashPrefix: '$invalid%' }
+      );
+    }).toThrow();
+  });
+
   it('should compress class name for styled component', () => {
     const actual = transform(
       `

--- a/packages/babel-plugin/src/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/__tests__/index.test.ts
@@ -205,7 +205,7 @@ describe('babel plugin', () => {
     expect(actual).toInclude('c_MyDiv');
   });
 
-  it.only('should add a prefix to style hash hashPrefix is present', () => {
+  it('should add a prefix to style hash classHashPrefix is present', () => {
     // changes to css/src/plugins/atomicify-rules can break this due to how the class name is hashed
     const hashedClassName = '_1lv61fwx';
     const actual = transform(
@@ -216,13 +216,13 @@ describe('babel plugin', () => {
         font-size: 12px;
       \`;
     `,
-      { hashPrefix: 'myprefix' }
+      { classHashPrefix: 'myprefix' }
     );
 
     expect(actual).toInclude(hashedClassName);
   });
 
-  it.only('should throw if a given hashPrefix is not a valid css identifier', () => {
+  it('should throw if a given classHashPrefix is not a valid css identifier', () => {
     expect(() => {
       transform(
         `
@@ -232,7 +232,7 @@ describe('babel plugin', () => {
           font-size: 12px;
         \`;
         `,
-        { hashPrefix: '$invalid%' }
+        { classHashPrefix: '$invalid%' }
       );
     }).toThrow();
   });

--- a/packages/babel-plugin/src/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/__tests__/index.test.ts
@@ -205,7 +205,9 @@ describe('babel plugin', () => {
     expect(actual).toInclude('c_MyDiv');
   });
 
-  it('should add a prefix to style hash hashPrefix is present', () => {
+  it.only('should add a prefix to style hash hashPrefix is present', () => {
+    // changes to css/src/plugins/atomicify-rules can break this due to how the class name is hashed
+    const hashedClassName = '_1lv61fwx';
     const actual = transform(
       `
       import { styled } from '@compiled/react';
@@ -217,10 +219,10 @@ describe('babel plugin', () => {
       { hashPrefix: 'myprefix' }
     );
 
-    expect(actual).toInclude('myprefix');
+    expect(actual).toInclude(hashedClassName);
   });
 
-  it('should throw if a given hashPrefix is not a valid css identifier', () => {
+  it.only('should throw if a given hashPrefix is not a valid css identifier', () => {
     expect(() => {
       transform(
         `

--- a/packages/babel-plugin/src/types.ts
+++ b/packages/babel-plugin/src/types.ts
@@ -103,6 +103,12 @@ export interface PluginOptions {
    * Defaults to `true`.
    */
   sortAtRules?: boolean;
+
+  /**
+   * Adds a defined prefix to the generated classes' hashes.
+   * Useful in micro frontend environments to avoid clashing/specificity issues.
+   */
+  hashPrefix?: string;
 }
 
 export interface State extends PluginPass {

--- a/packages/babel-plugin/src/types.ts
+++ b/packages/babel-plugin/src/types.ts
@@ -108,7 +108,7 @@ export interface PluginOptions {
    * Adds a defined prefix to the generated classes' hashes.
    * Useful in micro frontend environments to avoid clashing/specificity issues.
    */
-  hashPrefix?: string;
+  classHashPrefix?: string;
 }
 
 export interface State extends PluginPass {

--- a/packages/css/src/plugins/atomicify-rules.ts
+++ b/packages/css/src/plugins/atomicify-rules.ts
@@ -34,8 +34,6 @@ const isCssIdentifierValid = (value: string): boolean => {
  *
  * @param node CSS declaration
  * @param opts AtomicifyOpts
- *
- * @throws Throws an error if `opts.classHashPrefix` contains invalid css class/id characters
  */
 const atomicClassName = (node: Declaration, opts: PluginOpts) => {
   const selectors = opts.selectors ? opts.selectors.join('') : '';

--- a/packages/css/src/plugins/atomicify-rules.ts
+++ b/packages/css/src/plugins/atomicify-rules.ts
@@ -19,7 +19,7 @@ interface PluginOpts {
  *
  */
 const isCssIdentifierValid = (value: string): boolean => {
-  const validCssIdentifierRegex = /^[a-zA-Z\-][a-zA-Z\-_0-9]*$/;
+  const validCssIdentifierRegex = /^[a-zA-Z\-_]+[a-zA-Z\-_0-9]*$/;
   return Boolean(value.match(validCssIdentifierRegex));
 };
 
@@ -38,12 +38,6 @@ const isCssIdentifierValid = (value: string): boolean => {
  * @throws Throws an error if `opts.classHashPrefix` contains invalid css class/id characters
  */
 const atomicClassName = (node: Declaration, opts: PluginOpts) => {
-  if (opts.classHashPrefix && !isCssIdentifierValid(opts.classHashPrefix)) {
-    throw new Error(
-      `${opts.classHashPrefix} isn't a valid CSS identifier. Accepted characters are [a-zA-Z][a-zA-Z\-_0-9]`
-    );
-  }
-
   const selectors = opts.selectors ? opts.selectors.join('') : '';
   const prefix = opts.classHashPrefix ?? '';
   const group = hash(`${prefix}${opts.atRule}${selectors}${node.prop}`).slice(0, 4);
@@ -283,8 +277,16 @@ const atomicifyAtRule = (node: AtRule, opts: PluginOpts): AtRule => {
  * Preconditions:
  *
  * 1. No nested rules allowed - normalize them with the `parent-orphaned-pseudos` and `nested` plugins first.
+ *
+ * @throws Throws an error if `opts.classHashPrefix` contains invalid css class/id characters
  */
 export const atomicifyRules = (opts: PluginOpts = {}): Plugin => {
+  if (opts.classHashPrefix && !isCssIdentifierValid(opts.classHashPrefix)) {
+    throw new Error(
+      `${opts.classHashPrefix} isn't a valid CSS identifier. Accepted characters are ^[a-zA-Z\-_]+[a-zA-Z\-_0-9]*$`
+    );
+  }
+
   return {
     postcssPlugin: 'atomicify-rules',
     OnceExit(root) {

--- a/packages/css/src/plugins/atomicify-rules.ts
+++ b/packages/css/src/plugins/atomicify-rules.ts
@@ -45,11 +45,13 @@ const atomicClassName = (node: Declaration, opts: PluginOpts) => {
   }
 
   const selectors = opts.selectors ? opts.selectors.join('') : '';
-  const group = hash(`${opts.atRule}${selectors}${node.prop}`).slice(0, 4);
+  const prefix = opts.hashPrefix ?? '';
+  const group = hash(`${prefix}${opts.atRule}${selectors}${node.prop}`).slice(0, 4);
+
   const value = node.important ? node.value + node.important : node.value;
   const valueHash = hash(value).slice(0, 4);
 
-  return `_${opts.hashPrefix ?? ''}${group}${valueHash}`;
+  return `_${group}${valueHash}`;
 };
 
 /**

--- a/packages/css/src/plugins/atomicify-rules.ts
+++ b/packages/css/src/plugins/atomicify-rules.ts
@@ -20,7 +20,7 @@ interface PluginOpts {
  */
 const isCssIdentifierValid = (value: string): boolean => {
   const validCssIdentifierRegex = /^[a-zA-Z\-_]+[a-zA-Z\-_0-9]*$/;
-  return Boolean(value.match(validCssIdentifierRegex));
+  return validCssIdentifierRegex.test(value);
 };
 
 /**

--- a/packages/css/src/plugins/atomicify-rules.ts
+++ b/packages/css/src/plugins/atomicify-rules.ts
@@ -8,7 +8,7 @@ interface PluginOpts {
   selectors?: string[];
   atRule?: string;
   parentNode?: Container;
-  hashPrefix?: string;
+  classHashPrefix?: string;
 }
 
 /**
@@ -35,17 +35,17 @@ const isCssIdentifierValid = (value: string): boolean => {
  * @param node CSS declaration
  * @param opts AtomicifyOpts
  *
- * @throws Throws an error if `opts.hashPrefix` contains invalid css class/id characters
+ * @throws Throws an error if `opts.classHashPrefix` contains invalid css class/id characters
  */
 const atomicClassName = (node: Declaration, opts: PluginOpts) => {
-  if (opts.hashPrefix && !isCssIdentifierValid(opts.hashPrefix)) {
+  if (opts.classHashPrefix && !isCssIdentifierValid(opts.classHashPrefix)) {
     throw new Error(
-      `${opts.hashPrefix} isn't a valid CSS identifier. Accepted characters are [a-zA-Z][a-zA-Z\-_0-9]`
+      `${opts.classHashPrefix} isn't a valid CSS identifier. Accepted characters are [a-zA-Z][a-zA-Z\-_0-9]`
     );
   }
 
   const selectors = opts.selectors ? opts.selectors.join('') : '';
-  const prefix = opts.hashPrefix ?? '';
+  const prefix = opts.classHashPrefix ?? '';
   const group = hash(`${prefix}${opts.atRule}${selectors}${node.prop}`).slice(0, 4);
 
   const value = node.important ? node.value + node.important : node.value;

--- a/packages/css/src/plugins/atomicify-rules.ts
+++ b/packages/css/src/plugins/atomicify-rules.ts
@@ -8,7 +8,20 @@ interface PluginOpts {
   selectors?: string[];
   atRule?: string;
   parentNode?: Container;
+  hashPrefix?: string;
 }
+
+/**
+ * Returns true if a given string is a valid CSS identifier
+ *
+ * @param value the value to test
+ * @returns `true` if given value is valid, `false` if not
+ *
+ */
+const isCssIdentifierValid = (value: string): boolean => {
+  const validCssIdentifierRegex = /^[a-zA-Z\-][a-zA-Z\-_0-9]*$/;
+  return Boolean(value.match(validCssIdentifierRegex));
+};
 
 /**
  * Returns an atomic rule class name using this form:
@@ -21,14 +34,22 @@ interface PluginOpts {
  *
  * @param node CSS declaration
  * @param opts AtomicifyOpts
+ *
+ * @throws Throws an error if `opts.hashPrefix` contains invalid css class/id characters
  */
 const atomicClassName = (node: Declaration, opts: PluginOpts) => {
+  if (opts.hashPrefix && !isCssIdentifierValid(opts.hashPrefix)) {
+    throw new Error(
+      `${opts.hashPrefix} isn't a valid CSS identifier. Accepted characters are [a-zA-Z][a-zA-Z\-_0-9]`
+    );
+  }
+
   const selectors = opts.selectors ? opts.selectors.join('') : '';
   const group = hash(`${opts.atRule}${selectors}${node.prop}`).slice(0, 4);
   const value = node.important ? node.value + node.important : node.value;
   const valueHash = hash(value).slice(0, 4);
 
-  return `_${group}${valueHash}`;
+  return `_${opts.hashPrefix ?? ''}${group}${valueHash}`;
 };
 
 /**

--- a/packages/css/src/transform.ts
+++ b/packages/css/src/transform.ts
@@ -20,7 +20,7 @@ export interface TransformOpts {
   increaseSpecificity?: boolean;
   sortAtRules?: boolean;
   sortShorthand?: boolean;
-  hashPrefix?: string;
+  classHashPrefix?: string;
 }
 
 /**
@@ -50,7 +50,7 @@ export const transformCss = (
       atomicifyRules({
         classNameCompressionMap: opts.classNameCompressionMap,
         callback: (className: string) => classNames.push(className),
-        hashPrefix: opts.hashPrefix,
+        classHashPrefix: opts.classHashPrefix,
       }),
       ...(opts.increaseSpecificity ? [increaseSpecificity()] : []),
       sortAtomicStyleSheet({

--- a/packages/css/src/transform.ts
+++ b/packages/css/src/transform.ts
@@ -20,6 +20,7 @@ export interface TransformOpts {
   increaseSpecificity?: boolean;
   sortAtRules?: boolean;
   sortShorthand?: boolean;
+  hashPrefix?: string;
 }
 
 /**
@@ -49,6 +50,7 @@ export const transformCss = (
       atomicifyRules({
         classNameCompressionMap: opts.classNameCompressionMap,
         callback: (className: string) => classNames.push(className),
+        hashPrefix: opts.hashPrefix,
       }),
       ...(opts.increaseSpecificity ? [increaseSpecificity()] : []),
       sortAtomicStyleSheet({

--- a/packages/parcel-transformer/src/types.ts
+++ b/packages/parcel-transformer/src/types.ts
@@ -67,4 +67,10 @@ export interface ParcelTransformerOpts extends BabelPluginOpts {
    * When set, extract styles to an external CSS file
    */
   extractStylesToDirectory?: { source: string; dest: string };
+
+  /**
+   * Adds a defined prefix to the generated classes' hashes.
+   * Useful in micro frontend environments to avoid clashing/specificity issues.
+   */
+  hashPrefix?: string;
 }

--- a/packages/parcel-transformer/src/types.ts
+++ b/packages/parcel-transformer/src/types.ts
@@ -72,5 +72,5 @@ export interface ParcelTransformerOpts extends BabelPluginOpts {
    * Adds a defined prefix to the generated classes' hashes.
    * Useful in micro frontend environments to avoid clashing/specificity issues.
    */
-  hashPrefix?: string;
+  classHashPrefix?: string;
 }

--- a/packages/webpack-loader/src/types.ts
+++ b/packages/webpack-loader/src/types.ts
@@ -142,4 +142,10 @@ export interface CompiledExtractPluginOptions {
    * Defaults to `false`.
    */
   sortShorthand?: boolean;
+
+  /**
+   * Adds a defined prefix to the generated classes' hashes.
+   * Useful in micro frontend environments to avoid clashing/specificity issues.
+   */
+  hashPrefix?: string;
 }

--- a/packages/webpack-loader/src/types.ts
+++ b/packages/webpack-loader/src/types.ts
@@ -147,5 +147,5 @@ export interface CompiledExtractPluginOptions {
    * Adds a defined prefix to the generated classes' hashes.
    * Useful in micro frontend environments to avoid clashing/specificity issues.
    */
-  hashPrefix?: string;
+  classHashPrefix?: string;
 }

--- a/website/packages/docs/src/pages/pkg-babel-plugin.mdx
+++ b/website/packages/docs/src/pages/pkg-babel-plugin.mdx
@@ -49,6 +49,7 @@ If you choose to configure Compiled through Webpack or Parcel (recommended), you
 - `cache`
 - `classNameCompressionMap`
 - `extensions`
+- `hashPrefix`
 - `importReact`
 - `importSources`
 - `increaseSpecificity`
@@ -92,6 +93,15 @@ Extensions that we should consider code. We use these to identify if a file shou
 
 - Type: `string[]`
 - Default: `['.js', '.jsx', '.ts', '.tsx']`
+
+#### hashPrefix
+
+Adds a prefix to the generated hashed css rule names.
+
+This is useful when `@compiled` is being used in a micro frontend environment by multiple packages and you want to avoid specificity issues.
+
+- Type: `string`
+- Default: `undefined`
 
 #### importReact
 

--- a/website/packages/docs/src/pages/pkg-babel-plugin.mdx
+++ b/website/packages/docs/src/pages/pkg-babel-plugin.mdx
@@ -96,9 +96,11 @@ Extensions that we should consider code. We use these to identify if a file shou
 
 #### classHashPrefix
 
-Adds a prefix to the generated hashed css rule names.
+Adds a prefix to the generated hashed css rule names. The valued passed to it gets hashed in conjunction with the rest of the rule declaration.
 
 This is useful when `@compiled` is being used in a micro frontend environment by multiple packages and you want to avoid specificity issues.
+
+The currently accepted regex for this value is `^[a-zA-Z\-_]+[a-zA-Z\-_0-9]*$`.
 
 - Type: `string`
 - Default: `undefined`

--- a/website/packages/docs/src/pages/pkg-babel-plugin.mdx
+++ b/website/packages/docs/src/pages/pkg-babel-plugin.mdx
@@ -49,7 +49,7 @@ If you choose to configure Compiled through Webpack or Parcel (recommended), you
 - `cache`
 - `classNameCompressionMap`
 - `extensions`
-- `hashPrefix`
+- `classHashPrefix`
 - `importReact`
 - `importSources`
 - `increaseSpecificity`
@@ -94,7 +94,7 @@ Extensions that we should consider code. We use these to identify if a file shou
 - Type: `string[]`
 - Default: `['.js', '.jsx', '.ts', '.tsx']`
 
-#### hashPrefix
+#### classHashPrefix
 
 Adds a prefix to the generated hashed css rule names.
 

--- a/website/packages/docs/src/pages/pkg-babel-plugin.mdx
+++ b/website/packages/docs/src/pages/pkg-babel-plugin.mdx
@@ -47,9 +47,9 @@ If you choose to configure Compiled through Webpack or Parcel (recommended), you
 
 - `addComponentName`
 - `cache`
+- `classHashPrefix`
 - `classNameCompressionMap`
 - `extensions`
-- `classHashPrefix`
 - `importReact`
 - `importSources`
 - `increaseSpecificity`
@@ -79,6 +79,17 @@ Will cache the result of statically evaluated imports.
 * Type: `boolean | 'single-pass'`
 * Default: `true`
 
+#### classHashPrefix
+
+Adds a prefix to the generated hashed css rule names. The valued passed to it gets hashed in conjunction with the rest of the rule declaration.
+
+This is useful when `@compiled` is being used in a micro frontend environment by multiple packages and you want to avoid specificity issues.
+
+The currently accepted regex for this value is `^[a-zA-Z\-_]+[a-zA-Z\-_0-9]*$`.
+
+- Type: `string`
+- Default: `undefined`
+
 #### classNameCompressionMap
 
 Don't use this!
@@ -93,17 +104,6 @@ Extensions that we should consider code. We use these to identify if a file shou
 
 - Type: `string[]`
 - Default: `['.js', '.jsx', '.ts', '.tsx']`
-
-#### classHashPrefix
-
-Adds a prefix to the generated hashed css rule names. The valued passed to it gets hashed in conjunction with the rest of the rule declaration.
-
-This is useful when `@compiled` is being used in a micro frontend environment by multiple packages and you want to avoid specificity issues.
-
-The currently accepted regex for this value is `^[a-zA-Z\-_]+[a-zA-Z\-_0-9]*$`.
-
-- Type: `string`
-- Default: `undefined`
 
 #### importReact
 

--- a/website/packages/docs/src/pages/pkg-parcel-config.mdx
+++ b/website/packages/docs/src/pages/pkg-parcel-config.mdx
@@ -208,7 +208,7 @@ The following options are passed directly to `@compiled/babel-plugin`:
 
 - `addComponentName`
 - `classNameCompressionMap`
-- `hashPrefix`
+- `classHashPrefix`
 - `importReact`
 - `importSources`
 - `optimizeCss`

--- a/website/packages/docs/src/pages/pkg-parcel-config.mdx
+++ b/website/packages/docs/src/pages/pkg-parcel-config.mdx
@@ -207,8 +207,8 @@ Example usage:
 The following options are passed directly to `@compiled/babel-plugin`:
 
 - `addComponentName`
-- `classNameCompressionMap`
 - `classHashPrefix`
+- `classNameCompressionMap`
 - `importReact`
 - `importSources`
 - `optimizeCss`

--- a/website/packages/docs/src/pages/pkg-parcel-config.mdx
+++ b/website/packages/docs/src/pages/pkg-parcel-config.mdx
@@ -208,6 +208,7 @@ The following options are passed directly to `@compiled/babel-plugin`:
 
 - `addComponentName`
 - `classNameCompressionMap`
+- `hashPrefix`
 - `importReact`
 - `importSources`
 - `optimizeCss`

--- a/website/packages/docs/src/pages/pkg-webpack-loader.mdx
+++ b/website/packages/docs/src/pages/pkg-webpack-loader.mdx
@@ -211,8 +211,8 @@ module.exports = {
 `@compiled/webpack-loader` also accepts the following options. These are not used in the loader itself, but instead they are passed directly to the underlying `@compiled/babel-plugin`.
 
 - `addComponentName`
-- `classNameCompressionMap`
 - `classHashPrefix`
+- `classNameCompressionMap`
 - `importReact`
 - `importSources`
 - `nonce`

--- a/website/packages/docs/src/pages/pkg-webpack-loader.mdx
+++ b/website/packages/docs/src/pages/pkg-webpack-loader.mdx
@@ -212,7 +212,7 @@ module.exports = {
 
 - `addComponentName`
 - `classNameCompressionMap`
-- `hashPrefix`
+- `classHashPrefix`
 - `importReact`
 - `importSources`
 - `nonce`

--- a/website/packages/docs/src/pages/pkg-webpack-loader.mdx
+++ b/website/packages/docs/src/pages/pkg-webpack-loader.mdx
@@ -212,6 +212,7 @@ module.exports = {
 
 - `addComponentName`
 - `classNameCompressionMap`
+- `hashPrefix`
 - `importReact`
 - `importSources`
 - `nonce`


### PR DESCRIPTION
### What is this change?

This PR introduces a new configuration prop to `@compiled/babel-plugin` named `classHashPrefix` (feel free to suggest a better alternative) that allows users to define a prefix to be added to when generating class name hashes. 

### Why are we making this change?

We have an internal problem in a consumer of a remote module where it has its styles messed up due to the loss of specificity once the remote module is loaded. This is because both the wrapping application and the remote module use `@compiled` and due to the way we generate the class names, both end up generating a few with the same name. 

### How are we making this change?

This is the first time I ever work with a Babel plugin so I might be missing something, all feedback is appreciated. I tried to follow the code and tests to figure out where we were generating the hashes and hooked it up with the new config prop. 

Lastly, I only worked off of tests on this, guidance on how to better test it are welcomed 😅 

~_edit:_ I assume I'm probably missing a changeset on this pr~ done

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
