### PR TITLE
Fix shorthand sorting buggy

### DIFF
--- a/.changeset/witty-bags-complain.md
+++ b/.changeset/witty-bags-complain.md
@@ -1,0 +1,5 @@
+---
+'@compiled/css': patch
+---
+
+Fix shorthand sorting not working most of the time, when stylesheet extraction is turned on.

--- a/.changeset/witty-bags-complain.md
+++ b/.changeset/witty-bags-complain.md
@@ -1,5 +1,5 @@
 ---
-'@compiled/css': patch
+'@compiled/css': minor
 ---
 
 Fix shorthand sorting not working most of the time, when stylesheet extraction is turned on.

--- a/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
+++ b/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
@@ -36,8 +36,8 @@ describe('sort shorthand vs. longhand declarations', () => {
 
     expect(actual).toMatchInlineSnapshot(`
       ".a {
-        outline-width: 1px;
         font: 16px;
+        outline-width: 1px;
       }
       .b {
         font: 24px;
@@ -69,8 +69,8 @@ describe('sort shorthand vs. longhand declarations', () => {
     expect(actual).toMatchInlineSnapshot(`
       ".a {
         outline: none;
-        outline-width: 1px;
         font: 16px normal;
+        outline-width: 1px;
         font-weight: bold;
       }
       .b {
@@ -147,8 +147,8 @@ describe('sort shorthand vs. longhand declarations', () => {
 
       .a {
         outline: none;
-        outline-width: 1px;
         font: 16px normal;
+        outline-width: 1px;
         font-weight: bold;
       }
       .b {
@@ -162,14 +162,14 @@ describe('sort shorthand vs. longhand declarations', () => {
 
       .a:focus {
         outline: none;
-        outline-width: 1px;
         font: 16px normal;
+        outline-width: 1px;
         font-weight: bold;
       }@media all {
         .a {
           outline: none;
-          outline-width: 1px;
           font: 16px normal;
+          outline-width: 1px;
           font-weight: bold;
         }
         .b {
@@ -284,10 +284,10 @@ describe('sort shorthand vs. longhand declarations', () => {
 
     expect(actual).toMatchInlineSnapshot(`
       "
-      .a {
+      .a > .external {
         all: unset;
       }
-      .a > .external {
+      .a {
         all: unset;
       }
       .b[disabled] {
@@ -308,18 +308,21 @@ describe('sort shorthand vs. longhand declarations', () => {
       .c[data-foo='bar'] {
         border-top: none;
       }
+      .d {
+        border-top: none;
+      }
+      .c {
+        border-block-start: none;
+      }
+      .d:active {
+        border-block-start: none;
+      }
 
       .j {
         margin-bottom: 6px;
       }
       .f {
         display: block;
-      }
-      .d {
-        border-top: none;
-      }
-      .c {
-        border-block-start: none;
       }
       .e {
         border-block-start-color: transparent;
@@ -328,17 +331,11 @@ describe('sort shorthand vs. longhand declarations', () => {
       .f:focus {
         display: block;
       }
-      .d:active {
-        border-block-start: none;
-      }
       .e:hover {
         border-block-start-color: transparent;
       }@media all {
         .a {
           all: unset;
-        }
-        .f {
-          display: block;
         }
         .b {
           border: none;
@@ -348,6 +345,9 @@ describe('sort shorthand vs. longhand declarations', () => {
         }
         .c {
           border-block-start: none;
+        }
+        .f {
+          display: block;
         }
         .e {
           border-block-start-color: transparent;
@@ -386,10 +386,58 @@ describe('sort shorthand vs. longhand declarations', () => {
         border-block-start: 1px solid;
         border-block-start-color: transparent;
       }
-      .b { all: unset; }
       .c { all: unset; }
+      .b { all: unset; }
       .d { border: none; }
       .f { border-block-start-color: transparent; }"
+    `);
+  });
+
+  it('sorts a subset of atomic classes taken from a real stylesheet', () => {
+    const actual = transform(outdent`
+      ._oqicidpf{padding-top:0}
+      ._1rmjidpf{padding-right:0}
+      ._cjbtidpf{padding-bottom:0}
+      ._pnmbidpf{padding-left:0}
+      ._glte7vkz{width:1pc}
+      ._165t7vkz{height:1pc}
+      ._ue5g1408{margin:0 var(--ds-space-800,4pc)}
+      ._1yag1dzv{padding:var(--ds-space-100) var(--ds-space-150)}
+      ._dbjg12x7{margin-top:var(--ds-space-075,6px)}
+
+      @media (min-width:1200px){
+        ._jvpg11p5{display:grid}
+        ._szna1wug{margin-top:auto}
+        ._13on1wug{margin-right:auto}
+        ._1f3k1wug{margin-bottom:auto}
+        ._inid1wug{margin-left:auto}
+        ._1oqj1epz{padding:var(--ds-space-1000,5pc)}
+        ._12wp9ac1{max-width:1400px}
+        ._jvpgglyw{display:none}
+      }
+    `);
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+      ._ue5g1408{margin:0 var(--ds-space-800,4pc)}
+      ._1yag1dzv{padding:var(--ds-space-100) var(--ds-space-150)}._oqicidpf{padding-top:0}
+      ._1rmjidpf{padding-right:0}
+      ._cjbtidpf{padding-bottom:0}
+      ._pnmbidpf{padding-left:0}
+      ._glte7vkz{width:1pc}
+      ._165t7vkz{height:1pc}
+      ._dbjg12x7{margin-top:var(--ds-space-075,6px)}
+
+      @media (min-width:1200px){
+        ._1oqj1epz{padding:var(--ds-space-1000,5pc)}
+        ._jvpg11p5{display:grid}
+        ._szna1wug{margin-top:auto}
+        ._13on1wug{margin-right:auto}
+        ._1f3k1wug{margin-bottom:auto}
+        ._inid1wug{margin-left:auto}
+        ._12wp9ac1{max-width:1400px}
+        ._jvpgglyw{display:none}
+      }"
     `);
   });
 

--- a/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
+++ b/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
@@ -393,7 +393,7 @@ describe('sort shorthand vs. longhand declarations', () => {
     `);
   });
 
-  it('sorts a subset of atomic classes taken from a real stylesheet', () => {
+  it('sorts a stylesheet that is mainly longhand properties', () => {
     const actual = transform(outdent`
       ._oqicidpf{padding-top:0}
       ._1rmjidpf{padding-right:0}
@@ -437,6 +437,60 @@ describe('sort shorthand vs. longhand declarations', () => {
         ._inid1wug{margin-left:auto}
         ._12wp9ac1{max-width:1400px}
         ._jvpgglyw{display:none}
+      }"
+    `);
+  });
+
+  it('sorts border, border-top, border-top-color', () => {
+    const actual = transform(outdent`
+
+      ._abcd1234 { border-top-color: red }
+      ._abcd1234 { border-top: 1px solid }
+      ._abcd1234 { border: none }
+      ._abcd1234:hover { border-top-color: red }
+      ._abcd1234:hover { border-top: 1px solid }
+      ._abcd1234:hover { border: none }
+      ._abcd1234:active { border-top-color: red }
+      ._abcd1234:active { border-top: 1px solid }
+      ._abcd1234:active { border: none }
+      @supports (border: none) {
+        ._abcd1234 { border-top-color: red }
+        ._abcd1234 { border-top: 1px solid }
+        ._abcd1234 { border: none }
+      }
+      @media (max-width: 50px) { ._abcd1234 { border-top-color: red } }
+      @media (max-width: 100px) { ._abcd1234 { border-top: 1px solid } }
+      @media (max-width: 120px) {
+        ._abcd1234 { border-top-color: red }
+        ._abcd1234 { border-top: 1px solid }
+        ._abcd1234 { border: none }
+      }
+      @media (max-width: 150px) { ._abcd1234 { border: none } }
+    `);
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+      ._abcd1234 { border: none }
+      ._abcd1234:hover { border: none }
+      ._abcd1234:active { border: none }
+      ._abcd1234 { border-top: 1px solid }
+      ._abcd1234:hover { border-top: 1px solid }
+      ._abcd1234:active { border-top: 1px solid }
+      ._abcd1234 { border-top-color: red }
+      ._abcd1234:hover { border-top-color: red }
+      ._abcd1234:active { border-top-color: red }
+      @media (max-width: 150px) { ._abcd1234 { border: none } }
+      @media (max-width: 120px) {
+        ._abcd1234 { border: none }
+        ._abcd1234 { border-top: 1px solid }
+        ._abcd1234 { border-top-color: red }
+      }
+      @media (max-width: 100px) { ._abcd1234 { border-top: 1px solid } }
+      @media (max-width: 50px) { ._abcd1234 { border-top-color: red } }
+      @supports (border: none) {
+        ._abcd1234 { border: none }
+        ._abcd1234 { border-top: 1px solid }
+        ._abcd1234 { border-top-color: red }
       }"
     `);
   });

--- a/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
+++ b/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
@@ -210,6 +210,7 @@ describe('sort shorthand vs. longhand declarations', () => {
 
   it('sorts a variety of different shorthand properties used together', () => {
     const actual = transform(outdent`
+
       @media all {
         .f {
           display: block;
@@ -314,9 +315,6 @@ describe('sort shorthand vs. longhand declarations', () => {
       .c {
         border-block-start: none;
       }
-      .d:active {
-        border-block-start: none;
-      }
 
       .j {
         margin-bottom: 6px;
@@ -333,7 +331,11 @@ describe('sort shorthand vs. longhand declarations', () => {
       }
       .e:hover {
         border-block-start-color: transparent;
-      }@media all {
+      }
+      .d:active {
+        border-block-start: none;
+      }
+      @media all {
         .a {
           all: unset;
         }
@@ -471,13 +473,13 @@ describe('sort shorthand vs. longhand declarations', () => {
     expect(actual).toMatchInlineSnapshot(`
       "
       ._abcd1234 { border: none }
-      ._abcd1234:hover { border: none }
-      ._abcd1234:active { border: none }
       ._abcd1234 { border-top: 1px solid }
-      ._abcd1234:hover { border-top: 1px solid }
-      ._abcd1234:active { border-top: 1px solid }
       ._abcd1234 { border-top-color: red }
+      ._abcd1234:hover { border: none }
+      ._abcd1234:hover { border-top: 1px solid }
       ._abcd1234:hover { border-top-color: red }
+      ._abcd1234:active { border: none }
+      ._abcd1234:active { border-top: 1px solid }
       ._abcd1234:active { border-top-color: red }
       @media (max-width: 150px) { ._abcd1234 { border: none } }
       @media (max-width: 120px) {

--- a/packages/css/src/plugins/sort-atomic-style-sheet.ts
+++ b/packages/css/src/plugins/sort-atomic-style-sheet.ts
@@ -87,6 +87,14 @@ export const sortAtomicStyleSheet = (config: {
         }
       });
 
+      if (sortShorthandEnabled) {
+        sortShorthandDeclarations(catchAll);
+        sortShorthandDeclarations(rules);
+        sortShorthandDeclarations(atRules.map((atRule) => atRule.node));
+      }
+
+      // Pseudo-selector and at-rule sorting takes priority over shorthand
+      // property sorting.
       sortPseudoSelectors(rules);
       if (sortAtRulesEnabled) {
         atRules.sort(sortAtRules);
@@ -101,10 +109,6 @@ export const sortAtomicStyleSheet = (config: {
       }
 
       root.nodes = [...catchAll, ...rules, ...atRules.map((atRule) => atRule.node)];
-
-      if (sortShorthandEnabled) {
-        sortShorthandDeclarations(root.nodes);
-      }
     },
   };
 };

--- a/packages/css/src/plugins/sort-shorthand-declarations.ts
+++ b/packages/css/src/plugins/sort-shorthand-declarations.ts
@@ -3,7 +3,7 @@ import type { ChildNode, Declaration } from 'postcss';
 
 const nodeIsDeclaration = (node: ChildNode): node is Declaration => node.type === 'decl';
 
-const findDeclaration = (node: ChildNode): Declaration | Declaration[] | undefined => {
+const findDeclaration = (node: ChildNode): Declaration | undefined => {
   if (nodeIsDeclaration(node)) {
     return node;
   }
@@ -12,14 +12,6 @@ const findDeclaration = (node: ChildNode): Declaration | Declaration[] | undefin
     if (node.nodes.length === 1 && nodeIsDeclaration(node.nodes[0])) {
       return node.nodes[0];
     }
-
-    const declarations = node.nodes.map(findDeclaration).filter(Boolean) as Declaration[];
-
-    if (declarations.length === 1) {
-      return declarations[0];
-    }
-
-    return declarations;
   }
 
   return undefined;
@@ -29,12 +21,10 @@ const sortNodes = (a: ChildNode, b: ChildNode): number => {
   const aDecl = findDeclaration(a);
   const bDecl = findDeclaration(b);
 
-  // Don't worry about any array of declarations, this would be something like a group of
-  // AtRule versus a regular Rule.
-  //
-  // Those are sorted elsewhere…
-  if (Array.isArray(aDecl) || Array.isArray(bDecl)) return 0;
-
+  // This will probably happen because we have an AtRule being compared to a regular
+  // Rule. Don't try to sort this - the *contents* of the AtRule will be traversed and
+  // sorted by sortShorthandDeclarations, and the sort-at-rules plugin will sort AtRules
+  // so they come after regular rules.
   if (!aDecl?.prop || !bDecl?.prop) return 0;
 
   // Why default to Infinity? Because if the property is not a shorthand property,

--- a/packages/css/src/plugins/sort-shorthand-declarations.ts
+++ b/packages/css/src/plugins/sort-shorthand-declarations.ts
@@ -1,4 +1,4 @@
-import { shorthandBuckets, shorthandFor, type ShorthandProperties } from '@compiled/utils';
+import { shorthandBuckets, type ShorthandProperties } from '@compiled/utils';
 import type { ChildNode, Declaration } from 'postcss';
 
 const nodeIsDeclaration = (node: ChildNode): node is Declaration => node.type === 'decl';

--- a/packages/css/src/plugins/sort-shorthand-declarations.ts
+++ b/packages/css/src/plugins/sort-shorthand-declarations.ts
@@ -37,31 +37,19 @@ const sortNodes = (a: ChildNode, b: ChildNode): number => {
 
   if (!aDecl?.prop || !bDecl?.prop) return 0;
 
-  const aShorthand = shorthandFor[aDecl.prop as ShorthandProperties];
-  if (aShorthand === true || aShorthand?.includes(bDecl.prop)) {
-    return -1;
-  }
-
-  const bShorthand = shorthandFor[bDecl.prop as ShorthandProperties];
-  if (bShorthand === true || bShorthand?.includes(aDecl.prop)) {
-    return 1;
-  }
-
-  const aShorthandBucket = shorthandBuckets[aDecl.prop as ShorthandProperties];
-  const bShorthandBucket = shorthandBuckets[bDecl.prop as ShorthandProperties];
+  // Why default to Infinity? Because if the property is not a shorthand property,
+  // we want it to come after all of the other shorthand properties.
+  const aShorthandBucket = shorthandBuckets[aDecl.prop as ShorthandProperties] ?? Infinity;
+  const bShorthandBucket = shorthandBuckets[bDecl.prop as ShorthandProperties] ?? Infinity;
 
   // Ensures a deterministic sorting of shorthand properties in the case where those
   // shorthand properties overlap.
   //
   // For example, `border-top` and `border-color` are not shorthand properties of
   // each other, BUT both properties are shorthand versions of `border-top-color`.
-  // If `border-top` is in bucket 12 and `border-color` is in bucket 6, we can ensure
+  // If `border-top` is in bucket 4 and `border-color` is in bucket 2, we can ensure
   // that `border-color` always comes before `border-top`.
-  if (aShorthandBucket && bShorthandBucket) {
-    return aShorthandBucket - bShorthandBucket;
-  }
-
-  return 0;
+  return aShorthandBucket - bShorthandBucket;
 };
 
 export const sortShorthandDeclarations = (nodes: ChildNode[]): void => {

--- a/packages/css/src/sort.ts
+++ b/packages/css/src/sort.ts
@@ -8,14 +8,22 @@ import { sortAtomicStyleSheet } from './plugins/sort-atomic-style-sheet';
  * Sorts an atomic style sheet.
  *
  * @param stylesheet
- * @returns
+ * @returns the sorted stylesheet
  */
 export function sort(
   stylesheet: string,
   {
     sortAtRulesEnabled,
     sortShorthandEnabled,
-  }: { sortAtRulesEnabled: boolean | undefined; sortShorthandEnabled: boolean | undefined }
+  }: { sortAtRulesEnabled: boolean | undefined; sortShorthandEnabled: boolean | undefined } = {
+    // These default values should remain undefined so we don't override the default
+    // values set in packages/css/src/plugins/sort-atomic-style-sheet.ts
+    //
+    // Modify packages/css/src/plugins/sort-atomic-style-sheet.ts if you want to
+    // update the actual default values for sortAtRulesEnabled and sortShortEnabled.
+    sortAtRulesEnabled: undefined,
+    sortShorthandEnabled: undefined,
+  }
 ): string {
   const result = postcss([
     discardDuplicates(),


### PR DESCRIPTION
### What is this change?

Fix the shorthand property sorting being buggy when not using runtime mode (e.g. when using stylesheet extraction).

### Why are we making this change?

@kylorhall-atlassian and I noticed that `sortShorthand` wasn't actually sorting the properties as it should.

It turns out that a lot of the time in the sorting algorithm, the two properties being compared are

* not related to each other (e.g. `padding` is related to `paddingLeft`, but `padding` is not related to `borderColor`), and
* one of the properties is a longhand property that doesn't exist in `shorthandBuckets`

As a result, there are cases where the stylesheet would not be sorted _at all_, simply because the wrong nodes were being compared and so the `sortNodes` function returns `0` every time.

### How are we making this change?

Fix and simplify the `sortNodes` function:

* Remove the logic of checking whether one property is a shorthand of another. It is safe to assume that this logic evaluates to `false` most of the time anyway.
* In `aShorthandBucket` and `bShorthandBucket`, set the default value to `Infinity`. This way, if one property is a shorthand property and the other property is not a shorthand property, we guarantee that the shorthand property will come in front. For example, `margin` will come before `paddingRight` (even though they're not related).

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Verify the changes to existing tests are correct
- [x] Updated the documentation in `website/`
- [x] Verify that this PR fixes the lack of shorthand sorting in Jira
- [x] Address this PR comment from Kylor: https://github.com/atlassian-labs/compiled/pull/1730#discussion_r1809966320
- [x] Add changeset