### PR TITLE
Fix toHaveCompiledCss crash for SVG elements

### DIFF
--- a/.changeset/plain-windows-listen.md
+++ b/.changeset/plain-windows-listen.md
@@ -1,0 +1,6 @@
+---
+'@compiled/react': patch
+'@compiled/jest': patch
+---
+
+Fix toHaveCompiledCss crashing on SVG elements due to lack of className property

--- a/.changeset/plain-windows-listen.md
+++ b/.changeset/plain-windows-listen.md
@@ -3,4 +3,4 @@
 '@compiled/jest': patch
 ---
 
-Fix toHaveCompiledCss crashing on SVG elements due to lack of className property
+Fix `toHaveCompiledCss` in @compiled/jest crashing on SVG elements due to lack of className property and expands tests in `@compiled/react`.

--- a/packages/jest/src/matchers.ts
+++ b/packages/jest/src/matchers.ts
@@ -132,7 +132,7 @@ export function toHaveCompiledCss(
   const stylesToFind = mapProperties(properties);
   const foundStyles: string[] = [];
   const similarStyles: string[] = [];
-  const classNames = element.className.split(' ');
+  const classNames = element.classList;
 
   for (const styleElement of styleElements) {
     let css = styleElement.textContent || '';

--- a/packages/react/src/__tests__/jest-matcher.test.tsx
+++ b/packages/react/src/__tests__/jest-matcher.test.tsx
@@ -18,6 +18,19 @@ describe('toHaveCompliedCss', () => {
     expect(getByText('hello world')).toHaveCompiledCss('font-size', '12px');
   });
 
+  it('should detect styles (SVG)', () => {
+    const { getByText } = render(
+      <svg
+        css={{
+          fontSize: '12px',
+        }}>
+        hello world
+      </svg>
+    );
+
+    expect(getByText('hello world')).toHaveCompiledCss('font-size', '12px');
+  });
+
   it('should detect missing styles', () => {
     const { getByText } = render(<div css={{ fontSize: '12px' }}>hello world</div>);
 


### PR DESCRIPTION
### What is this change?

Use `classList` instead of `className` in `toHaveCompiledCss`

### Why are we making this change?

`SVGElement` does not have a `className` property.  Additionally we are splitting a string to iterate through it, but `classList` is already iterable.

---

### PR checklist

Don't delete me!

I have...

- [X] Updated or added applicable tests
- [X] Updated the documentation in `website/`
- [X] Added a changeset (if making any changes that affect Compiled's behaviour)
