### PR TITLE
Throw an error when compiling a `cssMap` object where we expect a `css` or nested `cssMap` object.

### DIFF
--- a/.changeset/silent-geese-wonder.md
+++ b/.changeset/silent-geese-wonder.md
@@ -1,0 +1,21 @@
+---
+'@compiled/babel-plugin': minor
+---
+
+Throw an error when compiling a `cssMap` object where we expect a `css` or nested `cssMap` object.
+
+Example of code that silently fails today, using `styles` directly:
+
+```tsx
+import { cssMap } from '@compiled/react';
+const styles = cssMap({ root: { padding: 8 } });
+export default () => <div css={styles} />;
+```
+
+What we expect to see instead, using `styles.root` instead:
+
+```tsx
+import { cssMap } from '@compiled/react';
+const styles = cssMap({ root: { padding: 8 } });
+export default () => <div css={styles.root} />;
+```

--- a/packages/babel-plugin/src/css-map/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/css-map/__tests__/index.test.ts
@@ -112,10 +112,21 @@ describe('css map basic functionality', () => {
       transform(`
       import { cssMap } from '@compiled/react';
 
-      const styles = cssMap(${styles});
+      const styles = cssMap({ root: { color: 'red' } });
 
-      // Eg. we expect 'styles.danger' here instead of 'styles'
+      // Eg. we expect 'styles.root' here instead of 'styles'
       <div css={styles} />
+    `);
+    }).toThrow(ErrorMessages.USE_VARIANT_OF_CSS_MAP);
+
+    expect(() => {
+      transform(`
+      import { cssMap } from '@compiled/react';
+
+      // Eg. we expect 'styles.root' here instead of 'styles'
+      <div css={styles} />
+
+      const styles = cssMap({ root: { color: 'red' } });
     `);
     }).toThrow(ErrorMessages.USE_VARIANT_OF_CSS_MAP);
   });

--- a/packages/babel-plugin/src/css-map/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/css-map/__tests__/index.test.ts
@@ -107,6 +107,19 @@ describe('css map basic functionality', () => {
     ]);
   });
 
