### PR TITLE
Fix broken css prop ternaries when referencing `cssMap` objects.

### DIFF
--- a/.changeset/cyan-waves-rest.md
+++ b/.changeset/cyan-waves-rest.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+Fix supporting ternaries referencing cssMap style objects when extracting styles.

--- a/packages/babel-plugin/src/styled/__tests__/tagged-template-expression.test.ts
+++ b/packages/babel-plugin/src/styled/__tests__/tagged-template-expression.test.ts
@@ -908,7 +908,7 @@ describe('styled tagged template expression', () => {
         props.isPrimary
           ? \`
             background-color: \${({ isLoading }) => (isLoading ? colors.N20 : colors.N40)};
-            color: \${({ loading: l }) => (l ? colors.N50 : colors.N10)};
+            color: \${({ loading }) => (loading ? colors.N50 : colors.N10)};
             border-color: \${(propz) => (propz.loading ? colors.N100 : colors.N200)};
           \` : 'color: black'
         };

--- a/packages/babel-plugin/src/styled/__tests__/tagged-template-expression.test.ts
+++ b/packages/babel-plugin/src/styled/__tests__/tagged-template-expression.test.ts
@@ -908,7 +908,7 @@ describe('styled tagged template expression', () => {
         props.isPrimary
           ? \`
             background-color: \${({ isLoading }) => (isLoading ? colors.N20 : colors.N40)};
-            color: \${({ loading }) => (loading ? colors.N50 : colors.N10)};
+            color: \${({ loading: l }) => (l ? colors.N50 : colors.N10)};
             border-color: \${(propz) => (propz.loading ? colors.N100 : colors.N200)};
           \` : 'color: black'
         };

--- a/packages/babel-plugin/src/utils/css-builders.ts
+++ b/packages/babel-plugin/src/utils/css-builders.ts
@@ -381,6 +381,8 @@ const extractConditionalExpression = (node: t.ConditionalExpression, meta: Metad
       }
     } else if (t.isConditionalExpression(pathNode)) {
       cssOutput = extractConditionalExpression(pathNode, meta);
+    } else if (t.isMemberExpression(pathNode)) {
+      cssOutput = extractMemberExpression(pathNode, meta);
     }
 
     if (cssOutput) {
@@ -664,6 +666,24 @@ const extractObjectExpression = (node: t.ObjectExpression, meta: Metadata): CSSO
 };
 
 /**
+ * Extracts CSS data from a member expression node (eg. `styles.primary`)
+ *
+ * @param node Node we're interested in extracting CSS from.
+ * @param meta {Metadata} Useful metadata that can be used during the transformation
+ */
+const extractMemberExpression = (node: t.MemberExpression, meta: Metadata): CSSOutput => {
+  const bindingIdentifier = findBindingIdentifier(node);
+  if (bindingIdentifier && meta.state.cssMap[bindingIdentifier.name]) {
+    return {
+      css: [{ type: 'map', expression: node, name: bindingIdentifier.name, css: '' }],
+      variables: [],
+    };
+  }
+  const { value, meta: updatedMeta } = evaluateExpression(node, meta);
+  return buildCss(value, updatedMeta);
+};
+
+/**
  * Extracts CSS data from a template literal node.
  *
  * @param node Node we're interested in extracting CSS from.
@@ -880,15 +900,7 @@ export const buildCss = (node: t.Expression | t.Expression[], meta: Metadata): C
   }
 
   if (t.isMemberExpression(node)) {
-    const bindingIdentifier = findBindingIdentifier(node);
-    if (bindingIdentifier && meta.state.cssMap[bindingIdentifier.name]) {
-      return {
-        css: [{ type: 'map', expression: node, name: bindingIdentifier.name, css: '' }],
-        variables: [],
-      };
-    }
-    const { value, meta: updatedMeta } = evaluateExpression(node, meta);
-    return buildCss(value, updatedMeta);
+    return extractMemberExpression(node, meta);
   }
 
   if (t.isArrowFunctionExpression(node)) {


### PR DESCRIPTION
### What is this change?

We extract nested member expressions inside of conditional expressions.

### Why are we making this change?

Fixes https://github.com/atlassian-labs/compiled/issues/1750

### How are we making this change?

We simply copy the direct `buildCss > MemberExpression > …` extraction into a new path through `buildCss > ConditionalExpression > extractConditionalExpression(…) > MemberExpression > …`.

…I believe this is safe and well protected, given the underlying `extractMemberExpression` code already existed!

---

### PR checklist

I have...

- [x] Updated or added applicable tests
- [x] ~~Updated the documentation in `website/`~~ n/a
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
