### PR TITLE
Bump actions/upload-artifact@v4 following blocking deprecation.

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -52,3 +52,4 @@ jobs:
         with:
           name: visual-regression-screenshots
           path: .loki
+          include-hidden-files: true

--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Archive screenshots
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: visual-regression-screenshots
           path: .loki


### PR DESCRIPTION
### What is this change?

Bumps `actions/upload-artifcat` to version 4 following https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md (eg. no changes expected)

All builds are failing due to a blocking upstream change: https://github.com/atlassian-labs/compiled/actions/runs/13124206809/job/36617003663?pr=1792