### PR TITLE
Fix the case when the styles are defined below the component and the …

### DIFF
--- a/.changeset/wild-numbers-share.md
+++ b/.changeset/wild-numbers-share.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Resolve an issue where cssMap was being defined after its consumer, which relies on the xcss prop.

--- a/packages/babel-plugin/src/css-map/__tests__/index.test.ts
+++ b/packages/babel-plugin/src/css-map/__tests__/index.test.ts
@@ -36,6 +36,37 @@ describe('css map basic functionality', () => {
     ]);
   });
 
+  it('should transform css map when the styles are defined below the component and the component uses xcss prop', () => {
+    const actual = transform(
+      `
+      import { cssMap } from '@compiled/react';
+
+      <Box xcss={styles.danger} />
+
+      const styles = cssMap(${styles});
+    `,
+      { pretty: true }
+    );
+
+    expect(actual).toMatchInlineSnapshot(`
+      "import * as React from "react";
+      import { ax, ix, CC, CS } from "@compiled/react/runtime";
+      const _4 = "._bfhkbf54{background-color:green}";
+      const _3 = "._syazbf54{color:green}";
+      const _2 = "._bfhk5scu{background-color:red}";
+      const _ = "._syaz5scu{color:red}";
+      <CC>
+        <CS>{[_, _2, _3, _4]}</CS>
+        {<Box xcss={styles.danger} />}
+      </CC>;
+      const styles = {
+        danger: "_syaz5scu _bfhk5scu",
+        success: "_syazbf54 _bfhkbf54",
+      };
+      "
+    `);
+  });
+
   it('should transform css map even when the styles are defined below the component', () => {
     const actual = transform(`
       import { cssMap } from '@compiled/react';

--- a/packages/babel-plugin/src/utils/css-builders.ts
+++ b/packages/babel-plugin/src/utils/css-builders.ts
@@ -698,7 +698,7 @@ const extractObjectExpression = (node: t.ObjectExpression, meta: Metadata): CSSO
  *
  * @returns {Boolean} Whether the cache was generated
  */
-const generateCacheForCSSMap = (node: t.Identifier, meta: Metadata): void => {
+export const generateCacheForCSSMap = (node: t.Identifier, meta: Metadata): void => {
   if (meta.state.cssMap[node.name] || meta.state.ignoreMemberExpressions[node.name]) {
     return;
   }


### PR DESCRIPTION
This PR fixes the below case:

```
<Box xcss={styles.main}>{children}</Box>

const styles = cssMap({
	main: {
		paddingTop: "10px",
	},
});

```

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
