### PR TITLE
optimising ax and improving its clarity

### DIFF
--- a/.changeset/nasty-jars-roll.md
+++ b/.changeset/nasty-jars-roll.md
@@ -1,0 +1,9 @@
+---
+'@compiled/react': patch
+---
+
+Reducing bundle size and improving runtime performance of the `ax` runtime function.
+
+```ts
+import { ax } from '@compiled/react/runtime';
+```

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime/ax.js",
-      "limit": "195B",
+      "limit": "176B",
       "import": "ax"
     },
     {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime/ax.js",
-      "limit": "176B",
+      "limit": "162B",
       "import": "ax"
     },
     {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime/ax.js",
-      "limit": "162B",
+      "limit": "169B",
       "import": "ax"
     },
     {

--- a/packages/react/src/runtime/__perf__/ax.test.ts
+++ b/packages/react/src/runtime/__perf__/ax.test.ts
@@ -3,42 +3,61 @@ import { runBenchmark } from '@compiled/benchmark';
 import { ax } from '../index';
 
 describe('ax benchmark', () => {
-  const arr = [
-    '_19itglyw',
-    '_2rko1l7b',
-    '_ca0qftgi',
-    '_u5f319bv',
-    '_n3tdftgi',
-    '_19bv19bv',
-    '_bfhk1mzw',
-    '_syazu67f',
-    '_k48p1nn1',
-    '_ect41kw7',
-    '_1wybdlk8',
-    '_irr3mlcl',
-    '_1di6vctu',
-    // `undefined` is an acceptable parameter so we want to include it in the test case.
-    // Example: ax(['aaaabbbb', foo() && "aaaacccc"])
-    undefined,
+  const chunks: string[] = ['aaaa', 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg'];
+  const uniques: string[] = chunks.map((chunk) => `_${chunk}${chunk}`);
+  const withClashes: string[] = [
+    ...Array.from({ length: 4 }, () => `_${chunks[0]}${chunks[0]}`),
+    ...Array.from({ length: 6 }, () => `_${chunks[0]}${chunks[1]}`),
+    ...Array.from({ length: 8 }, () => `_${chunks[0]}${chunks[2]}`),
   ];
 
-  it('completes with ax() string as the fastest', async () => {
-    // Remove undefined and join the strings
-    const str = arr.slice(0, -1).join(' ');
+  const getRandomRules = (() => {
+    function randomChunk() {
+      return chunks[Math.floor(Math.random() * chunks.length)];
+    }
 
+    return function create(): string[] {
+      return Array.from({ length: 20 }, () => `_${randomChunk()}${randomChunk()}`);
+    };
+  })();
+
+  it('completes with ax() string as the fastest', async () => {
     const benchmark = await runBenchmark('ax', [
       {
-        name: 'ax() array',
-        fn: () => ax(arr),
+        name: 'ax() single',
+        fn: () => ax(['_aaaabbbb']),
       },
       {
-        name: 'ax() string',
-        fn: () => ax([str, undefined]),
+        name: 'ax() uniques (array)',
+        fn: () => ax(uniques),
+      },
+      {
+        name: 'ax() uniques (as a string)',
+        fn: () => ax([uniques.join(' ')]),
+      },
+      {
+        name: 'ax() clashes',
+        fn: () => ax(withClashes),
+      },
+      {
+        name: 'ax() clashes (as a string)',
+        fn: () => ax([withClashes.join(' ')]),
+      },
+      {
+        name: 'ax() random keys (no clashes)',
+        fn: () => ax(getRandomRules()),
+      },
+      {
+        name: 'ax() random keys (with clashes)',
+        fn: () => {
+          const random = getRandomRules();
+          ax([...random, ...random, ...random]);
+        },
       },
     ]);
 
     expect(benchmark).toMatchObject({
-      fastest: ['ax() string'],
+      fastest: ['ax() single'],
     });
-  }, 30000);
+  }, 90000);
 });

--- a/packages/react/src/runtime/__tests__/ax.test.ts
+++ b/packages/react/src/runtime/__tests__/ax.test.ts
@@ -50,7 +50,8 @@ describe('ax', () => {
       ['hello_there', 'hello_world', '_aaaabbbb'],
       'hello_there hello_world _aaaabbbb',
     ],
-  ])('%s', (_, params, result) => {
-    expect(result).toEqual(ax(params));
+    ['should remove duplicate custom class names', ['a', 'a'], 'a'],
+  ])('%s', (_, params, expected) => {
+    expect(ax(params)).toEqual(expected);
   });
 });

