### PR TITLE
Update the `suggest changes` page link to point to the new location

### DIFF
--- a/website/packages/docs/src/components/app.tsx
+++ b/website/packages/docs/src/components/app.tsx
@@ -81,7 +81,7 @@ section: My section
 
 const getEditUrl = () => {
   const name = location.pathname.split('/')[2] || 'installation';
-  return `https://github.com/compiled/compiled-website/tree/master/packages/docs/src/pages/${name}.mdx`;
+  return `https://github.com/atlassian-labs/compiled/tree/master/website/packages/docs/src/pages/${name}.mdx`;
 };
 
 const getPage = (slug: string) => {


### PR DESCRIPTION
Link to:
https://github.com/atlassian-labs/compiled/tree/master/website/packages/docs/src/...

### What is this change?

Fix "suggest page" link location

### Why are we making this change?

Reduce the friction for consumers to make suggestions/corrections.

The link points to the old repo, and when you get to the right repo, you need to find the content. 

### How are we making this change?

(Optional.)

---

### PR checklist

Don't delete me!

I have...

- [ ] Updated or added applicable tests?
- [X] Updated the documentation in `website/`
