### PR TITLE
Fix shorthand-property-sorting crashing when styles not initialised

### DIFF
--- a/.changeset/purple-parrots-eat.md
+++ b/.changeset/purple-parrots-eat.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Fix shorthand-property-sorting crashing when variable in css prop is not initialised

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,3 +20,4 @@ I have...
 
 - [ ] Updated or added applicable tests
 - [ ] Updated the documentation in `website/`
+- [ ] Added a changeset (if making any changes that affect Compiled's behaviour)

--- a/packages/eslint-plugin/src/rules/shorthand-property-sorting/__tests__/rule.test.ts
+++ b/packages/eslint-plugin/src/rules/shorthand-property-sorting/__tests__/rule.test.ts
@@ -286,6 +286,30 @@ tester.run('shorthand-property-sorting', shorthandFirst, {
         });
       `,
     },
+
+    //
+    // styles is not defined
+    //
+
+    {
+      // People really should not be doing this, so no point in handling this case.
+      //
+      // This test case is just to make sure the rule does not crash when it encounters
+      // this kind of edge case.
+      name: 'styles is not defined',
+      code: `
+        import { css, jsx } from '@compiled/react';
+
+        let styles;
+        const someCondition = true;
+        if (someCondition) {
+          styles = css({ top: 0 });
+        } else {
+          styles = css({ top: '2px' });
+        }
+        export const EmphasisText = ({ children }) => <span css={styles}>{children}</span>;
+      `,
+    },
   ]),
 
   invalid: includedImports.flatMap((imp) => [

--- a/packages/eslint-plugin/src/rules/shorthand-property-sorting/index.ts
+++ b/packages/eslint-plugin/src/rules/shorthand-property-sorting/index.ts
@@ -85,7 +85,7 @@ const getVariableDefinition = (
     functionCall &&
     functionCall.defs.length &&
     functionCall.defs[0].node.type === 'VariableDeclarator' &&
-    functionCall.defs[0].node.init.type === 'CallExpression'
+    functionCall.defs[0].node.init?.type === 'CallExpression'
   ) {
     return functionCall.defs[0].node.init as CallExpression;
   }


### PR DESCRIPTION
### What is this change?

Fix the rule crashing when an uninitialised variable is passed to the `css` prop.

ESLint's types give an `any` type for `functionCall.defs[0].node` so this bug was not detected by type-checking 😭 

### Why are we making this change?

Prevent rule from crashing when run on one of our internal codebases.

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