--- a/packages/react/src/runtime/__tests__/ax.test.ts
+++ b/packages/react/src/runtime/__tests__/ax.test.ts
@@ -6,6 +6,7 @@ describe('ax', () => {
   it.each([
     ['should handle empty array', [], undefined],
     ['should handle array with undefined', [undefined], undefined],
+    ['should handle array with falsy values', [undefined, null, false as const, ''], undefined],
     ['should join single classes together', ['foo', 'bar'], 'foo bar'],
     ['should join multi classes together', ['foo baz', 'bar'], 'foo baz bar'],
     ['should remove undefined', ['foo', 'bar', undefined], 'foo bar'],

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -67,5 +67,6 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
     return;
   }
 
+  // Return all our classnames as a single string, with all classnames separated by a space
   return Array.from(map.values()).join(' ');
 }

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -71,11 +71,34 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
     }
   }
 
-  const values = Object.values(map);
+  // return Object.values(map).join(' ');
 
-  if (!values.length) {
+  let result: string = '';
+  for (const key in map) {
+    result += map[key] + ' ';
+  }
+  if (!result) {
     return;
   }
+  // remove last " " from the string
+  return result.trimEnd();
 
-  return values.join(' ');
+  // const values = Object.values(map);
+
+  // if (!values.length) {
+  //   return;
+  // }
+  // return values.join(' ');
+
+  // // It turns out this is a bit faster than leveraging Object.values()
+  // const result: string[] = [];
+  // for (const key in map) {
+  //   result.push(map[key]);
+  // }
+
+  // if (!result.length) {
+  //   return;
+  // }
+
+  // return result.join(' ');
 }

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -71,11 +71,14 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
     }
   }
 
-  // We are converting the map into a string.
-  // The simple way to do this would be Object.values(map).join(' ').
-  // However, the approach below did perform 10%-20% better in benchmarks.
-  // For `ax()` it feels like to squeeze as much runtime performance out as we can.
-
+  /**
+   * We are converting the `map` into a string.
+   *
+   * The simple way to do this would be `Object.values(map).join(' ')`.
+   * However, the approach below performs 10%-20% better in benchmarks.
+   *
+   * For `ax()` it feels right to squeeze as much runtime performance out as we can.
+   */
   let result: string = '';
   for (const key in map) {
     result += map[key] + ' ';

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -5,7 +5,10 @@
 const ATOMIC_GROUP_LENGTH = 5;
 
 /**
- * Create a classname string which contains only a _single_ classname for each atomic _group_, and that the _last_ atomic definition _value_ remains.
+ * Create a single string containing all the classnames provided, separated by a space (`" "`).
+ * The result will only contain a _single_ classname for each `group` of atomic style classnames.
+ * Only the _last_ atomic style classname for a given `group` will remain.
+ *
  *
  * ```ts
  * ax(['_aaaabbbb', '_aaaacccc']);
@@ -13,9 +16,15 @@ const ATOMIC_GROUP_LENGTH = 5;
  * '_aaaacccc'
  * ```
  *
- * **Notes**
- * - Atomic style declarations take the form of `_{group}{value}`, where `group` and `value` are four characters long
- * - This function will preserve any non atomic style declarations (eg "my-cool-class")
+ * Format of Atomic style classnames: `_{group}{value}` (`_\w{4}\w{4}`)
+ *
+ * `ax` will preserve any non atomic style classnames (eg "border-red")
+ *
+ * ```ts
+ * ax(['_aaaabbbb', '_aaaacccc', 'border-red']);
+ * // output
+ * '_aaaacccc border-red'
+ * ```
  */
 export default function ax(classNames: (string | undefined | null | false)[]): string | undefined {
   // Shortcut: nothing to do
@@ -48,12 +57,12 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
 
     for (const className of list) {
       /**
-       * For atomic style declarations: the `key` is the `group`
+       * For atomic style classnames: the `key` is the `group`
        *
-       * - Later atomic declarations with the same `group` will override earlier ones
+       * - Later atomic classnames with the same `group` will override earlier ones
        *   (which is what we want).
-       * - Assumes atomic declarations are the only things that start with `_`
-       * - Could use a regex to ensure that atomic declarations are structured how we expect,
+       * - Assumes atomic classnames are the only things that start with `_`
+       * - Could use a regex to ensure that atomic classnames are structured how we expect,
        *   but did not add that for now as it did slow things down a bit.
        *
        * For other classnames: the `key` is the whole classname

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -6,9 +6,7 @@ const ATOMIC_GROUP_LENGTH = 5;
 
 /**
  * Create a single string containing all the classnames provided, separated by a space (`" "`).
- * The result will only contain a _single_ classname for each `group` of atomic style classnames.
- * Only the _last_ atomic style classname for a given `group` will remain.
- *
+ * The result will only contain the _last_ atomic style classname for each atomic `group`.
  *
  * ```ts
  * ax(['_aaaabbbb', '_aaaacccc']);
@@ -18,7 +16,7 @@ const ATOMIC_GROUP_LENGTH = 5;
  *
  * Format of Atomic style classnames: `_{group}{value}` (`_\w{4}\w{4}`)
  *
- * `ax` will preserve any non atomic style classnames (eg "border-red")
+ * `ax` will preserve any non atomic style classnames (eg `"border-red"`)
  *
  * ```ts
  * ax(['_aaaabbbb', '_aaaacccc', 'border-red']);

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -42,7 +42,6 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
     return classNames[0];
   }
 
-  // Map<Group, Value>
   const map = new Map<string, string>();
 
   // Note: using loops to minimize iterations over the collection

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -71,34 +71,18 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
     }
   }
 
-  // return Object.values(map).join(' ');
+  // We are converting the map into a string.
+  // The simple way to do this would be Object.values(map).join(' ').
+  // However, the approach below did perform 10%-20% better in benchmarks.
+  // For `ax()` it feels like to squeeze as much runtime performance out as we can.
 
   let result: string = '';
   for (const key in map) {
     result += map[key] + ' ';
   }
-  if (!result) {
-    return;
-  }
+  // The `map` will always contain at least one value,
+  // so we don't need to return `undefined` if `result` is empty string.
+
   // remove last " " from the string
   return result.trimEnd();
-
-  // const values = Object.values(map);
-
-  // if (!values.length) {
-  //   return;
-  // }
-  // return values.join(' ');
-
-  // // It turns out this is a bit faster than leveraging Object.values()
-  // const result: string[] = [];
-  // for (const key in map) {
-  //   result.push(map[key]);
-  // }
-
-  // if (!result.length) {
-  //   return;
-  // }
-
-  // return result.join(' ');
 }

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -68,15 +68,14 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
        * */
       const key = className.startsWith('_') ? className.slice(0, ATOMIC_GROUP_LENGTH) : className;
       map[key] = className;
-      // map.set(key, className);
     }
   }
 
-  if (!map.size) {
+  const values = Object.values(map);
+
+  if (!values.length) {
     return;
   }
 
-  // Return all our classnames as a single string, with all classnames separated by a space
-  // return Array.from(map.values()).join(' ');
-  return Object.values(map).join(' ');
+  return values.join(' ');
 }

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -40,7 +40,7 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
     return classNames[0];
   }
 
