### PR TITLE
Properly handle more flex keywords in shorthand extraction.

### DIFF
--- a/.changeset/seven-falcons-build.md
+++ b/.changeset/seven-falcons-build.md
@@ -1,0 +1,5 @@
+---
+'@compiled/css': minor
+---
+
+Properly handle flex keywords such as 'flex:initial', 'flex:revert', etc, rather than defaulting to 'flex:auto' on any keyword.

--- a/packages/css/src/plugins/expand-shorthands/__tests__/flex.test.ts
+++ b/packages/css/src/plugins/expand-shorthands/__tests__/flex.test.ts
@@ -12,7 +12,7 @@ const transform = (css: TemplateStringsArray) => {
 
 describe('flex property expander', () => {
   describe('has one parameter', () => {
-    it('should expand flex none', () => {
+    it('should expand flex=none', () => {
       const result = transform`
         flex: none;
       `;
@@ -26,21 +26,21 @@ describe('flex property expander', () => {
       `);
     });
 
-    it('should expand flex single', () => {
+    it('should expand flex=initial', () => {
       const result = transform`
-        flex: 2;
+        flex: initial;
       `;
 
       expect(result).toMatchInlineSnapshot(`
         "
-                flex-grow: 2;
+                flex-grow: 0;
                 flex-shrink: 1;
-                flex-basis: 0%;
+                flex-basis: auto;
               "
       `);
     });
 
-    it('should expand flex auto', () => {
+    it('should expand flex=auto', () => {
       const result = transform`
         flex: auto;
       `;
@@ -50,6 +50,37 @@ describe('flex property expander', () => {
                 flex-grow: 1;
                 flex-shrink: 1;
                 flex-basis: auto;
+              "
+      `);
+    });
+
+    it('should not expand flex=revert', () => {
+      const result = transform`flex: revert;`;
+      expect(result).toMatchInlineSnapshot(`"flex: revert;"`);
+    });
+    it('should not expand flex=revert-layer', () => {
+      const result = transform`flex: revert-layer;`;
+      expect(result).toMatchInlineSnapshot(`"flex: revert-layer;"`);
+    });
+    it('should not expand flex=unset', () => {
+      const result = transform`flex: unset;`;
+      expect(result).toMatchInlineSnapshot(`"flex: unset;"`);
+    });
+    it('should not expand flex=inherit', () => {
+      const result = transform`flex: inherit;`;
+      expect(result).toMatchInlineSnapshot(`"flex: inherit;"`);
+    });
+
+    it('should expand flex numbers', () => {
+      const result = transform`
+        flex: 2;
+      `;
+
+      expect(result).toMatchInlineSnapshot(`
+        "
+                flex-grow: 2;
+                flex-shrink: 1;
+                flex-basis: 0%;
               "
       `);
     });

--- a/packages/css/src/plugins/expand-shorthands/flex.ts
+++ b/packages/css/src/plugins/expand-shorthands/flex.ts
@@ -27,22 +27,51 @@ export const flex: ConversionFunction = (value) => {
 
   switch (value.nodes.length) {
     case 1: {
-      if (left.type === 'word' && left.value == 'none') {
-        // none is equivalent to 0 0 auto
-        return [
-          { prop: 'flex-grow', value: 0 },
-          { prop: 'flex-shrink', value: 0 },
-          { prop: 'flex-basis', value: 'auto' },
-        ];
+      if (left.type === 'word') {
+        if (left.value === 'auto') {
+          // `flex: 'auto'` is equivalent to `flex: '1 1 auto'`
+          return [
+            { prop: 'flex-grow', value: 1 },
+            { prop: 'flex-shrink', value: 1 },
+            { prop: 'flex-basis', value: 'auto' },
+          ];
+        }
+        if (left.value === 'none') {
+          // `flex: 'none'` is equivalent to `flex: '0 0 auto'`
+          return [
+            { prop: 'flex-grow', value: 0 },
+            { prop: 'flex-shrink', value: 0 },
+            { prop: 'flex-basis', value: 'auto' },
+          ];
+        }
+        if (left.value === 'initial') {
+          // `flex: 'initial'` is equivalent to `flex: '0 1 auto'`
+          return [
+            { prop: 'flex-grow', value: 0 },
+            { prop: 'flex-shrink', value: 1 },
+            { prop: 'flex-basis', value: 'auto' },
+          ];
+        }
+
+        if (
+          left.value === 'revert' ||
+          left.value === 'revert-layer' ||
+          left.value === 'unset' ||
+          left.value === 'inherit'
+        ) {
+          // Early exit, simply `flex: 'inherit'` (etc)
+          // NOTE: This doesn't even take this `value`, simply omitting the `prop` key is the early exit
+          return [{ value: left.value }];
+        }
       } else if (isFlexNumber(left)) {
-        // flex grow
+        // the value should map to `flex-grow`
         return [
           { prop: 'flex-grow', value: left.value },
           { prop: 'flex-shrink', value: 1 },
           { prop: 'flex-basis', value: flexBasisDefaultValue },
         ];
       } else if (isFlexBasis(left)) {
-        // flex basis
+        // we assume that the value should map to `flex-basis`
         return [
           { prop: 'flex-grow', value: 1 },
           { prop: 'flex-shrink', value: 1 },


### PR DESCRIPTION
### What is this change?

This adds more shorthand expansion logic to the `flex` shorthand parsing.

### Why are we making this change?

Namely, because `flex: 'inherit'` becomes `flex: 'auto'` via `flex-grow: 1; flex-shrink: 1; flex-basis: auto` which isn't what [MDN says](https://developer.mozilla.org/en-US/docs/Web/CSS/flex) and may result in bugs internally.

### How are we making this change?

By adding direct keyword support and adding tests.

---

### PR checklist


- [x] Updated or added applicable tests
- [x] ~Updated the documentation in `website/`~ n/a
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
