### PR TITLE
Fix `@compiled/babel-plugin` to not silently skip `cssMap()` extraction in a few common edge-cases.

### DIFF
--- a/.changeset/dirty-carrots-sit.md
+++ b/.changeset/dirty-carrots-sit.md
@@ -1,0 +1,13 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+Fix `@compiled/babel-plugin` to not require `cssMap()` to be called prior to use.
+
+Example, this failed before for no reason other than the fact that our `state.cssMap` was generated _after_ `JSXElement` and `JSXOpeningElement` were ran.
+
+```tsx
+import { cssMap } from '@compiled/react';
+export default () => <div css={styles.root} />;
+const styles = cssMap({ root: { padding: 8 } });
+```

--- a/.changeset/silent-geese-wonder.md
+++ b/.changeset/silent-geese-wonder.md
@@ -1,0 +1,21 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+Throw an error when compiling a `cssMap` object where we expect a `css` or nested `cssMap` object.
+
+Example of code that silently fails today, using `styles` directly:
+
+```tsx
+import { cssMap } from '@compiled/react';
+const styles = cssMap({ root: { padding: 8 } });
+export default () => <div css={styles} />;
+```
+
+What we expect to see instead, using `styles.root` instead:
+
+```tsx
+import { cssMap } from '@compiled/react';
+const styles = cssMap({ root: { padding: 8 } });
+export default () => <div css={styles.root} />;
+```

--- a/packages/babel-plugin/src/babel-plugin.ts
+++ b/packages/babel-plugin/src/babel-plugin.ts
@@ -40,6 +40,63 @@ const JSX_SOURCE_ANNOTATION_REGEX = /\*?\s*@jsxImportSource\s+([^\s]+)/;
 
 let globalCache: Cache | undefined;
 
+const buildCompiledImportsCache: Visitor<State> = {
+  ImportDeclaration(path, state) {
+    const userLandModule = path.node.source.value;
+    const isCompiledModule = this.importSources.some((compiledModuleOrigin) => {
+      if (compiledModuleOrigin === userLandModule) {
+        return true;
+      }
+
+      if (
+        state.filename &&
+        userLandModule[0] === '.' &&
+        userLandModule.endsWith(basename(compiledModuleOrigin))
+      ) {
+        // Relative import that might be a match, resolve the relative path and compare.
+        const fullpath = resolve(dirname(state.filename), userLandModule);
+        return fullpath === compiledModuleOrigin;
+      }
+
+      return false;
+    });
+
+    if (!isCompiledModule) {
+      return;
+    }
+
+    // The presence of the module enables CSS prop
+    state.compiledImports = state.compiledImports || {};
+
+    // Go through each import and enable each found API
+    path.get('specifiers').forEach((specifier) => {
+      if (!state.compiledImports || !specifier.isImportSpecifier()) {
+        // Bail out early
+        return;
+      }
+
+      (['styled', 'ClassNames', 'css', 'keyframes', 'cssMap'] as const).forEach((apiName) => {
+        if (
+          state.compiledImports &&
+          t.isIdentifier(specifier.node?.imported) &&
+          specifier.node?.imported.name === apiName
+        ) {
+          // Enable the API with the local name
+          const apiArray = state.compiledImports[apiName] || [];
+          apiArray.push(specifier.node.local.name);
+          state.compiledImports[apiName] = apiArray;
+
+          specifier.remove();
+        }
+      });
+    });
+
+    if (path.node.specifiers.length === 0) {
+      path.remove();
+    }
+  },
+};
+
 const findClassicJsxPragmaImport: Visitor<State> = {
   ImportSpecifier(path, state) {
     const specifier = path.node;
@@ -60,6 +117,15 @@ const findClassicJsxPragmaImport: Visitor<State> = {
       // Remove the jsx import; the assumption is that we removed the classic JSX pragma, so
       // Babel shouldn't convert React.createElement to the jsx function anymore.
       path.remove();
+      return;
+    }
+  },
+};
+
+const buildCssMapState: Visitor<State> = {
+  CallExpression(path, state) {
+    if (isCompiledCSSMapCallExpression(path.node, state)) {
+      visitCssMapPath(path, { context: 'root', state, parentPath: path });
       return;
     }
   },
@@ -178,6 +244,11 @@ export default declare<State>((api) => {
               );
             }
           }