-  const map = new Map<string, string>();
+  const map: Record<string, string> = {};
 
   // Note: using loops to minimize iterations over the collection
   for (const value of classNames) {
@@ -67,7 +67,8 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
        *
        * */
       const key = className.startsWith('_') ? className.slice(0, ATOMIC_GROUP_LENGTH) : className;
-      map.set(key, className);
+      map[key] = className;
+      // map.set(key, className);
     }
   }
 
@@ -76,5 +77,6 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
   }
 
   // Return all our classnames as a single string, with all classnames separated by a space
-  return Array.from(map.values()).join(' ');
+  // return Array.from(map.values()).join(' ');
+  return Object.values(map).join(' ');
 }

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -40,6 +40,8 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
     return classNames[0];
   }
 
+  // Using an object rather than a `Map` as it performed better in our benchmarks.
+  // Would be happy to move to `Map` if it proved to be better under real conditions.
   const map: Record<string, string> = {};
 
   // Note: using loops to minimize iterations over the collection
@@ -83,9 +85,12 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
   for (const key in map) {
     result += map[key] + ' ';
   }
-  // The `map` will always contain at least one value,
-  // so we don't need to return `undefined` if `result` is empty string.
 
-  // remove last " " from the string
+  // If we have an empty string, then our `map` was empty.
+  if (!result) {
+    return;
+  }
+
+  // remove last " " from the result (we added " " at the end of every value)
   return result.trimEnd();
 }

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -36,6 +36,7 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
   // Map<Group, Value>
   const map = new Map<string, string>();
 
+  // Note: using loops to minimize iterations over the collection
   for (const value of classNames) {
     // Exclude all falsy values, which leaves us with populated strings
     if (!value) {
@@ -49,9 +50,10 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
       /**
        * For atomic style declarations: the `key` is the `group`
        *
-       * - Later entries for a `group` will override earlier ones (which is what we want).
+       * - Later atomic declarations with the same `group` will override earlier ones
+       *   (which is what we want).
        * - Assumes atomic declarations are the only things that start with `_`
-       * - Could use a Regex to ensure that atomic declarations are structured how we expect,
+       * - Could use a regex to ensure that atomic declarations are structured how we expect,
        *   but did not add that for now as it did slow things down a bit.
        *
        * For other classnames: the `key` is the whole classname


### PR DESCRIPTION
This change results in:

- A smaller bundle size (`362b` → `305b` using `esbuild --minify`)
- Faster runtime performance (when there is higher variance in the keys). The new variant was consistency ~60% faster on [this test case](https://jsbench.me/2nm89s22n9) [Chrome@134]
- Improved clarity of code + code paths.

📺 [I made a video about this change to step through all my thought process](https://www.youtube.com/watch?v=-wmYoQ7Ph8A)

📖 [More information on Objects vs Maps](https://www.zhenghao.io/posts/object-vs-map)