### PR TITLE
Export KeyframeSteps from main entrypoint

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -13,7 +13,7 @@ export type {
 } from './create-strict-api/types';
 export { default as css } from './css';
 export { default as cssMap } from './css-map';
-export { keyframes } from './keyframes';
+export { keyframes, type KeyframeSteps } from './keyframes';
 export { styled, StyledProps } from './styled';
 export type {
   CSSProperties,


### PR DESCRIPTION
Makes it so that `KeyframeSteps` is available via the main entrypoint so the keyframe object passed via indirection/props can be correctly typed

### What is this change?

Adds type export for `KeyframeSteps`

### Why are we making this change?

In some cases keyframe step objects are passed via props, so without this it's unable to be correctly typed.

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