+  it('should error out if the root cssMap object is being directly called', () => {
+    expect(() => {
+      transform(`
+      import { cssMap } from '@compiled/react';
+
+      const styles = cssMap(${styles});
+
+      // Eg. we expect 'styles.danger' here instead of 'styles'
+      <div css={styles} />
+    `);
+    }).toThrow(ErrorMessages.USE_VARIANT_OF_CSS_MAP);
+  });
+
   it('should error out if variants are not defined at the top-most scope of the module.', () => {
     expect(() => {
       transform(`

--- a/packages/babel-plugin/src/utils/css-builders.ts
+++ b/packages/babel-plugin/src/utils/css-builders.ts
@@ -670,6 +670,45 @@ const extractObjectExpression = (node: t.ObjectExpression, meta: Metadata): CSSO
 };
 
 /**
+ * If we don't yet have a `meta.state.cssMap[node.name]` built yet, try to build and cache it, eg. in this scenario:
+ * ```tsx
+ * const Component = () => <div css={styles.root} />
+ * const styles = cssMap({ root: { padding: 0 } });
+ * ```
+ *
+ * If we don't find this is a `cssMap()` call, we put it into `ignoreMemberExpressions` to ignore on future runs.
+ *
+ * @returns {Boolean} Whether the cache was generated
+ */
+const generateCacheForCSSMap = (node: t.Identifier, meta: Metadata): void => {
+  if (meta.state.cssMap[node.name] || meta.state.ignoreMemberExpressions[node.name]) {
+    return;
+  }
+
+  const resolved = resolveBinding(node.name, meta, evaluateExpression);
+  if (resolved && isCompiledCSSMapCallExpression(resolved.node, meta.state)) {
+    let resolvedCallPath = resolved.path.get('init');
+    if (Array.isArray(resolvedCallPath)) {
+      resolvedCallPath = resolvedCallPath[0];
+    }
+
+    if (t.isCallExpression(resolvedCallPath.node)) {
+      // This visits the cssMap path and caches the styles
+      visitCssMapPath(resolvedCallPath as NodePath<t.CallExpression>, {
+        context: 'root',
+        state: meta.state,
+        parentPath: resolved.path,
+      });
+    }
+  }
+
+  if (!meta.state.cssMap[node.name]) {
+    // If this cannot be found, it's likely not a `cssMap` identifier and we shouldn't parse it again on future runs…
+    meta.state.ignoreMemberExpressions[node.name] = true;
+  }
+};
+
+/**
  * Extracts CSS data from a member expression node (eg. `styles.primary`)
  *
  * @param node Node we're interested in extracting CSS from.
@@ -694,45 +733,14 @@ function extractMemberExpression(
   const bindingIdentifier = findBindingIdentifier(node);
 
   if (bindingIdentifier) {
-    /**
-     * If we don't yet have a `meta.state.cssMap[…]` built yet, build it and cache it, eg. in this scenario:
-     * ```tsx
-     * const Component = () => <div css={styles.root} />
-     * const styles = cssMap({ root: { padding: 0 } });
-     * ```
-     *
-     * If we don't hit this, we put it into `ignoreMemberExpressions` to ignore on future runs.
-     */
-    if (
-      !meta.state.cssMap[bindingIdentifier.name] &&
-      !meta.state.ignoreMemberExpressions[bindingIdentifier.name]
-    ) {
-      const resolved = resolveBinding(bindingIdentifier.name, meta, evaluateExpression);
-      if (resolved && isCompiledCSSMapCallExpression(resolved.node, meta.state)) {
-        let resolvedCallPath = resolved.path.get('init');
-        if (Array.isArray(resolvedCallPath)) {
-          resolvedCallPath = resolvedCallPath[0];
-        }
-
-        if (t.isCallExpression(resolvedCallPath.node)) {
-          visitCssMapPath(resolvedCallPath as NodePath<t.CallExpression>, {
-            context: 'root',
-            state: meta.state,
-            parentPath: resolved.path,
-          });
-        }
-      }
-    }
-
+    // In some cases, the `state.cssMap` is not warmed yet, so run it:
+    generateCacheForCSSMap(bindingIdentifier, meta);
     if (meta.state.cssMap[bindingIdentifier.name]) {
       return {
         css: [{ type: 'map', expression: node, name: bindingIdentifier.name, css: '' }],
         variables: [],
       };
     }
-
-    // If this cannot be found, it's likely not a `cssMap` identifier and we shouldn't parse it again on future runs…
-    meta.state.ignoreMemberExpressions[bindingIdentifier.name] = true;
   }
 
   if (fallbackToEvaluate) {
@@ -996,6 +1004,8 @@ export const buildCss = (node: t.Expression | t.Expression[], meta: Metadata): C
       );
     }
 
+    // In some cases, the `state.cssMap` is not warmed yet, so run it:
+    generateCacheForCSSMap(node, meta);
     if (meta.state.cssMap[node.name]) {
       throw buildCodeFrameError(
         createErrorMessage(ErrorMessages.USE_VARIANT_OF_CSS_MAP),

--- a/packages/babel-plugin/src/utils/css-builders.ts
+++ b/packages/babel-plugin/src/utils/css-builders.ts
@@ -9,6 +9,7 @@ import type { Metadata } from '../types';
 
 import { buildCodeFrameError } from './ast';
 import { CONDITIONAL_PATHS } from './constants';
+import { createErrorMessage, ErrorMessages } from './css-map';
 import { evaluateExpression } from './evaluate-expression';
 import {
   isCompiledCSSCallExpression,
@@ -990,6 +991,14 @@ export const buildCss = (node: t.Expression | t.Expression[], meta: Metadata): C
     if (!t.isExpression(resolvedBinding.node)) {
       throw buildCodeFrameError(
         `${resolvedBinding.node.type} isn't a supported CSS type - try using an object or string`,
+        node,
+        meta.parentPath
+      );
+    }
+
+    if (meta.state.cssMap[node.name]) {
+      throw buildCodeFrameError(
+        createErrorMessage(ErrorMessages.USE_VARIANT_OF_CSS_MAP),
         node,
         meta.parentPath
       );

--- a/packages/babel-plugin/src/utils/css-map.ts
+++ b/packages/babel-plugin/src/utils/css-map.ts
@@ -86,6 +86,7 @@ export enum ErrorMessages {
   STATIC_PROPERTY_KEY = 'Property key may only be a static string.',
   SELECTOR_BLOCK_WRONG_PLACE = '`selector` key was defined in the wrong place.',
   USE_SELECTORS_WITH_AMPERSAND = 'This selector is applied to the parent element, and so you need to specify the ampersand symbol (&) directly before it. For example, `:hover` should be written as `&:hover`.',
+  USE_VARIANT_OF_CSS_MAP = 'You must use the variant of a CSS Map object (eg. `styles.root`), not the root object itself, eg. `styles`.',
 }
 
 export const createErrorMessage = (message: string): string => {

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -19,7 +19,7 @@ describe('createStrictAPI()', () => {
   });
 
   it('should mark all styles as optional in cssMap()', () => {
-    const styles = cssMap({
+    const stylesMap = cssMap({
       nested: {
         '&:hover': {},
         '&:active': {},
@@ -28,7 +28,7 @@ describe('createStrictAPI()', () => {
       },
     });
 
-    const { getByTestId } = render(<div css={styles.nested} data-testid="div" />);
+    const { getByTestId } = render(<div css={stylesMap.nested} data-testid="div" />);
 
     expect(getByTestId('div')).toBeDefined();
   });
@@ -96,7 +96,7 @@ describe('createStrictAPI()', () => {
     });
 
     it('should violate types for cssMap()', () => {
-      const styles = cssMap({
+      const stylesMap = cssMap({
         primary: {
           // @ts-expect-error — Type '""' is not assignable to type ...
           color: '',
@@ -129,7 +129,7 @@ describe('createStrictAPI()', () => {
         },
       });
 
-      const { getByTestId } = render(<div css={styles.primary} data-testid="div" />);
+      const { getByTestId } = render(<div css={stylesMap.primary} data-testid="div" />);
 
       expect(getByTestId('div')).toBeDefined();
     });
@@ -224,7 +224,7 @@ describe('createStrictAPI()', () => {
     });
 
     it('should pass type check for cssMap()', () => {
-      const styles = cssMap({
+      const stylesMap = cssMap({
         primary: {
           color: 'var(--ds-text)',
           backgroundColor: 'var(--ds-bold)',
@@ -258,7 +258,7 @@ describe('createStrictAPI()', () => {
         },
       });
 
-      const { getByTestId } = render(<div css={styles.primary} data-testid="div" />);
+      const { getByTestId } = render(<div css={stylesMap.primary} data-testid="div" />);
 
       expect(getByTestId('div')).toHaveCompiledCss('color', 'var(--ds-text)');
     });


### PR DESCRIPTION
### What is this change?

Fixes https://github.com/atlassian-labs/compiled/issues/1642

Example of code that silently fails today, using `styles` directly:
```tsx
import { cssMap } from '@compiled/react';
const styles = cssMap({ root: { padding: 8 } });
export default () => <div css={styles} />;
```

What we expect to see instead, using `styles.root` instead:
```tsx
import { cssMap } from '@compiled/react';
const styles = cssMap({ root: { padding: 8 } });
export default () => <div css={styles.root} />;
```

---

### PR checklist

- [x] Updated or added applicable tests
- [x] ~Updated the documentation in `website/`~ n/a
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
