### PR TITLE
new eslint rule to expand border shorthand property

### DIFF
--- a/.changeset/breezy-beds-walk.md
+++ b/.changeset/breezy-beds-walk.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Adding eslint rule to enforce expansion of the 'border' shorthand property to 'borderWidth', 'borderStyle', and 'borderColor'

--- a/packages/eslint-plugin/src/rules/expand-border-shorthand/README.md
+++ b/packages/eslint-plugin/src/rules/expand-border-shorthand/README.md
@@ -1,0 +1,36 @@
+# `shorthand-property-sorting`
+
+This ESLint rule enforces the expansion of CSS `border` shorthand property, into their longhand equivalents `borderStyle`, `borderWidth`, `borderColor`, for packages `css`, `cssMap`, `styled` that originates from `@compiled/react`, and `@atlaskit/css`.
+
+This rule only targets `border` shorthand with 3 properties, and does not take cases like:
+
+```js
+const styles1 = css({
+  border: '1px',
+});
+const styles2 = css({
+  border: '1px solid',
+});
+```
+
+into consideration.
+
+## Rule details
+
+👎 Examples of **incorrect** code for this rule:
+
+```js
+const styles = css({
+  border: `1px solid black`,
+});
+```
+
+👍 Examples of **correct** code for this rule:
+
+```js
+const styles = css({
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: 'black',
+});
+```