+
+          // Build our `state.compiledImports[…]` state now that we've traversed JSX pragmas
+          path.traverse<State>(buildCompiledImportsCache, this);
+          // Build our `state.cssMap[…]` before we traverse the JSXElements which consume it
+          path.traverse<State>(buildCssMapState, this);
         },
         exit(path, state) {
           if (!state.compiledImports && !state.usesXcss) {
@@ -237,60 +308,6 @@ export default declare<State>((api) => {
           });
         },
       },
-      ImportDeclaration(path, state) {
-        const userLandModule = path.node.source.value;
-
-        const isCompiledModule = this.importSources.some((compiledModuleOrigin) => {
-          if (compiledModuleOrigin === userLandModule) {
-            return true;
-          }
-
-          if (
-            state.filename &&
-            userLandModule[0] === '.' &&
-            userLandModule.endsWith(basename(compiledModuleOrigin))
-          ) {
-            // Relative import that might be a match, resolve the relative path and compare.
-            const fullpath = resolve(dirname(state.filename), userLandModule);
-            return fullpath === compiledModuleOrigin;
-          }
-
-          return false;
-        });
-
-        if (!isCompiledModule) {
-          return;
-        }
-
-        // The presence of the module enables CSS prop
-        state.compiledImports = state.compiledImports || {};
-
-        // Go through each import and enable each found API
-        path.get('specifiers').forEach((specifier) => {
-          if (!state.compiledImports || !specifier.isImportSpecifier()) {
-            // Bail out early
-            return;
-          }
-
-          (['styled', 'ClassNames', 'css', 'keyframes', 'cssMap'] as const).forEach((apiName) => {
-            if (
-              state.compiledImports &&
-              t.isIdentifier(specifier.node?.imported) &&
-              specifier.node?.imported.name === apiName
-            ) {
-              // Enable the API with the local name
-              const apiArray = state.compiledImports[apiName] || [];
-              apiArray.push(specifier.node.local.name);
-              state.compiledImports[apiName] = apiArray;
-              specifier.remove();
-            }
-          });
-        });
-
-        if (path.node.specifiers.length === 0) {
-          path.remove();
-        }
-      },
       'TaggedTemplateExpression|CallExpression'(
         path: NodePath<t.TaggedTemplateExpression> | NodePath<t.CallExpression>,
         state: State
@@ -310,10 +327,6 @@ Reasons this might happen:
             path.parentPath.node,
             path.parentPath
           );
-        }
-        if (isCompiledCSSMapCallExpression(path.node, state)) {
-          visitCssMapPath(path, { context: 'root', state, parentPath: path });
-          return;
         }
 
         const hasStyles =

--- a/packages/babel-plugin/src/css-map/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/css-map/__tests__/index.test.ts
@@ -107,6 +107,30 @@ describe('css map basic functionality', () => {
     ]);
   });
 
