### PR TITLE
Add `shorthand-property-sorting` to recommended ESLint rules

### DIFF
--- a/.changeset/four-beds-own.md
+++ b/.changeset/four-beds-own.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Add `shorthand-property-sorting` to recommended ESLint rules

--- a/.changeset/four-beds-own.md
+++ b/.changeset/four-beds-own.md
@@ -1,5 +1,5 @@
 ---
-'@compiled/eslint-plugin': patch
+'@compiled/eslint-plugin': minor
 ---
 
 Add `shorthand-property-sorting` to recommended ESLint rules

--- a/packages/eslint-plugin/src/configs/flat-recommended.ts
+++ b/packages/eslint-plugin/src/configs/flat-recommended.ts
@@ -12,5 +12,6 @@ export const flatRecommended = {
     '@compiled/no-keyframes-tagged-template-expression': 'error',
     '@compiled/no-styled-tagged-template-expression': 'error',
     '@compiled/no-suppress-xcss': 'error',
+    '@compiled/shorthand-property-sorting': 'error',
   },
 } as const;

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -12,5 +12,6 @@ export const recommended = {
     '@compiled/no-keyframes-tagged-template-expression': 'error',
     '@compiled/no-styled-tagged-template-expression': 'error',
     '@compiled/no-suppress-xcss': 'error',
+    '@compiled/shorthand-property-sorting': 'error',
   },
-};
+} as const;


### PR DESCRIPTION
### What is this change?

Add `shorthand-property-sorting` to recommended ESLint rules, meaning that it will be turned on by default for all codebases where `@compiled/eslint-plugin` set up correctly.

### Why are we making this change?

After https://github.com/atlassian-labs/compiled/pull/1700 was merged in, Compiled will now sort shorthand properties to come before longhand properties at buiild-time and runtime. @zesmith2 [made a lint rule](https://github.com/atlassian-labs/compiled/pull/1714) to enforce that the order of the properties in the source code of Compiled usages matches this ordering. We've resolved all the eslint rule violations in jira and confluence (I think?), so we can just add this as a default recommended eslint rule to remove the need to configure it manually.

### Some asks

Some requests from me before I go:

* If someone could extend `shorthand-property-sorting` so it handles the different forms of style composition, that would be great 🙏  @pancaspe87 has a link to the internal jira ticket for tracking this. @liamqma gave some examples in https://github.com/atlassian-labs/compiled/pull/1714#discussion_r1783816451

* If someone could quickly verify that the rule does indeed get applied in our products after the Compiled eslint plugin is version bumped, that would be great 🙏 

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