--- a/packages/eslint-plugin/src/rules/expand-border-shorthand/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/expand-border-shorthand/__tests__/rule.test.ts
@@ -1,0 +1,295 @@
+import { outdent } from 'outdent';
+
+import { tester } from '../../../test-utils';
+import { expandBorderShorthand } from '../index';
+
+const packages_calls_and_imports = [
+  ['css', 'css', '@atlaskit/css'],
+  ['css', 'css', '@compiled/react'],
+  ['styled', 'styled.div', '@compiled/react'],
+  ['styled', 'styled.ul', '@compiled/react'],
+  ['cssMap', 'cssMap', '@atlaskit/css'],
+  ['cssMap', 'cssMap', '@compiled/react'],
+];
+
+tester.run('expand-border-shorthand', expandBorderShorthand, {
+  valid: [
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `border shorthand less than 3 elements (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles1 = ${call}({
+          border: '1px',
+        });
+        const styles2 = ${call}({
+          border: '2px solid',
+        });
+        const styles3 = ${call}({
+          border: '3px red',
+        });
+        const styles4 = ${call}({
+          border: 'red',
+        });
+      `,
+    })),
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `not using border shorthand            (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles1 = ${call}({
+          borderTop: '2px solid green',
+          borderRight: '3px dashed orange',
+          borderBottom: '4px double purple',
+          borderLeft: '5px groove teal',
+        });
+
+        const styles2 = ${call}({
+          borderWidth: '1px',
+          borderStyle: 'solid',
+          borderColor: 'black',
+        });
+      `,
+    })),
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `invalid formats                       (${call}, ${imp})`,
+      code: outdent`
+          import {${pkg}} from '${imp}';
+
+          const styles1 = ${call}({
+            border: '1.5cm dotted ab',
+          });
+
+          const styles2 = ${call}({
+            border: '1.5cm dotted abcdefghijklmnopqrstuv',
+          });
+
+          const styles3 = ${call}({
+            border: '1.5cm dotted var(--color)',
+          });
+
+          const styles4 = ${call}({
+            border: 'foo bar baz'
+          });
+
+          const styles5 = ${call}({
+            border: '   1px     solid   blue   ',
+          });
+        `,
+    })),
+  ],
+  invalid: [
+    /* borderStyle borderWidth borderColor */
+
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `borderStyle:keyword, borderWidth:px,      borderColor:rgb     - single property             (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          border: 'none 2px rgb(1, 1, 2)',
+        });
+      `,
+      output: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          borderWidth: '2px', borderStyle: 'none', borderColor: 'rgb(1, 1, 2)',\u0020
+        });
+      `,
+      errors: [{ messageId: 'expandBorderShorthand' }],
+    })),
+
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `borderStyle:keyword, borderWidth:px,      borderColor:hex     - 2 properties, border first  (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          border: 'hidden 0.5px #00b8d9',
+          margin: '1px',
+        });
+      `,
+      output: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          borderWidth: '0.5px', borderStyle: 'hidden', borderColor: '#00b8d9', margin: '1px',
+        });
+      `,
+      errors: [{ messageId: 'expandBorderShorthand' }],
+    })),
+
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `borderStyle:keyword, borderWidth:rem,     borderColor:token   - 2 properties, border last   (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px',
+          border: 'dotted 1rem token("color.border.danger", "red")',
+        });
+      `,
+      output: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px',
+          borderWidth: '1rem', borderStyle: 'dotted', borderColor: 'token("color.border.danger", "red")',\u0020
+        });
+      `,
+      errors: [{ messageId: 'expandBorderShorthand' }],
+    })),
+
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `borderStyle:keyword, borderWidth:rem,     borderColor:keyword - 3 properties, border middle (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px, solid, blue',
+          border: 'dashed 1.5rem red',
+          padding: '1px',
+        });
+      `,
+      output: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px, solid, blue',
+          borderWidth: '1.5rem', borderStyle: 'dashed', borderColor: 'red', padding: '1px',
+        });
+      `,
+      errors: [{ messageId: 'expandBorderShorthand' }],
+    })),
+
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `borderStyle:keyword, borderWidth:cm,      borderColor:keyword - borderColor duplicated      (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px, solid, red',
+          border: 'solid 1cm blue',
+          borderColor: 'red',
+        });
+      `,
+      output: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px, solid, red',
+          borderWidth: '1cm', borderStyle: 'solid', borderColor: 'blue', borderColor: 'red',
+        });
+      `,
+      errors: [{ messageId: 'expandBorderShorthand' }],
+    })),
+
+    /* borderWidth borderStyle borderColor */
+
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `borderWidth:integer, borderStyle:keyword, borderColor:rgba    - single property             (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          border: '1 double rgba(255, 0, 0, 0.5)',
+        });
+      `,
+      output: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          borderWidth: '1', borderStyle: 'double', borderColor: 'rgba(255, 0, 0, 0.5)',\u0020
+        });
+        `,
+      errors: [{ messageId: 'expandBorderShorthand' }],
+    })),
+
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `borderWidth:decimal, borderStyle:keyword, borderColor:hsl     - 2 properties, border first  (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          border: '1.5 groove hsl(0, 100%, 50%)',
+          margin: '1px',
+        });
+        `,
+      output: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          borderWidth: '1.5', borderStyle: 'groove', borderColor: 'hsl(0, 100%, 50%)', margin: '1px',
+        });
+        `,
+      errors: [{ messageId: 'expandBorderShorthand' }],
+    })),
+
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `borderWidth:em,      borderStyle:keyword, borderColor:token   - 2 properties, border last   (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px',
+          border: '1em ridge token("color.border.danger", "red")',
+        });
+        `,
+      output: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px',
+          borderWidth: '1em', borderStyle: 'ridge', borderColor: 'token("color.border.danger", "red")',\u0020
+        });
+        `,
+      errors: [{ messageId: 'expandBorderShorthand' }],
+    })),
+
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `borderWidth:keyword, borderStyle:keyword, borderColor: hsla   - 3 properties, border middle (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px solid red',
+          border: 'thin inset hsla(0, 100%, 50%, 0.5)',
+          padding: '1px',
+        });
+        `,
+      output: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px solid red',
+          borderWidth: 'thin', borderStyle: 'inset', borderColor: 'hsla(0, 100%, 50%, 0.5)', padding: '1px',
+        });
+        `,
+      errors: [{ messageId: 'expandBorderShorthand' }],
+    })),
+
+    ...packages_calls_and_imports.map(([pkg, call, imp]) => ({
+      name: `borderWidth:global,  borderStyle:global,  borderColor:keyword - borderColor duplicated      (${call}, ${imp})`,
+      code: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px, solid, red',
+          border: 'inherit inherit LightGoldenRodYellow',
+          borderColor: 'red',
+        });
+      `,
+      output: outdent`
+        import {${pkg}} from '${imp}';
+
+        const styles = ${call}({
+          margin: '1px, solid, red',
+          borderWidth: 'inherit', borderStyle: 'inherit', borderColor: 'LightGoldenRodYellow', borderColor: 'red',
+        });
+      `,
+      errors: [{ messageId: 'expandBorderShorthand' }],
+    })),
+  ],
+});

