### PR TITLE
Sort shorthand across multi-properties

### DIFF
--- a/.changeset/heavy-actors-appear.md
+++ b/.changeset/heavy-actors-appear.md
@@ -1,0 +1,5 @@
+---
+'@compiled/css': patch
+---
+
+Fix sortShorthand when mixed with multi-property classes such as `._1jmq18uv{-webkit-text-decoration-color:initial;text-decoration-color:initial}` (previously, these broke sorting as they exited early).

--- a/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
+++ b/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
@@ -20,6 +20,104 @@ describe('sort shorthand vs. longhand declarations', () => {
     process.env.BROWSERSLIST = 'last 1 version';
   });
 
+  it('sorts against multi-property classes', () => {
+    const actual = transform(outdent`
+      ._zulph461{gap:var(--ds-space-050)}
+      ._y44v1tgl{animation:kbayob8 5s ease infinite}
+      ._j6xt1fef:hover{background:var(--_hcgrh3)}
+      ._bfhk29zg, ._irr329zg:hover{background-color:var(--ds-background-selected,#deebff)}
+      ._bfhk1ayf{background-color:var(--_rgmfhj)}
+      ._irr312tn:hover{background-color:var(--_1hwiu8a)}
+      ._syaz1qtk{color:var(--ds-link)}
+      ._1jmq18uv:hover .linkText{-webkit-text-decoration-color:initial;text-decoration-color:initial}
+      ._1owrotz2:active, ._jzfzotz2:focus, ._1mq6otz2:hover{padding:0 var(--ds-space-050,4px)}
+      ._apju8stv:hover .linkText{-webkit-text-decoration-line:underline;text-decoration-line:underline}
+      ._kkk21kw7{all:inherit}
+      @media (min-width:1024px){
+        ._j6xt1fef:active{background:var(--_hcgrh3)}
+        ._syaz1qtk{color:var(--ds-link)}
+        ._1jmq18uv:hover .linkText{-webkit-text-decoration-color:initial;text-decoration-color:initial}
+        ._1owrotz2:active, ._jzfzotz2:focus, ._1mq6otz2:hover{padding:0 var(--ds-space-050,4px)}
+        ._apju8stv:hover .linkText{-webkit-text-decoration-line:underline;text-decoration-line:underline}
+        ._kkk21kw7{all:inherit}
+        ._ku3unqa1:hover .linkText{-webkit-text-decoration-style:solid;text-decoration-style:solid}
+        ._18s8paju{margin:var(--ds-space-150,9pt) auto 28px auto}
+        ._y44v1syn{animation:kbpspdk 5s ease infinite}
+      }
+      ._ku3unqa1:hover .linkText{-webkit-text-decoration-style:solid;text-decoration-style:solid}
+      ._18s8paju{margin:var(--ds-space-150,9pt) auto 28px auto}
+      ._y44v1syn{animation:kbpspdk 5s ease infinite}
+      @keyframes kbpspdk{0%{stroke-dashoffset:10}}
+      ._y44vbxa2{animation:k1qo9wnt 5s ease infinite}
+      @media (min-width:30rem){
+        ._1letfkly{margin:0 var(--ds-space-400,2pc)}
+        ._1wbfxncg{padding:var(--ds-space-800,4pc)}
+        ._1tn2iyik{font:var(--ds-font-heading-xlarge,normal 600 29px/2pc ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Ubuntu,system-ui,"Helvetica Neue",sans-serif)}
+        ._l7hko0gd [data-ds--text-field--input]{font:var(--ds-font-heading-medium,normal 500 20px/24px ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Ubuntu,system-ui,"Helvetica Neue",sans-serif)}._1odf1h6o{justify-content:center}
+        ._j6xt1fef:active{background:var(--_hcgrh3)}
+        ._syaz1qtk{color:var(--ds-link)}
+        ._1jmq18uv:hover .linkText{-webkit-text-decoration-color:initial;text-decoration-color:initial}
+        ._1owrotz2:active, ._jzfzotz2:focus, ._1mq6otz2:hover{padding:0 var(--ds-space-050,4px)}
+        ._apju8stv:hover .linkText{-webkit-text-decoration-line:underline;text-decoration-line:underline}
+        ._kkk21kw7{all:inherit}
+        ._ku3unqa1:hover .linkText{-webkit-text-decoration-style:solid;text-decoration-style:solid}
+        ._18s8paju{margin:var(--ds-space-150,9pt) auto 28px auto}
+        ._y44v1syn{animation:kbpspdk 5s ease infinite}
+        ._pwyo12x7{padding-inline-end:var(--ds-space-075,6px)}
+        ._1b7p1epz{padding-left:var(--ds-space-1000,5pc)}
+        ._jvmr1epz{padding-right:var(--ds-space-1000,5pc)}
+      }
+    `);
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+      ._kkk21kw7{all:inherit}._zulph461{gap:var(--ds-space-050)}
+      ._y44v1tgl{animation:kbayob8 5s ease infinite}
+      ._18s8paju{margin:var(--ds-space-150,9pt) auto 28px auto}
+      ._y44v1syn{animation:kbpspdk 5s ease infinite}
+      ._y44vbxa2{animation:k1qo9wnt 5s ease infinite}
+      ._bfhk29zg, ._irr329zg:hover{background-color:var(--ds-background-selected,#deebff)}
+      ._bfhk1ayf{background-color:var(--_rgmfhj)}
+      ._syaz1qtk{color:var(--ds-link)}
+      ._1jmq18uv:hover .linkText{-webkit-text-decoration-color:initial;text-decoration-color:initial}
+      ._apju8stv:hover .linkText{-webkit-text-decoration-line:underline;text-decoration-line:underline}
+      ._ku3unqa1:hover .linkText{-webkit-text-decoration-style:solid;text-decoration-style:solid}
+      ._j6xt1fef:hover{background:var(--_hcgrh3)}
+      ._irr312tn:hover{background-color:var(--_1hwiu8a)}
+      ._1owrotz2:active, ._jzfzotz2:focus, ._1mq6otz2:hover{padding:0 var(--ds-space-050,4px)}
+      @keyframes kbpspdk{0%{stroke-dashoffset:10}}
+      @media (min-width:30rem){
+        ._kkk21kw7{all:inherit}
+        ._1letfkly{margin:0 var(--ds-space-400,2pc)}
+        ._1wbfxncg{padding:var(--ds-space-800,4pc)}
+        ._1tn2iyik{font:var(--ds-font-heading-xlarge,normal 600 29px/2pc ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Ubuntu,system-ui,"Helvetica Neue",sans-serif)}
+        ._l7hko0gd [data-ds--text-field--input]{font:var(--ds-font-heading-medium,normal 500 20px/24px ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Ubuntu,system-ui,"Helvetica Neue",sans-serif)}
+        ._18s8paju{margin:var(--ds-space-150,9pt) auto 28px auto}
+        ._y44v1syn{animation:kbpspdk 5s ease infinite}._1odf1h6o{justify-content:center}
+        ._syaz1qtk{color:var(--ds-link)}
+        ._1jmq18uv:hover .linkText{-webkit-text-decoration-color:initial;text-decoration-color:initial}
+        ._apju8stv:hover .linkText{-webkit-text-decoration-line:underline;text-decoration-line:underline}
+        ._ku3unqa1:hover .linkText{-webkit-text-decoration-style:solid;text-decoration-style:solid}
+        ._pwyo12x7{padding-inline-end:var(--ds-space-075,6px)}
+        ._1b7p1epz{padding-left:var(--ds-space-1000,5pc)}
+        ._jvmr1epz{padding-right:var(--ds-space-1000,5pc)}
+        ._j6xt1fef:active{background:var(--_hcgrh3)}
+        ._1owrotz2:active, ._jzfzotz2:focus, ._1mq6otz2:hover{padding:0 var(--ds-space-050,4px)}
+      }
+      @media (min-width:1024px){
+        ._kkk21kw7{all:inherit}
+        ._18s8paju{margin:var(--ds-space-150,9pt) auto 28px auto}
+        ._y44v1syn{animation:kbpspdk 5s ease infinite}
+        ._syaz1qtk{color:var(--ds-link)}
+        ._1jmq18uv:hover .linkText{-webkit-text-decoration-color:initial;text-decoration-color:initial}
+        ._apju8stv:hover .linkText{-webkit-text-decoration-line:underline;text-decoration-line:underline}
+        ._ku3unqa1:hover .linkText{-webkit-text-decoration-style:solid;text-decoration-style:solid}
+        ._j6xt1fef:active{background:var(--_hcgrh3)}
+        ._1owrotz2:active, ._jzfzotz2:focus, ._1mq6otz2:hover{padding:0 var(--ds-space-050,4px)}
+      }"
+    `);
+  });
+
   it('leaves untouched when no crossover is present', () => {
     const actual = transform(outdent`
       .a {
@@ -380,7 +478,7 @@ describe('sort shorthand vs. longhand declarations', () => {
     // We are ok with this because we expect atomicifyRules to run before this plugin,
     // so each class will never have more than one property.
     expect(actual).toMatchInlineSnapshot(`
-      ".e { border-top: none; }
+      "
       .a {
         all: reset;
         border: 2px dashed;
@@ -390,7 +488,7 @@ describe('sort shorthand vs. longhand declarations', () => {
       }
       .c { all: unset; }
       .b { all: unset; }
-      .d { border: none; }
+      .d { border: none; }.e { border-top: none; }
       .f { border-block-start-color: transparent; }"
     `);
   });

--- a/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
+++ b/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
@@ -493,11 +493,6 @@ describe('sort shorthand vs. longhand declarations', () => {
       .b { all: unset; }
     `);
 
-    // WARNING: This is technically wrong as `.a { … }` is not sorted as we expect;
-    // it _should_ be 'abcdef' not 'eabcdf'.
-    //
-    // We are ok with this because we expect atomicifyRules to run before this plugin,
-    // so each class will never have more than one property.
     expect(actual).toMatchInlineSnapshot(`
       "
       .a {

--- a/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
+++ b/packages/css/src/plugins/__tests__/sort-shorthand-declarations.test.ts
@@ -20,7 +20,28 @@ describe('sort shorthand vs. longhand declarations', () => {
     process.env.BROWSERSLIST = 'last 1 version';
   });
 
-  it('sorts against multi-property classes', () => {
+  it('sorts against multi-property classes: simple', () => {
+    // We need to make sure this `{-webkit-text-decoration-color:initial;text-decoration-color:initial}` doesn't "block" sorting
+    const actual = transform(outdent`
+      ._zulph461{gap:3px}
+      ._bfhk1ayf{background-color:red}
+      ._1jmq18uv{-webkit-text-decoration-color:initial;text-decoration-color:initial}
+      ._bfhk1ayf{background-color:red}
+      ._y44v1tgl{background:red}
+      ._kkk21kw7{all:inherit}
+    `);
+
+    expect(actual).toMatchInlineSnapshot(`
+      "
+      ._kkk21kw7{all:inherit}._zulph461{gap:3px}
+      ._y44v1tgl{background:red}
+      ._bfhk1ayf{background-color:red}
+      ._1jmq18uv{-webkit-text-decoration-color:initial;text-decoration-color:initial}
+      ._bfhk1ayf{background-color:red}"
+    `);
+  });
+
+  it('sorts against multi-property classes fully', () => {
     const actual = transform(outdent`
       ._zulph461{gap:var(--ds-space-050)}
       ._y44v1tgl{animation:kbayob8 5s ease infinite}
@@ -32,7 +53,6 @@ describe('sort shorthand vs. longhand declarations', () => {
       ._1jmq18uv:hover .linkText{-webkit-text-decoration-color:initial;text-decoration-color:initial}
       ._1owrotz2:active, ._jzfzotz2:focus, ._1mq6otz2:hover{padding:0 var(--ds-space-050,4px)}
       ._apju8stv:hover .linkText{-webkit-text-decoration-line:underline;text-decoration-line:underline}
-      ._kkk21kw7{all:inherit}
       @media (min-width:1024px){
         ._j6xt1fef:active{background:var(--_hcgrh3)}
         ._syaz1qtk{color:var(--ds-link)}
@@ -67,6 +87,7 @@ describe('sort shorthand vs. longhand declarations', () => {
         ._1b7p1epz{padding-left:var(--ds-space-1000,5pc)}
         ._jvmr1epz{padding-right:var(--ds-space-1000,5pc)}
       }
+      ._kkk21kw7{all:inherit}
     `);
 
     expect(actual).toMatchInlineSnapshot(`

--- a/packages/css/src/plugins/sort-shorthand-declarations.ts
+++ b/packages/css/src/plugins/sort-shorthand-declarations.ts
@@ -16,8 +16,6 @@ const findDeclaration = (node: ChildNode): Declaration | undefined => {
   return undefined;
 };
 
-export const props = new Set();
-
 const sortNodes = (a: ChildNode, b: ChildNode): number => {
   // NOTE: These return the first declaration when the class has multiple properties
   // eg. `-webkit-text-decoration:initial;text-decoration:initial` would sort

--- a/packages/css/src/plugins/sort-shorthand-declarations.ts
+++ b/packages/css/src/plugins/sort-shorthand-declarations.ts
@@ -9,15 +9,19 @@ const findDeclaration = (node: ChildNode): Declaration | undefined => {
   }
 
   if ('nodes' in node) {
-    if (node.nodes.length === 1 && nodeIsDeclaration(node.nodes[0])) {
-      return node.nodes[0];
-    }
+    // Return the first node that is a declaration, if we find one
+    return node.nodes.find(nodeIsDeclaration);
   }
 
   return undefined;
 };
 
+export const props = new Set();
+
 const sortNodes = (a: ChildNode, b: ChildNode): number => {
+  // NOTE: These return the first declaration when the class has multiple properties
+  // eg. `-webkit-text-decoration:initial;text-decoration:initial` would sort
+  // against `-webkit-text-decoration`, which may not be perfect in all cases
   const aDecl = findDeclaration(a);
   const bDecl = findDeclaration(b);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5885,10 +5885,10 @@ bn.js@^5.0.0, bn.js@^5.1.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
-body-parser@1.20.2:
-  version "1.20.2"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
-  integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
+body-parser@1.20.3:
+  version "1.20.3"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.3.tgz#1953431221c6fb5cd63c4b36d53fab0928e548c6"
+  integrity sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==
   dependencies:
     bytes "3.1.2"
     content-type "~1.0.5"
@@ -5898,7 +5898,7 @@ body-parser@1.20.2:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     on-finished "2.4.1"
-    qs "6.11.0"
+    qs "6.13.0"
     raw-body "2.5.2"
     type-is "~1.6.18"
     unpipe "1.0.0"
@@ -6223,13 +6223,16 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-call-bind@^1.0.0, call-bind@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
-  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
+  integrity sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==
   dependencies:
-    function-bind "^1.1.1"
-    get-intrinsic "^1.0.2"
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
+    set-function-length "^1.2.1"
 
 call-me-maybe@^1.0.1:
   version "1.0.1"
@@ -7667,6 +7670,15 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-data-property@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
+  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
+  dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
+    gopd "^1.0.1"
+
 define-lazy-prop@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
@@ -8115,6 +8127,11 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
+encodeurl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-2.0.0.tgz#7b8ea898077d7e409d3ac45474ea38eaf0857a58"
+  integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -8244,6 +8261,18 @@ es-array-method-boxes-properly@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
   integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
+
+es-define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.0.tgz#c7faefbdff8b2696cf5f46921edfb77cc4ba3845"
+  integrity sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==
+  dependencies:
+    get-intrinsic "^1.2.4"
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 es-get-iterator@^1.0.2:
   version "1.1.2"
@@ -8710,37 +8739,37 @@ expect@^29.4.3:
     jest-message-util "^29.4.3"
     jest-util "^29.4.3"
 
-express@4.19.2, express@^4.17.1, express@^4.17.3:
-  version "4.19.2"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.19.2.tgz#e25437827a3aa7f2a827bc8171bbbb664a356465"
-  integrity sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==
+express@4.20.0, express@^4.17.1, express@^4.17.3:
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.20.0.tgz#f1d08e591fcec770c07be4767af8eb9bcfd67c48"
+  integrity sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"
-    body-parser "1.20.2"
+    body-parser "1.20.3"
     content-disposition "0.5.4"
     content-type "~1.0.4"
     cookie "0.6.0"
     cookie-signature "1.0.6"
     debug "2.6.9"
     depd "2.0.0"
-    encodeurl "~1.0.2"
+    encodeurl "~2.0.0"
     escape-html "~1.0.3"
     etag "~1.8.1"
     finalhandler "1.2.0"
     fresh "0.5.2"
     http-errors "2.0.0"
-    merge-descriptors "1.0.1"
+    merge-descriptors "1.0.3"
     methods "~1.1.2"
     on-finished "2.4.1"
     parseurl "~1.3.3"
-    path-to-regexp "0.1.7"
+    path-to-regexp "0.1.10"
     proxy-addr "~2.0.7"
     qs "6.11.0"
     range-parser "~1.2.1"
     safe-buffer "5.2.1"
-    send "0.18.0"
-    serve-static "1.15.0"
+    send "0.19.0"
+    serve-static "1.16.0"
     setprototypeof "1.2.0"
     statuses "2.0.1"
     type-is "~1.6.18"
@@ -9290,10 +9319,10 @@ fsevents@^2.1.2, fsevents@^2.3.2, fsevents@~2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
-function-bind@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
-  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+function-bind@^1.1.1, function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 function.prototype.name@^1.1.0, function.prototype.name@^1.1.5:
   version "1.1.5"
@@ -9335,14 +9364,16 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
-  integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.4.tgz#e385f5a4b5227d449c3eabbad05494ef0abbeadd"
+  integrity sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==
   dependencies:
-    function-bind "^1.1.1"
-    has "^1.0.3"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    has-proto "^1.0.1"
     has-symbols "^1.0.3"
+    hasown "^2.0.0"
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -9675,12 +9706,12 @@ has-glob@^1.0.0:
   dependencies:
     is-glob "^3.0.0"
 
-has-property-descriptors@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz#610708600606d36961ed04c196193b6a607fa861"
-  integrity sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==
+has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
   dependencies:
-    get-intrinsic "^1.1.1"
+    es-define-property "^1.0.0"
 
 has-proto@^1.0.1:
   version "1.0.1"
@@ -9758,6 +9789,13 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+hasown@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
 
 hast-to-hyperscript@^9.0.0:
   version "9.0.1"
@@ -12695,10 +12733,10 @@ meow@^6.0.0:
     type-fest "^0.13.1"
     yargs-parser "^18.1.3"
 
-merge-descriptors@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
-  integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
+merge-descriptors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.3.tgz#d80319a65f3c7935351e5cfdac8f9318504dbed5"
+  integrity sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -13338,10 +13376,10 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.12.2, object-inspect@^1.9.0:
-  version "1.12.3"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
-  integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
+object-inspect@^1.12.2, object-inspect@^1.13.1:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.2.tgz#dea0088467fb991e67af4058147a24824a3043ff"
+  integrity sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==
 
 object-keys@^1.1.1:
   version "1.1.1"
@@ -13853,10 +13891,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
-  integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+path-to-regexp@0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.10.tgz#67e9108c5c0551b9e5326064387de4763c4d5f8b"
+  integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -15171,12 +15209,19 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@6.11.0, qs@^6.10.0:
+qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
+
+qs@6.13.0, qs@^6.10.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.13.0.tgz#6ca3bd58439f7e245655798997787b0d88a51906"
+  integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
+  dependencies:
+    side-channel "^1.0.6"
 
 qs@~6.5.2:
   version "6.5.2"
@@ -16185,6 +16230,25 @@ send@0.18.0:
     range-parser "~1.2.1"
     statuses "2.0.1"
 
+send@0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.19.0.tgz#bbc5a388c8ea6c048967049dbeac0e4a3f09d7f8"
+  integrity sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==
+  dependencies:
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "2.4.1"
+    range-parser "~1.2.1"
+    statuses "2.0.1"
+
 serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
@@ -16230,10 +16294,10 @@ serve-index@^1.9.1:
     mime-types "~2.1.17"
     parseurl "~1.3.2"
 
-serve-static@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
-  integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==
+serve-static@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.16.0.tgz#2bf4ed49f8af311b519c46f272bf6ac3baf38a92"
+  integrity sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==
   dependencies:
     encodeurl "~1.0.2"
     escape-html "~1.0.3"
@@ -16244,6 +16308,18 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-function-length@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.2"
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"
@@ -16338,14 +16414,15 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-side-channel@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
-  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+side-channel@^1.0.4, side-channel@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.6.tgz#abd25fb7cd24baf45466406b1096b7831c9215f2"
+  integrity sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==
   dependencies:
-    call-bind "^1.0.0"
-    get-intrinsic "^1.0.2"
-    object-inspect "^1.9.0"
+    call-bind "^1.0.7"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.4"
+    object-inspect "^1.13.1"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"


### PR DESCRIPTION
### What is this change?

Making sure sorting works across mutli-property classes.

Example: this `{-webkit-text-decoration-color:initial;text-decoration-color:initial}` currently blocks all sorting above or below it, effectively creating a new "sorting bucket" because it always returns `0` as `a` or `b`.

This doesn't get sorted:
```css
._y44v1tgl{animation:kbayob8 5s ease infinite}
._syaz1qtk{color:var(--ds-link)}
._1jmq18uv{-webkit-text-decoration-color:initial;text-decoration-color:initial}
._zulph461{gap:var(--ds-space-050)}
```

Added a test to show how this works now!

### PR checklist

I have...

- [x] Updated or added applicable tests
- [x] ~~Not updated the documentation in `website/`~~
