### PR TITLE
Type definition css properties string values fix

### DIFF
--- a/.changeset/sweet-eggs-tan.md
+++ b/.changeset/sweet-eggs-tan.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Fix type definition for CSS properties with string values.

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -104,7 +104,7 @@ export type CSSPseudos = CSSPseudoElements | CSSPseudoClasses;
  * excess property check doesn't enable makers to circumvent the
  * system and pass in values they shouldn't.
  */
-export type CSSProperties = Readonly<CSS.Properties<(string & object) | number>>;
+export type CSSProperties = Readonly<CSS.Properties<(string & NonNullable<unknown>) | number>>;
 
 /**
  * A stricter subset of the {@link CSSProperties} type that excludes


### PR DESCRIPTION
### What is this change?

In a `@compiled/react` cssMap style I wanted to define an `em` value for a letter spacing style. I noticed I could only use number values. This means I can only define a `px` values. With this change I'm able to define values with `em` or other units for letterspacing (and other style properties).

### Why are we making this change?

Opening up the type to allow values of type string allows me to use `em` and other units for style values.

### How are we making this change?

In [this change](https://github.com/atlassian-labs/compiled/commit/20528e9115efbb30932f2a0215b4b550d94ac40a#diff-84f256c9526675be4ce59318afe5f494f4ef705bc836911864ff1f4f6159602dR107) `string & object` was added to fix type inference. This was probably changed from `string & {}` to `string & object` by linting. I have changed this to `string & NonNullable<unknown>` to support string values while not breaking the type inference. This is confirmed by not having a type error in [this create strict API unit tests](https://github.com/atlassian-labs/compiled/blob/master/packages/react/src/create-strict-api/__tests__/index.test.tsx#L354).

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
