### PR TITLE
Fix height usages causing crash in non-media query

### DIFF
--- a/.changeset/shy-deers-exist.md
+++ b/.changeset/shy-deers-exist.md
@@ -1,0 +1,5 @@
+---
+'@compiled/css': patch
+---
+
+Fix height property in non-media query causing Compiled to crash

--- a/packages/css/src/plugins/__tests__/sort-at-rules.test.ts
+++ b/packages/css/src/plugins/__tests__/sort-at-rules.test.ts
@@ -884,5 +884,33 @@ describe('sort at-rules', () => {
               "
       `);
     });
+
+    it("shouldn't crash when height property is in a non-media query", () => {
+      const actual = transform(`
+        @supports not (height: 1lh) {
+          height: 1lh;
+        }
+        @media (width > 200px) {
+          color: abc;
+        }
+        @media (width > 26.1ch) {
+          color: abc;
+        }
+      `);
+
+      expect(actual).toMatchInlineSnapshot(`
+        "
+                @media (width > 200px) {
+                  color: abc;
+                }
+                @media (width > 26.1ch) {
+                  color: abc;
+                }
+                @supports not (height: 1lh) {
+                  height: 1lh;
+                }
+              "
+      `);
+    });
   });
 });

--- a/packages/css/src/plugins/at-rules/parse-media-query.ts
+++ b/packages/css/src/plugins/at-rules/parse-media-query.ts
@@ -45,7 +45,7 @@ const length_ = /(?<length>-?\d*\.?\d+)(?<lengthUnit>ch|em|ex|px|rem)?\s*/;
  * @param params The original media query, as a string
  * @returns The extracted and parsed breakpoints from the media query
  */
-export const parseAtRule = (params: string): ParsedAtRule[] => {
+export const parseMediaQuery = (params: string): ParsedAtRule[] => {
   // Inspired by previous work from
   // https://github.com/OlehDutchenko/sort-css-media-queries/blob/master/lib/create-sort.js
 

--- a/packages/css/src/plugins/sort-atomic-style-sheet.ts
+++ b/packages/css/src/plugins/sort-atomic-style-sheet.ts
@@ -2,7 +2,7 @@ import type { ChildNode, Rule, Plugin, AtRule } from 'postcss';
 
 import { sortPseudoSelectors } from '../utils/sort-pseudo-selectors';
 
-import { parseAtRule } from './at-rules/parse-at-rule';
+import { parseMediaQuery } from './at-rules/parse-media-query';
 import { sortAtRules } from './at-rules/sort-at-rules';
 import type { AtRuleInfo } from './at-rules/types';
 import { sortShorthandDeclarations } from './sort-shorthand-declarations';
@@ -61,7 +61,7 @@ export const sortAtomicStyleSheet = (config: {
               atRules.push({
                 parsed:
                   sortAtRulesEnabled && node.first.name === 'media'
-                    ? parseAtRule(node.first.params)
+                    ? parseMediaQuery(node.first.params)
                     : [],
                 node,
                 atRuleName: node.first.name,
@@ -76,7 +76,8 @@ export const sortAtomicStyleSheet = (config: {
 
           case 'atrule': {
             atRules.push({
-              parsed: sortAtRulesEnabled && node.name === 'media' ? parseAtRule(node.params) : [],
+              parsed:
+                sortAtRulesEnabled && node.name === 'media' ? parseMediaQuery(node.params) : [],
               node,
               atRuleName: node.name,
               query: node.params,

--- a/packages/css/src/plugins/sort-atomic-style-sheet.ts
+++ b/packages/css/src/plugins/sort-atomic-style-sheet.ts
@@ -59,7 +59,10 @@ export const sortAtomicStyleSheet = (config: {
           case 'rule': {
             if (node.first?.type === 'atrule') {
               atRules.push({
-                parsed: sortAtRulesEnabled ? parseAtRule(node.first.params) : [],
+                parsed:
+                  sortAtRulesEnabled && node.first.name === 'media'
+                    ? parseAtRule(node.first.params)
+                    : [],
                 node,
                 atRuleName: node.first.name,
                 query: node.first.params,
@@ -73,7 +76,7 @@ export const sortAtomicStyleSheet = (config: {
 
           case 'atrule': {
             atRules.push({
-              parsed: sortAtRulesEnabled ? parseAtRule(node.params) : [],
+              parsed: sortAtRulesEnabled && node.name === 'media' ? parseAtRule(node.params) : [],
               node,
               atRuleName: node.name,
               query: node.params,


### PR DESCRIPTION
### What is this change?

Update the `parseAtRule` function to ensure it only runs for media queries (what the function is designed for) and not other types of at-rules. Also update the name to clarify that it only works for media queries.

### Why are we making this change?

Fixes the bug where this causes Compiled to crash at build time:

```
const overlayStyles = css({
	'@supports not (height: 1lh)': {
		color: token('color.text'),
	},
});
```

This is because the presence of `height` causes the at-rule to be treated like a media query, resulting in Compiled crashing when the at-rule doesn't use the expected syntax.


---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