+  it('should error out if the root cssMap object is being directly called', () => {
+    expect(() => {
+      transform(`
+      import { cssMap } from '@compiled/react';
+
+      const styles = cssMap({ root: { color: 'red' } });
+
+      // Eg. we expect 'styles.root' here instead of 'styles'
+      <div css={styles} />
+    `);
+    }).toThrow(ErrorMessages.USE_VARIANT_OF_CSS_MAP);
+
+    expect(() => {
+      transform(`
+      import { cssMap } from '@compiled/react';
+
+      // Eg. we expect 'styles.root' here instead of 'styles'
+      <div css={styles} />
+
+      const styles = cssMap({ root: { color: 'red' } });
+    `);
+    }).toThrow(ErrorMessages.USE_VARIANT_OF_CSS_MAP);
+  });
+
   it('should error out if variants are not defined at the top-most scope of the module.', () => {
     expect(() => {
       transform(`

--- a/packages/babel-plugin/src/css-map/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/css-map/__tests__/index.test.ts
@@ -36,6 +36,25 @@ describe('css map basic functionality', () => {
     ]);
   });
 
+  it('should transform css map even when the styles are defined below the component', () => {
+    const actual = transform(`
+      import { cssMap } from '@compiled/react';
+
+      const Component = () => <div>
+        <span css={styles.danger} />
+        <span css={styles.success} />
+      </div>
+
+      const styles = cssMap(${styles});
+    `);
+
+    expect(actual).toIncludeMultiple([
+      'const styles={danger:"_syaz5scu _bfhk5scu",success:"_syazbf54 _bfhkbf54"};',
+      '<span className={ax([styles.danger])}/>',
+      '<span className={ax([styles.success])}/>',
+    ]);
+  });
+
   it('should transform css map even with an empty object', () => {
     const actual = transform(`
         import { css, cssMap } from '@compiled/react';

--- a/packages/babel-plugin/src/types.ts
+++ b/packages/babel-plugin/src/types.ts
@@ -195,6 +195,11 @@ export interface State extends PluginPass {
   cssMap: Record<string, string[]>;
 
   /**
+   * Holdings a record of member expression names to ignore
+   */
+  ignoreMemberExpressions: Record<string, true>;
+
+  /**
    * A custom resolver used to statically evaluate import declarations
    */
   resolver?: Resolver;

--- a/packages/babel-plugin/src/utils/css-map.ts
+++ b/packages/babel-plugin/src/utils/css-map.ts
@@ -86,6 +86,7 @@ export enum ErrorMessages {
   STATIC_PROPERTY_KEY = 'Property key may only be a static string.',
   SELECTOR_BLOCK_WRONG_PLACE = '`selector` key was defined in the wrong place.',
   USE_SELECTORS_WITH_AMPERSAND = 'This selector is applied to the parent element, and so you need to specify the ampersand symbol (&) directly before it. For example, `:hover` should be written as `&:hover`.',
+  USE_VARIANT_OF_CSS_MAP = 'You must use the variant of a CSS Map object (eg. `styles.root`), not the root object itself, eg. `styles`.',
 }
 
 export const createErrorMessage = (message: string): string => {

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -19,7 +19,7 @@ describe('createStrictAPI()', () => {
   });
 
   it('should mark all styles as optional in cssMap()', () => {
-    const styles = cssMap({
+    const stylesMap = cssMap({
       nested: {
         '&:hover': {},
         '&:active': {},
@@ -28,7 +28,7 @@ describe('createStrictAPI()', () => {
       },
     });
 
-    const { getByTestId } = render(<div css={styles.nested} data-testid="div" />);
+    const { getByTestId } = render(<div css={stylesMap.nested} data-testid="div" />);
 
     expect(getByTestId('div')).toBeDefined();
   });
@@ -96,7 +96,7 @@ describe('createStrictAPI()', () => {
     });
 
     it('should violate types for cssMap()', () => {
-      const styles = cssMap({
+      const stylesMap = cssMap({
         primary: {
           // @ts-expect-error — Type '""' is not assignable to type ...
           color: '',
@@ -129,7 +129,7 @@ describe('createStrictAPI()', () => {
         },
       });
 
-      const { getByTestId } = render(<div css={styles.primary} data-testid="div" />);
+      const { getByTestId } = render(<div css={stylesMap.primary} data-testid="div" />);
 
       expect(getByTestId('div')).toBeDefined();
     });
@@ -224,7 +224,7 @@ describe('createStrictAPI()', () => {
     });
 
     it('should pass type check for cssMap()', () => {
-      const styles = cssMap({
+      const stylesMap = cssMap({
         primary: {
           color: 'var(--ds-text)',
           backgroundColor: 'var(--ds-bold)',
@@ -258,7 +258,7 @@ describe('createStrictAPI()', () => {
         },
       });
 
-      const { getByTestId } = render(<div css={styles.primary} data-testid="div" />);
+      const { getByTestId } = render(<div css={stylesMap.primary} data-testid="div" />);
 
       expect(getByTestId('div')).toHaveCompiledCss('color', 'var(--ds-text)');
     });


### PR DESCRIPTION
### What is this change?

Fixes https://github.com/atlassian-labs/compiled/issues/1642

Resolves two issues revolving around `cssMap` not extracting which could lead to production issues as Runtime and Extraction are handled differently with little to no testability in this area.
1. When `cssMap` is called after it's used, eg. `<div css={styles.root}>; const styles  = cssMap({ root: … });`, styles are never extracted
2. When the root `cssMap` object is passed to css, eg. `<div css={styles}>; const styles  = cssMap(…);`, styles are never extracted and this results in no typescript error — built via https://github.com/atlassian-labs/compiled/pull/1774 and merged into this branch already.

### Why are we making this change?

Both of these seemingly acceptable code examples passed full CI, TS, Linting, Babel, etc., but styles were simply never displayed to the user.

```tsx
import { cssMap } from "@compiled/react";
export default () => <div css={styles.root} />;
const styles = cssMap({ root: { padding: 8 } });
```

```tsx
import { cssMap } from "@compiled/react";
const styles = cssMap({ root: { padding: 8 } });
export default () => <div css={styles} />;
```

These should both worth now and be tested, with the downside that this _could_ result in breaking changes by "fixing" these currently erroring paths…

---

### PR checklist

I have...

- [x] Updated or added applicable tests
- [x] ~Updated the documentation in `website/`~ n/a
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