--- a/packages/eslint-plugin/src/rules/expand-border-shorthand/index.ts
+++ b/packages/eslint-plugin/src/rules/expand-border-shorthand/index.ts
@@ -1,0 +1,97 @@
+import type { Rule } from 'eslint';
+import type { Property, SpreadElement } from 'estree';
+
+const loopProperties = (properties: (Property | SpreadElement)[], context: Rule.RuleContext) => {
+  properties.forEach((property) => {
+    if (property.type === 'Property') {
+      if (property.key.type === 'Identifier' && property.key.name === 'border') {
+        // we found a 'border' property
+        if (property.value.type === 'Literal') {
+          if (property.value.value && typeof property.value.value === 'string') {
+            const borderString: string = property.value.value;
+            const borderRegex =
+              /^(?<style>(solid|dashed|dotted|double|groove|ridge|inset|outset|none|hidden|inherit|initial|revert|revert-layer|unset|))?\s*(?<width>(thin|medium|thick|inherit|initial|revert|revert-layer|unset|\d+(\.\d+)?(px|em|rem|cm|%)?))?\s*(?<color>(#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})|token\(([^)]+)\)|rgb\(([^)]+)\)|rgba\(([^)]+)\)|hsl\(([^)]+)\)|hsla\(([^)]+)\)|[a-zA-Z]{3,20})?)$|^(?<width2>(thin|medium|thick|inherit|initial|revert|revert-layer|unset|\d+(\.\d+)?(px|em|rem|cm|%)?))?\s*(?<style2>(solid|dashed|dotted|double|groove|ridge|inset|outset|none|hidden|inherit|initial|revert|revert-layer|unset|))?\s*(?<color2>(#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})|token\(([^)]+)\)|rgb\(([^)]+)\)|rgba\(([^)]+)\)|hsl\(([^)]+)\)|hsla\(([^)]+)\)|[a-zA-Z]{3,20})?)$/;
+
+            const match = borderString.match(borderRegex);
+
+            if (match) {
+              const { style, width, color, style2, width2, color2 } = match.groups || {};
+
+              // borderWidth and borderStyle can be in either order, borderColor is always last
+              const borderWidth = width || width2 || '';
+              const borderStyle = style || style2 || '';
+              const borderColor = color || color2 || '';
+
+              if (borderWidth && borderStyle && borderColor) {
+                context.report({
+                  node: property.key,
+                  messageId: 'expandBorderShorthand',
+                  fix: (fixer) => {
+                    const fixes = [];
+
+                    const propertyRangeStart = property.range ? property.range[0] : undefined;
+                    const propertyRangeEnd = property.range ? property.range[1] : undefined;
+                    const nextSibling = properties[properties.indexOf(property) + 1];
+
+                    if (propertyRangeEnd && propertyRangeStart) {
+                      // Remove the original property
+                      fixes.push(fixer.remove(property));
+
+                      // Prepare the new properties to insert
+                      const newProperties = `borderWidth: '${borderWidth}', borderStyle: '${borderStyle}', borderColor: '${borderColor}', `;
+
+                      // Insert new properties after the property range
+                      fixes.push(
+                        fixer.insertTextAfterRange(
+                          [propertyRangeStart, propertyRangeEnd],
+                          newProperties
+                        )
+                      );
+
+                      // Remove trailing commas
+                      if (nextSibling && nextSibling.range) {
+                        fixes.push(fixer.removeRange([propertyRangeEnd, nextSibling.range[0]]));
+                      } else {
+                        fixes.push(fixer.removeRange([propertyRangeEnd, propertyRangeEnd + 1]));
+                      }
+                    }
+                    return fixes;
+                  },
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+};
+
+const selectorString =
+  'CallExpression[callee.type="Identifier"][callee.name="css"] > ObjectExpression, ' +
+  'CallExpression[callee.type="MemberExpression"][callee.object.type="Identifier"][callee.object.name="styled"] > ObjectExpression, ' +
+  'CallExpression[callee.type="Identifier"][callee.name="cssMap"] > ObjectExpression';
+
+export const expandBorderShorthand: Rule.RuleModule = {
+  meta: {
+    docs: {
+      url: 'https://github.com/atlassian-labs/compiled/tree/master/packages/eslint-plugin/src/rules/expand-border-shorthand',
+    },
+    fixable: 'code',
+    messages: {
+      expandBorderShorthand:
+        'Use borderColor, borderStyle, and borderWidth instead of border shorthand',
+    },
+    type: 'problem',
+  },
+
+  create(context) {
+    return {
+      [selectorString]: (node: Rule.Node) => {
+        if (node.type === 'ObjectExpression' && node.properties) {
+          loopProperties(node.properties, context);
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
### What is this change?

Adding an eslint rule that expands `border` shorthand property into it's longhand parts `borderStyle`, `borderWidth`, and `borderColor`. 

`border` property supports `borderStyle`, `borderWidth` being in either order, and `borderColor` always coming last. This rule supports this allowance, and only applies to shorthand that has all 3 properties present, 

e.g. `border: '1px',` isn't covered in this rule.

### Why are we making this change?

Expanding the `border` property will decrease stylesheet size due to more common usages without all properties matching.

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
