### PR TITLE
Fix some false positives with ternary operators and cssMap

### DIFF
--- a/.changeset/few-camels-compare.md
+++ b/.changeset/few-camels-compare.md
@@ -1,0 +1,5 @@
+---
+'@compiled/eslint-plugin': patch
+---
+
+Fix some false positives in `shorthand-property-sorting` with css and cssMap

--- a/packages/eslint-plugin/src/rules/shorthand-property-sorting/index.ts
+++ b/packages/eslint-plugin/src/rules/shorthand-property-sorting/index.ts
@@ -120,15 +120,15 @@ const getObjectCSSProperties = (
 // repeated properties are de-duplicated.
 //
 // Nested arrays (nested selectors, pseudo-selectors, etc.) are not de-duplicated.
-const union = (...otherArrays: PropertyArray[]): PropertyArray => {
+const union = (...arrays: PropertyArray[]): PropertyArray => {
   const newArray = [];
-  const propertiesInArrayA = new Set<string>();
 
-  if (otherArrays.length === 0) {
+  if (arrays.length === 0) {
     return [];
   }
 
-  const arrayA = otherArrays[0];
+  const arrayA = arrays[0];
+  const propertiesInArrayA = new Set<string>();
 
   for (const elementA of arrayA) {
     newArray.push(elementA);
@@ -137,7 +137,7 @@ const union = (...otherArrays: PropertyArray[]): PropertyArray => {
     }
   }
 
-  for (const arrayB of otherArrays.slice(1)) {
+  for (const arrayB of arrays.slice(1)) {
     for (const elementB of arrayB) {
       if (Array.isArray(elementB)) {
         newArray.push(elementB);

--- a/packages/eslint-plugin/src/rules/shorthand-property-sorting/index.ts
+++ b/packages/eslint-plugin/src/rules/shorthand-property-sorting/index.ts
@@ -116,6 +116,45 @@ const getObjectCSSProperties = (
   return properties;
 };
 
+// Given two (or more) arrays of properties, concatenate them in such a way that any
+// repeated properties are de-duplicated.
+//
+// Nested arrays (nested selectors, pseudo-selectors, etc.) are not de-duplicated.
+const union = (...otherArrays: PropertyArray[]): PropertyArray => {
+  const newArray = [];
+  const propertiesInArrayA = new Set<string>();
+
+  if (otherArrays.length === 0) {
+    return [];
+  }
+
+  const arrayA = otherArrays[0];
+
+  for (const elementA of arrayA) {
+    newArray.push(elementA);
+    if (!Array.isArray(elementA)) {
+      propertiesInArrayA.add(elementA.name);
+    }
+  }
+
+  for (const arrayB of otherArrays.slice(1)) {
+    for (const elementB of arrayB) {
+      if (Array.isArray(elementB)) {
+        newArray.push(elementB);
+        continue;
+      }
+
+      if (propertiesInArrayA.has(elementB.name)) {
+        continue;
+      }
+
+      newArray.push(elementB);
+    }
+  }
+
+  return newArray;
+};
+
 const parseCssArrayElement = (
   context: Rule.RuleContext,
   element: ArrayExpression['elements'][number]
@@ -136,8 +175,10 @@ const parseCssArrayElement = (
     // Covers the case:
     //     someCondition ? someStyles : someOtherStyles
     return [
-      ...parseCssArrayElement(context, element.consequent),
-      ...parseCssArrayElement(context, element.alternate),
+      ...union(
+        parseCssArrayElement(context, element.consequent),
+        parseCssArrayElement(context, element.alternate)
+      ),
     ];
   } else if (element.type === 'MemberExpression' && element.object.type === 'Identifier') {
     // Covers cssMap usages
@@ -275,7 +316,7 @@ const parseCssMap = (
   context: Rule.RuleContext,
   { node, key }: { node: CallExpression; key?: string | Literal['value'] }
 ): PropertyArray => {
-  const properties: PropertyArray = [];
+  const properties: PropertyArray[] = [];
   const { references } = context.sourceCode.getScope(node);
   if (!isCssMap(node.callee as Rule.Node, references)) {
     return [];
@@ -303,26 +344,24 @@ const parseCssMap = (
       // If we know what key in the cssMap function call to traverse,
       // we can make sure we only traverse that.
       if (property.key.type === 'Literal' && key === property.key.value) {
-        properties.push(...getObjectCSSProperties(context, property.value));
-        break;
+        return getObjectCSSProperties(context, property.value);
       } else if (property.key.type === 'Identifier' && key === property.key.name) {
-        properties.push(...getObjectCSSProperties(context, property.value));
-        break;
+        return getObjectCSSProperties(context, property.value);
       }
-    } else {
-      // We cannot determine which key in the cssMap function call to traverse,
-      // so we have no choice but to unconditionally traverse through the whole
-      // cssMap object.
-      //
-      // Not very performant and can give false positives, but considering that
-      // the cssMap key can be dynamic, we at least avoid any false negatives.
-      //
-      // (https://compiledcssinjs.com/docs/api-cssmap#dynamic-declarations)
-      properties.push(...getObjectCSSProperties(context, property.value));
     }
+
+    // We cannot determine which key in the cssMap function call to traverse,
+    // so we have no choice but to unconditionally traverse through the whole
+    // cssMap object.
+    //
+    // Not very performant and can give false positives, but considering that
+    // the cssMap key can be dynamic, we at least avoid any false negatives.
+    //
+    // (https://compiledcssinjs.com/docs/api-cssmap#dynamic-declarations)
+    properties.push(getObjectCSSProperties(context, property.value));
   }
 
-  return properties;
+  return union(...properties);
 };
 
 const parseStyled = (context: Rule.RuleContext, node: CallExpression): PropertyArray => {

--- a/packages/eslint-plugin/src/rules/shorthand-property-sorting/index.ts
+++ b/packages/eslint-plugin/src/rules/shorthand-property-sorting/index.ts
@@ -174,12 +174,10 @@ const parseCssArrayElement = (
   } else if (element.type === 'ConditionalExpression') {
     // Covers the case:
     //     someCondition ? someStyles : someOtherStyles
-    return [
-      ...union(
-        parseCssArrayElement(context, element.consequent),
-        parseCssArrayElement(context, element.alternate)
-      ),
-    ];
+    return union(
+      parseCssArrayElement(context, element.consequent),
+      parseCssArrayElement(context, element.alternate)
+    );
   } else if (element.type === 'MemberExpression' && element.object.type === 'Identifier') {
     // Covers cssMap usages
     functionCall = getVariableDefinition(context, element.object);


### PR DESCRIPTION
### What is this change?

Fix two edge cases:

* When using the _same properties_ across two `css` function calls through ternary operators, we should not get an ESLint violation.

```tsx
import { css } from '@compiled/react';

const oldStyles = css({
  font: '...',
  fontWeight: '...',
});
const newStyles = css({
  font: '...',
  fontWeight: '...',
});
const someCondition = true;
export const EmphasisText = ({ children }) => <span css={[someCondition ? oldStyles : newStyles]}>{children}</span>;
```

* When using the _same properties_ across two keys in a `cssMap` function call, we should not get an ESLint violation.

```tsx
import { cssMap } from '@compiled/react';

const styles = cssMap({
  warning: {
    borderColor: '...',
    borderTop: '...',
  },
  debug: {
    borderColor: '...',
    borderTop: '...',
  },
  normal: {
    borderColor: '...',
    borderTop: '...',
  },
});
export const EmphasisText = ({ children, appearance }) => <span css={styles[appearance]}>{children}</span>;
```

Note that there still remain a lot of other (pre-existing) edge cases -- this rule is really hard to make fully rigorous, sorry 🙇  For example, this will still cause a false positive:

```tsx
import { css } from '@compiled/react';

const oldStyles = css({
  fontWeight: '...',
});
const newStyles = css({
  font: '...',
});

const someCondition = true;
export const EmphasisText = ({ children }) => <span css={[someCondition ? oldStyles : newStyles]}>{children}</span>;
```

### Why are we making this change?

We've received an internal query about a false positive with `css`, and it looks like it's pretty easy to fix.

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
