### PR TITLE
Improve the types to the `keyframes()` function to handle CSS variables.

### DIFF
--- a/.changeset/long-foxes-pay.md
+++ b/.changeset/long-foxes-pay.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Improve the types to the `keyframes()` function to handle CSS variables.

--- a/packages/react/src/keyframes/__tests__/index.test.tsx
+++ b/packages/react/src/keyframes/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @compiled/react */
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { keyframes, styled } from '@compiled/react';
+import { keyframes, styled, css } from '@compiled/react';
 import { render } from '@testing-library/react';
 
 import defaultFadeOut, { namedFadeOut, fadeOut as shadowedFadeOut } from '../__fixtures__';
@@ -178,6 +178,32 @@ describe('keyframes', () => {
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'korwhog');
         expect(getKeyframe('korwhog')).toMatchInlineSnapshot(
           `"@keyframes korwhog{0%{opacity:1}to{opacity:0}}"`
+        );
+      });
+
+      it('containing css variables', () => {
+        const variable = '--opacity';
+        const fadeOut = keyframes({
+          from: {
+            [variable]: 1,
+          },
+          to: {
+            '--opacity': 0,
+          },
+        });
+        const styles = css({
+          animationName: fadeOut,
+          opacity: `var(${variable})`,
+        });
+
+        const { getByText } = render(<div css={styles}>hello world</div>);
+
+        expect(getByText('hello world')).toHaveCompiledCss({
+          animationName: 'k1sm7npi',
+          opacity: 'var(--opacity)',
+        });
+        expect(getKeyframe('k1sm7npi')).toMatchInlineSnapshot(
+          `"@keyframes k1sm7npi{0%{--opacity:1px}to{--opacity:0}}"`
         );
       });
     });

--- a/packages/react/src/keyframes/index.ts
+++ b/packages/react/src/keyframes/index.ts
@@ -1,7 +1,15 @@
 import type { BasicTemplateInterpolations, CSSProps } from '../types';
 import { createSetupError } from '../utils/error';
 
-export type KeyframeSteps = string | Record<string, CSSProps<void>>;
+export type KeyframeSteps =
+  // `string` would just be an arbitrary CSS-like string such as `keyframes('from{opacity:1;}to{opacity:0;}')`
+  | string
+  | Record<
+      'from' | 'to' | string,
+      // We allow basically all CSSProperties here and CSS Variables mapping to their values.
+      // eg. `{ display: 'block', '--var': 'block' }` — but likely it just becomes `'--var': any`
+      CSSProps<void> | { [key: `--${string}`]: CSSProps<void>[keyof CSSProps<void>] }
+    >;
 
 /**
  * ## Keyframes


### PR DESCRIPTION
### What is this change?

Today, `keyframes()` doesn't work with CSS variables, eg. this doesn't work, this PR fixes the types for it.
```tsx
const animation = keyframes({
  from: { '--opacity': 1 },
  to: { '--opacity: 0 },
});
```

### Why are we making this change?

While CSS variables can be unsafe at times, there are some circumstances where this is the absolute best way to animate something, and Compiled should still protect from arbitrarily imported `[variableName]` properties regardlesss.

---

### PR checklist

- [x] Updated or added applicable tests
- [x] ~~Updated the documentation in `website/`~~ n/a
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
