### PR TITLE
Add hash to stylesheet extraction docs

### DIFF
--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -65,7 +65,7 @@ module.exports = {
   plugins: [
     ...(extractCSS
       ? [
-          new MiniCssExtractPlugin({ filename: '[name].css' }),
+          new MiniCssExtractPlugin({ filename: '[name].[contenthash].css' }),
           new CompiledExtractPlugin({ sortShorthand: true }),
         ]
       : []),

--- a/website/packages/docs/src/pages/css-extraction-webpack.mdx
+++ b/website/packages/docs/src/pages/css-extraction-webpack.mdx
@@ -173,7 +173,7 @@ module.exports = {
 		],
 	},
 	plugins: [
-+		new MiniCssExtractPlugin(),
++		new MiniCssExtractPlugin({ filename: '[name].[contenthash].css' }),
 		new CompiledExtractPlugin(),
 	],
 };
@@ -227,16 +227,17 @@ All extracted styles will be placed in a file called `compiled-css.css`.
 
 #### Filename
 
-Pass the `filename` option to the extract plugin,
-we recommend using `[contenthash]` in the name.
+Some production environments may require you to include a hash in the filename to allow the stylesheet to be cached correctly.
+
+To do this, pass the `filename` option to the extract plugin, including `[contenthash]` in the name.
 
 ```diff
 // webpack.config.js
 -new MiniCssExtractPlugin()
-+new MiniCssExtractPlugin({ filename: '[contenthash].[name].css' })
++new MiniCssExtractPlugin({ filename: '[name].[contenthash].css' })
 ```
 
-See [`mini-css-extract-plugin` docs](https://github.com/webpack-contrib/mini-css-extract-plugin/#long-term-caching) for more information on these options.
+See the [`mini-css-extract-plugin` docs](https://github.com/webpack-contrib/mini-css-extract-plugin/#long-term-caching) for more information on the available options.
 
 ### CSS minification
 


### PR DESCRIPTION
### What is this change?

Clarify in the documentation that with Webpack stylesheet extraction, the developer needs to make sure that the `compiled-css.css` filename contains a unique hash.

### Why are we making this change?

Our Webpack-based production environments expect a unique hash as part of the filename path.


---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
