### PR TITLE
Allow flattening of multiple selectors into separate rules to better deduplicate and sort styles.

### DIFF
--- a/.changeset/lazy-bats-remain.md
+++ b/.changeset/lazy-bats-remain.md
@@ -3,10 +3,14 @@
 '@compiled/babel-component-extracted-fixture': none
 '@compiled/parcel-transformer': none
 '@compiled/babel-component-fixture': none
-'@compiled/css': patch
+'@compiled/css': minor
 ---
 
-Flatten multiple selectors into separate rules to better deduplicate and sort styles, eg.:
+Adds a possibly breaking change to flatten multiple selectors into separate rules to better deduplicate and sort styles.
+
+You can disable this by setting `flattenMultipleSelectors: false` in Babel and other config.
+
+For example:
 
 ```tsx
 css({
@@ -24,7 +28,5 @@ css({
   '&:focus': { color: 'red' },
 });
 ```
-
-This will be enabled by default in a future minor release once impact is validated.
 
 Without this, pseudo-selectors aren't sorted properly in some scenarios.

--- a/.changeset/lazy-bats-remain.md
+++ b/.changeset/lazy-bats-remain.md
@@ -1,0 +1,30 @@
+---
+'@compiled/parcel-transformer-external': none
+'@compiled/babel-component-extracted-fixture': none
+'@compiled/parcel-transformer': none
+'@compiled/babel-component-fixture': none
+'@compiled/css': patch
+---
+
+Flatten multiple selectors into separate rules to better deduplicate and sort styles, eg.:
+
+```tsx
+css({
+  '&:hover, &:focus': {
+    color: 'red',
+  },
+});
+```
+
+Is transformed into the same code as this would be:
+
+```tsx
+css({
+  '&:hover': { color: 'red' },
+  '&:focus': { color: 'red' },
+});
+```
+
+This will be enabled by default in a future minor release once impact is validated.
+
+Without this, pseudo-selectors aren't sorted properly in some scenarios.

--- a/.changeset/lovely-rockets-hammer.md
+++ b/.changeset/lovely-rockets-hammer.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Adds option flattenMultipleSelectors to allow flattening of multiple selectors into separate rules to better deduplicate and sort styles.

--- a/.changeset/lovely-rockets-hammer.md
+++ b/.changeset/lovely-rockets-hammer.md
@@ -1,5 +1,5 @@
 ---
-'@compiled/babel-plugin': patch
+'@compiled/babel-plugin': minor
 ---
 
-Adds option flattenMultipleSelectors to allow flattening of multiple selectors into separate rules to better deduplicate and sort styles.
+Adds option `flattenMultipleSelectors` (defaults to `true`) to allow flattening of multiple selectors into separate rules to better deduplicate and sort styles.

--- a/fixtures/babel-component-extracted/.babelrc
+++ b/fixtures/babel-component-extracted/.babelrc
@@ -4,7 +4,10 @@
     ["@babel/preset-react", { "runtime": "automatic" }]
   ],
   "plugins": [
-    ["@compiled/babel-plugin", { "importReact": false, "optimizeCss": false }],
+    [
+      "@compiled/babel-plugin",
+      { "importReact": false, "optimizeCss": false, "flattenMultipleSelectors": true }
+    ],
     [
       "@compiled/babel-plugin-strip-runtime",
       { "extractStylesToDirectory": { "source": "src", "dest": "dist" } }

--- a/fixtures/babel-component-extracted/src/index.jsx
+++ b/fixtures/babel-component-extracted/src/index.jsx
@@ -3,9 +3,20 @@ import { styled, css } from '@compiled/react';
 const Button = styled.button({
   color: 'blue',
   fontSize: '30px',
-  border: '2px solid blue',
+  border: '2px solid transparent',
   padding: '32px',
   backgroundColor: 'yellow',
+
+  '&:hover': {
+    borderColor: 'blue',
+    backgroundColor: 'blue',
+    color: 'white',
+  },
+
+  '&:hover, &:focus': {
+    backgroundColor: 'blue',
+    color: 'white',
+  },
 });
 
 export default function BabelComponent({ children }) {

--- a/fixtures/babel-component/.babelrc
+++ b/fixtures/babel-component/.babelrc
@@ -3,5 +3,10 @@
     ["@babel/preset-env", { "targets": { "browsers": "last 1 version" } }],
     ["@babel/preset-react", { "runtime": "automatic" }]
   ],
-  "plugins": [["@compiled/babel-plugin", { "importReact": false, "optimizeCss": false }]]
+  "plugins": [
+    [
+      "@compiled/babel-plugin",
+      { "importReact": false, "optimizeCss": false, "flattenMultipleSelectors": true }
+    ]
+  ]
 }

--- a/fixtures/babel-component/src/index.jsx
+++ b/fixtures/babel-component/src/index.jsx
@@ -3,8 +3,20 @@ import { styled } from '@compiled/react';
 const Button = styled.button`
   color: blue;
   font-size: 30px;
-  border: 2px solid blue;
+  border: 2px solid transparent;
   padding: 32px;
+
+  &:hover {
+    border-color: blue;
+    background-color: blue;
+    color: white;
+  }
+
+  &:hover,
+  &:focus {
+    background-color: blue;
+    color: white;
+  }
 `;
 
 export default function BabelComponent({ children }) {

--- a/packages/babel-plugin/src/__tests__/module-traversal.test.ts
+++ b/packages/babel-plugin/src/__tests__/module-traversal.test.ts
@@ -366,9 +366,11 @@ describe('module traversal', () => {
       </BackgroundWithSelector>;
     `);
 
-    expect(actual).toInclude(
-      '._15rzbf54 #joined-selector, ._1khrbf54 .red{background-color:green}'
-    );
+    // This gets split into two rules due to flattenMultipleSelectors
+    expect(actual).toIncludeMultiple([
+      '._15rzbf54 #joined-selector{background-color:green}',
+      '._1khrbf54 .red{background-color:green}',
+    ]);
   });
 
   describe('should call onIncludedFiles with the filepath', () => {

--- a/packages/babel-plugin/src/keyframes/__tests__/call-expression.test.ts
+++ b/packages/babel-plugin/src/keyframes/__tests__/call-expression.test.ts
@@ -82,7 +82,7 @@ describe('keyframes', () => {
             const _3 = "._j7hqb4f3{animation-name:k1wmcptp}";
             const _2 = "._5sagymdr{animation-duration:2s}";
             const _ =
-              "@keyframes k1wmcptp{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes k1wmcptp{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const fadeOut = null;
             <CC>
               <CS>{[_, _2, _3, _4]}</CS>
@@ -100,7 +100,7 @@ describe('keyframes', () => {
           expect(actual).toMatchInlineSnapshot(`
             "const _2 = "._y44vjvcp{animation:k1wmcptp 2s ease-in-out}";
             const _ =
-              "@keyframes k1wmcptp{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes k1wmcptp{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
@@ -857,7 +857,7 @@ describe('keyframes', () => {
             const _3 = "._j7hqb4f3{animation-name:k1wmcptp}";
             const _2 = "._5sagymdr{animation-duration:2s}";
             const _ =
-              "@keyframes k1wmcptp{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes k1wmcptp{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const fadeOut = null;
             <CC>
               <CS>{[_, _2, _3, _4]}</CS>
@@ -875,7 +875,7 @@ describe('keyframes', () => {
           expect(actual).toMatchInlineSnapshot(`
             "const _2 = "._y44vjvcp{animation:k1wmcptp 2s ease-in-out}";
             const _ =
-              "@keyframes k1wmcptp{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes k1wmcptp{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
@@ -918,7 +918,7 @@ describe('keyframes', () => {
 
           expect(actual).toMatchInlineSnapshot(`
             "const _4 =
-              "@keyframes k1wmcptp{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes k1wmcptp{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const _3 = "._1pgl1ytf{animation-timing-function:ease-in-out}";
             const _2 = "._j7hqb4f3{animation-name:k1wmcptp}";
             const _ = "._5sagymdr{animation-duration:2s}";
@@ -952,7 +952,7 @@ describe('keyframes', () => {
 
           expect(actual).toMatchInlineSnapshot(`
             "const _2 =
-              "@keyframes k1wmcptp{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes k1wmcptp{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const _ = "._y44vjvcp{animation:k1wmcptp 2s ease-in-out}";
             const fadeOut = null;
             const StyledComponent = forwardRef(
@@ -1028,7 +1028,7 @@ describe('keyframes', () => {
 
           expect(actual).toMatchInlineSnapshot(`
             "const _4 =
-              "@keyframes k1wmcptp{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes k1wmcptp{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const _3 = "._1pgl1ytf{animation-timing-function:ease-in-out}";
             const _2 = "._j7hqb4f3{animation-name:k1wmcptp}";
             const _ = "._5sagymdr{animation-duration:2s}";
@@ -1062,7 +1062,7 @@ describe('keyframes', () => {
 
           expect(actual).toMatchInlineSnapshot(`
             "const _2 =
-              "@keyframes k1wmcptp{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes k1wmcptp{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const _ = "._y44vjvcp{animation:k1wmcptp 2s ease-in-out}";
             const fadeOut = null;
             const StyledComponent = forwardRef(
@@ -1191,7 +1191,7 @@ describe('keyframes', () => {
             const _3 = "._j7hq1c6j{animation-name:khheuil}";
             const _2 = "._5sagymdr{animation-duration:2s}";
             const _ =
-              "@keyframes khheuil{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes khheuil{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const fadeOut = null;
             <CC>
               <CS>{[_, _2, _3, _4]}</CS>
@@ -1209,7 +1209,7 @@ describe('keyframes', () => {
           expect(actual).toMatchInlineSnapshot(`
             "const _2 = "._y44v1go4{animation:khheuil 2s ease-in-out}";
             const _ =
-              "@keyframes khheuil{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes khheuil{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
@@ -1255,7 +1255,7 @@ describe('keyframes', () => {
             const _3 = "._j7hq1c6j{animation-name:khheuil}";
             const _2 = "._5sagymdr{animation-duration:2s}";
             const _ =
-              "@keyframes khheuil{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes khheuil{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const fadeOut = null;
             <CC>
               <CS>{[_, _2, _3, _4]}</CS>
@@ -1273,7 +1273,7 @@ describe('keyframes', () => {
           expect(actual).toMatchInlineSnapshot(`
             "const _2 = "._y44v1go4{animation:khheuil 2s ease-in-out}";
             const _ =
-              "@keyframes khheuil{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes khheuil{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const fadeOut = null;
             <CC>
               <CS>{[_, _2]}</CS>
@@ -1316,7 +1316,7 @@ describe('keyframes', () => {
 
           expect(actual).toMatchInlineSnapshot(`
             "const _4 =
-              "@keyframes khheuil{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes khheuil{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const _3 = "._1pgl1ytf{animation-timing-function:ease-in-out}";
             const _2 = "._j7hq1c6j{animation-name:khheuil}";
             const _ = "._5sagymdr{animation-duration:2s}";
@@ -1350,7 +1350,7 @@ describe('keyframes', () => {
 
           expect(actual).toMatchInlineSnapshot(`
             "const _2 =
-              "@keyframes khheuil{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes khheuil{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const _ = "._y44v1go4{animation:khheuil 2s ease-in-out}";
             const fadeOut = null;
             const StyledComponent = forwardRef(
@@ -1426,7 +1426,7 @@ describe('keyframes', () => {
 
           expect(actual).toMatchInlineSnapshot(`
             "const _4 =
-              "@keyframes khheuil{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes khheuil{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const _3 = "._1pgl1ytf{animation-timing-function:ease-in-out}";
             const _2 = "._j7hq1c6j{animation-name:khheuil}";
             const _ = "._5sagymdr{animation-duration:2s}";
@@ -1460,7 +1460,7 @@ describe('keyframes', () => {
 
           expect(actual).toMatchInlineSnapshot(`
             "const _2 =
-              "@keyframes khheuil{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+              "@keyframes khheuil{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
             const _ = "._y44v1go4{animation:khheuil 2s ease-in-out}";
             const fadeOut = null;
             const StyledComponent = forwardRef(

--- a/packages/babel-plugin/src/keyframes/__tests__/tagged-template-expression.test.ts
+++ b/packages/babel-plugin/src/keyframes/__tests__/tagged-template-expression.test.ts
@@ -81,7 +81,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const _3 = "._j7hqa2t1{animation-name:k1a3bdtb}";
           const _2 = "._5sagymdr{animation-duration:2s}";
           const _ =
-            "@keyframes k1a3bdtb{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+            "@keyframes k1a3bdtb{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
           const fadeOut = null;
           <CC>
             <CS>{[_, _2, _3, _4]}</CS>
@@ -99,7 +99,7 @@ describe('keyframes transforms a tagged template expression', () => {
         expect(actual).toMatchInlineSnapshot(`
           "const _2 = "._y44v1e4p{animation:k1a3bdtb 2s ease-in-out}";
           const _ =
-            "@keyframes k1a3bdtb{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+            "@keyframes k1a3bdtb{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
@@ -145,7 +145,7 @@ describe('keyframes transforms a tagged template expression', () => {
           const _3 = "._j7hqa2t1{animation-name:k1a3bdtb}";
           const _2 = "._5sagymdr{animation-duration:2s}";
           const _ =
-            "@keyframes k1a3bdtb{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+            "@keyframes k1a3bdtb{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
           const fadeOut = null;
           <CC>
             <CS>{[_, _2, _3, _4]}</CS>
@@ -163,7 +163,7 @@ describe('keyframes transforms a tagged template expression', () => {
         expect(actual).toMatchInlineSnapshot(`
           "const _2 = "._y44v1e4p{animation:k1a3bdtb 2s ease-in-out}";
           const _ =
-            "@keyframes k1a3bdtb{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+            "@keyframes k1a3bdtb{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
           const fadeOut = null;
           <CC>
             <CS>{[_, _2]}</CS>
@@ -806,7 +806,7 @@ describe('keyframes transforms a tagged template expression', () => {
 
         expect(actual).toMatchInlineSnapshot(`
           "const _4 =
-            "@keyframes k1a3bdtb{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+            "@keyframes k1a3bdtb{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
           const _3 = "._1pgl1ytf{animation-timing-function:ease-in-out}";
           const _2 = "._j7hqa2t1{animation-name:k1a3bdtb}";
           const _ = "._5sagymdr{animation-duration:2s}";
@@ -840,7 +840,7 @@ describe('keyframes transforms a tagged template expression', () => {
 
         expect(actual).toMatchInlineSnapshot(`
           "const _2 =
-            "@keyframes k1a3bdtb{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+            "@keyframes k1a3bdtb{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
           const _ = "._y44v1e4p{animation:k1a3bdtb 2s ease-in-out}";
           const fadeOut = null;
           const StyledComponent = forwardRef(
@@ -916,7 +916,7 @@ describe('keyframes transforms a tagged template expression', () => {
 
         expect(actual).toMatchInlineSnapshot(`
           "const _4 =
-            "@keyframes k1a3bdtb{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+            "@keyframes k1a3bdtb{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
           const _3 = "._1pgl1ytf{animation-timing-function:ease-in-out}";
           const _2 = "._j7hqa2t1{animation-name:k1a3bdtb}";
           const _ = "._5sagymdr{animation-duration:2s}";
@@ -950,7 +950,7 @@ describe('keyframes transforms a tagged template expression', () => {
 
         expect(actual).toMatchInlineSnapshot(`
           "const _2 =
-            "@keyframes k1a3bdtb{0%,25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
+            "@keyframes k1a3bdtb{0%{opacity:1}25%{opacity:1}25%{opacity:0.75}50%{opacity:0.5}to{opacity:0}}";
           const _ = "._y44v1e4p{animation:k1a3bdtb 2s ease-in-out}";
           const fadeOut = null;
           const StyledComponent = forwardRef(

--- a/packages/babel-plugin/src/types.ts
+++ b/packages/babel-plugin/src/types.ts
@@ -23,7 +23,7 @@ export interface PluginOptions {
    * Will import the React namespace if it is missing.
    * When using the `'automatic'` jsx runtime set this to `false`.
    *
-   * Defaults to `true`.
+   * Defaults to `true`
    */
   importReact?: boolean;
 
@@ -45,7 +45,7 @@ export interface PluginOptions {
   /**
    * Will run additional cssnano plugins to normalize CSS during build.
    *
-   * Default to `true`.
+   * Defaults to `true`
    */
   optimizeCss?: boolean;
 
@@ -69,7 +69,7 @@ export interface PluginOptions {
   /**
    * Add the component name as class name to DOM in non-production environment if styled is used
    *
-   * Default to `false`
+   * Defults to `false`
    */
   addComponentName?: boolean;
 
@@ -77,7 +77,7 @@ export interface PluginOptions {
    * A map holds the key-value pairs between full Atomic class names and the compressed ones
    * i.e. { '_aaaabbbb': 'a' }
    *
-   * Default to `undefined`
+   * Defults to `undefined`
    */
   classNameCompressionMap?: { [index: string]: string };
 
@@ -85,7 +85,7 @@ export interface PluginOptions {
    * Whether Compiled should process usages of xcss in the codebase.
    * Disable this if xcss is not implemented in your codebase using Compiled's xcss functionality.
    *
-   * Default to `true`
+   * Defults to `true`
    */
   processXcss?: boolean;
 
@@ -94,13 +94,13 @@ export interface PluginOptions {
    * Generally you would only use this for migration purposes when mixing two or more styling
    * solutions.
    *
-   * Default to `false`.
+   * Defults to `false`
    */
   increaseSpecificity?: boolean;
 
   /**
    * Whether to sort at-rules, including media queries.
-   * Defaults to `true`.
+   * Defaults to `true`
    */
   sortAtRules?: boolean;
 
@@ -116,7 +116,7 @@ export interface PluginOptions {
   /**
    * Whether to flatten multiple selectors into separate rules to better deduplicate and sort styles.
    *
-   * Default to `false`.
+   * Defults to `true`.
    */
   flattenMultipleSelectors?: boolean;
 }

--- a/packages/babel-plugin/src/types.ts
+++ b/packages/babel-plugin/src/types.ts
@@ -112,6 +112,13 @@ export interface PluginOptions {
    * or `extract: true` in Webpack loaders or Parcel tranformers.
    */
   classHashPrefix?: string;
+
+  /**
+   * Whether to flatten multiple selectors into separate rules to better deduplicate and sort styles.
+   *
+   * Default to `false`.
+   */
+  flattenMultipleSelectors?: boolean;
 }
 
 export interface State extends PluginPass {

--- a/packages/css/src/__tests__/transform.test.ts
+++ b/packages/css/src/__tests__/transform.test.ts
@@ -1,6 +1,6 @@
 import { transformCss as transform, type TransformOpts } from '../transform';
 
-const defaultOpts: TransformOpts = { optimizeCss: false, flattenMultipleSelectors: true };
+const defaultOpts: TransformOpts = { optimizeCss: false };
 const transformCss = (code: string, opts: TransformOpts = defaultOpts) => transform(code, opts);
 
 describe('#css-transform', () => {
@@ -499,7 +499,7 @@ describe('#css-transform', () => {
   });
 
   describe('flatten multiple selectors', () => {
-    it('should flatten multiple selectors when configured (by default in this test)', () => {
+    it('should flatten multiple selectors when configured (by default)', () => {
       const { sheets: actual } = transformCss(`div, span { color: red; }`);
 
       expect(actual.join('\n')).toMatchInlineSnapshot(`
@@ -508,7 +508,7 @@ describe('#css-transform', () => {
       `);
     });
 
-    it('should not flatten multiple selectors when not configured', () => {
+    it('should not flatten multiple selectors when disabled', () => {
       const { sheets: actual } = transformCss(`div, span { color: red; }`, {
         ...defaultOpts,
         flattenMultipleSelectors: false,

--- a/packages/css/src/plugins/__tests__/flatten-multiple-selectors.test.ts
+++ b/packages/css/src/plugins/__tests__/flatten-multiple-selectors.test.ts
@@ -1,0 +1,179 @@
+import autoprefixer from 'autoprefixer';
+import postcss from 'postcss';
+import nested from 'postcss-nested';
+import whitespace from 'postcss-normalize-whitespace';
+
+import { atomicifyRules } from '../atomicify-rules';
+import { flattenMultipleSelectors } from '../flatten-multiple-selectors';
+
+const transform = (css: TemplateStringsArray) => {
+  const result = postcss([
+    nested({
+      bubble: [
+        'container',
+        '-moz-document',
+        'layer',
+        'else',
+        'when',
+        // postcss-nested bubbles `starting-style` by default in versions from 6.0.2 onwards:
+        // https://github.com/postcss/postcss-nested?tab=readme-ov-file#bubble
+        // When we upgrade to a version that includes this change, we can remove this from the list.
+        'starting-style',
+      ],
+      unwrap: ['color-profile', 'counter-style', 'font-palette-values', 'page', 'property'],
+    }),
+    atomicifyRules(),
+    flattenMultipleSelectors(),
+    whitespace(),
+    autoprefixer(),
+  ]).process(css[0], {
+    from: undefined,
+  });
+
+  return result.css;
+};
+
+describe('flatten multiple selectors', () => {
+  beforeEach(() => {
+    process.env.BROWSERSLIST = 'last 1 version';
+  });
+
+  it('should leave a single declaration alone', () => {
+    const actual = transform`
+      color: blue;
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`"._syaz13q2{color:blue}"`);
+  });
+
+  it('should leave a nested selector alone', () => {
+    const actual = transform`
+      [data-look='h100']& {
+        display: block;
+      }
+      div {
+        display: none;
+        span {
+          display: none;
+        }
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(
+      `"[data-look='h100']._mi0g1ule{display:block}._tkqhglyw div{display:none}._1jaqglyw div span{display:none}"`
+    );
+  });
+
+  it('should leave a specificity increase alone', () => {
+    const result = transform`
+      & {
+        display: none;
+      }
+      && {
+        display: block;
+      }
+    `;
+
+    expect(result).toMatchInlineSnapshot(
+      `"._1e0cglyw{display:none}._if291ule._if291ule{display:block}"`
+    );
+  });
+
+  it('should flatten multiple element selectors', () => {
+    const actual = transform`
+      div, span, li {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "._65g013q2 div{color:blue}
+      ._1tjq13q2 span{color:blue}
+      ._thoc13q2 li{color:blue}"
+    `);
+  });
+
+  it('should flatten multiple pseduo selectors', () => {
+    // Its assumed the pseudos will get a nesting selector from the nested plugin.
+    const actual = transform`
+      &:hover, &:focus {
+        color: blue;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(`
+      "._30l313q2:hover{color:blue}
+      ._f8pj13q2:focus{color:blue}"
+    `);
+  });
+
+  it('should handle complex selectors', () => {
+    const actual = transform`
+      && > *, &:is(h1, h2, h3), div, &:hover, [data-content~="user,id"] {
+        margin-bottom: 1rem;
+      }
+
+      &, && {
+        &,&:is(h1, h2, h3) {
+          margin-bottom: 1rem;
+        }
+      }
+
+      @media (min-width: 768px) {
+        && > *, &:is(h1, h2, h3), div, &:hover, [data-content~="user,id"] {
+          margin-bottom: 1rem;
+        }
+      }
+
+      @media (max-width: 768px) {
+        @supports (margin-bottom: 1rem) {
+          && > *, &:is(h1, h2, h3), div, &:hover, [data-content~="user,id"] {
+            margin-bottom: 1rem;
+          }
+        }
+      }
+    `;
+
+    expect(actual.split('}').join('}\n')).toMatchInlineSnapshot(`
+      "._169r1j6v._169r1j6v > *{margin-bottom:1rem}
+      ._uw1v1j6v:is(h1, h2, h3){margin-bottom:1rem}
+      ._1oyy1j6v div{margin-bottom:1rem}
+      ._1axs1j6v:hover{margin-bottom:1rem}
+      ._hdj91j6v [data-content~="user,id"]{margin-bottom:1rem}
+      ._otyr1j6v{margin-bottom:1rem}
+      ._uw1v1j6v:is(h1, h2, h3){margin-bottom:1rem}
+      ._1l6u1j6v._1l6u1j6v{margin-bottom:1rem}
+      ._1xw41j6v._1xw41j6v:is(h1, h2, h3){margin-bottom:1rem}
+      @media (min-width: 768px){._yi8y1j6v._yi8y1j6v > *{margin-bottom:1rem}
+      ._syz31j6v:is(h1, h2, h3){margin-bottom:1rem}
+      ._h8sc1j6v div{margin-bottom:1rem}
+      ._1q9c1j6v:hover{margin-bottom:1rem}
+      ._q3671j6v [data-content~="user,id"]{margin-bottom:1rem}
+      }
+      @media (max-width: 768px){@supports (margin-bottom: 1rem){._1isd1j6v._1isd1j6v > *{margin-bottom:1rem}
+      ._1r2l1j6v:is(h1, h2, h3){margin-bottom:1rem}
+      ._9ykl1j6v div{margin-bottom:1rem}
+      ._co771j6v:hover{margin-bottom:1rem}
+      ._1n1h1j6v [data-content~="user,id"]{margin-bottom:1rem}
+      }
+      }
+      "
+    `);
+  });
+
+  it('should leave duplicate styles alone (that belongs to another plugin)', () => {
+    // Its assumed the pseudos will get a nesting selector from the nested plugin.
+    const actual = transform`
+      &:first-child, &:last-child {
+        color: hotpink;
+      }
+      &:first-child {
+        color: hotpink;
+      }
+    `;
+
+    expect(actual).toMatchInlineSnapshot(
+      `"._4zxh1q9v:first-child{color:hotpink}._18k61q9v:last-child{color:hotpink}._4zxh1q9v:first-child{color:hotpink}"`
+    );
+  });
+});

--- a/packages/css/src/plugins/flatten-multiple-selectors.ts
+++ b/packages/css/src/plugins/flatten-multiple-selectors.ts
@@ -1,0 +1,50 @@
+import type { Plugin, Container, Rule } from 'postcss';
+import selectorParser from 'postcss-selector-parser';
+
+function flattenNode(node: Container) {
+  node.each((child) => {
+    if (!child.parent) return;
+
+    // Recursively flatten inside at-rules
+    if (child.type === 'atrule' && 'each' in child) {
+      flattenNode(child as Container);
+    }
+
+    // Flatten rules with multiple selectors
+    if (child.type === 'rule' && child.parent) {
+      const selectors: string[] = [];
+      selectorParser((root) => {
+        root.each((sel) => {
+          selectors.push(sel.toString().trim());
+        });
+      }).processSync((child as Rule).selector);
+      if (selectors.length > 1) {
+        selectors.forEach((selector) => {
+          const rule = (child as Rule).clone();
+          rule.selector = selector;
+          child.parent?.insertBefore(child, rule);
+        });
+        child.parent?.removeChild(child);
+      }
+    }
+  });
+}
+
+/**
+ * Transforms a style sheet into atomic rules.
+ * When passing a `callback` option it will callback with created class names.
+ *
+ * Preconditions:
+ *
+ * 1. No nested rules allowed - normalize them with the `parent-orphaned-pseudos` and `nested` plugins first.
+ *
+ * @throws Throws an error if `opts.classHashPrefix` contains invalid css class/id characters
+ */
+export const flattenMultipleSelectors = (): Plugin => {
+  return {
+    postcssPlugin: 'flatten-multiple-selectors',
+    OnceExit(root) {
+      flattenNode(root);
+    },
+  };
+};

--- a/packages/css/src/transform.ts
+++ b/packages/css/src/transform.ts
@@ -37,6 +37,9 @@ export const transformCss = (
   const sheets: string[] = [];
   const classNames: string[] = [];
 
+  // This is defaulted to `true` unless set
+  const flattenMultipleSelectorsOption = opts.flattenMultipleSelectors ?? true;
+
   try {
     const result = postcss([
       discardDuplicates(),
@@ -63,7 +66,7 @@ export const transformCss = (
         callback: (className: string) => classNames.push(className),
         classHashPrefix: opts.classHashPrefix,
       }),
-      ...(opts.flattenMultipleSelectors ? [flattenMultipleSelectors(), discardDuplicates()] : []),
+      ...(flattenMultipleSelectorsOption ? [flattenMultipleSelectors(), discardDuplicates()] : []),
       ...(opts.increaseSpecificity ? [increaseSpecificity()] : []),
       sortAtomicStyleSheet({
         sortAtRulesEnabled: opts.sortAtRules,

--- a/packages/css/src/transform.ts
+++ b/packages/css/src/transform.ts
@@ -9,11 +9,11 @@ import { discardDuplicates } from './plugins/discard-duplicates';
 import { discardEmptyRules } from './plugins/discard-empty-rules';
 import { expandShorthands } from './plugins/expand-shorthands';
 import { extractStyleSheets } from './plugins/extract-stylesheets';
+import { flattenMultipleSelectors } from './plugins/flatten-multiple-selectors';
 import { increaseSpecificity } from './plugins/increase-specificity';
 import { normalizeCSS } from './plugins/normalize-css';
 import { parentOrphanedPseudos } from './plugins/parent-orphaned-pseudos';
 import { sortAtomicStyleSheet } from './plugins/sort-atomic-style-sheet';
-
 export interface TransformOpts {
   optimizeCss?: boolean;
   classNameCompressionMap?: Record<string, string>;
@@ -21,6 +21,7 @@ export interface TransformOpts {
   sortAtRules?: boolean;
   sortShorthand?: boolean;
   classHashPrefix?: string;
+  flattenMultipleSelectors?: boolean;
 }
 
 /**
@@ -62,6 +63,7 @@ export const transformCss = (
         callback: (className: string) => classNames.push(className),
         classHashPrefix: opts.classHashPrefix,
       }),
+      ...(opts.flattenMultipleSelectors ? [flattenMultipleSelectors(), discardDuplicates()] : []),
       ...(opts.increaseSpecificity ? [increaseSpecificity()] : []),
       sortAtomicStyleSheet({
         sortAtRulesEnabled: opts.sortAtRules,

--- a/packages/parcel-transformer-external/src/__tests__/transformer.parceltest.ts
+++ b/packages/parcel-transformer-external/src/__tests__/transformer.parceltest.ts
@@ -54,8 +54,8 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
       singleQuote: true,
     })
   ).toMatchInlineSnapshot(`
-    "._19itlf8h {
-      border: 2px solid blue;
+    "._19it1vrj {
+      border: 2px solid transparent;
     }
     ._1wyb12am {
       font-size: 50px;
@@ -83,6 +83,21 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
     }
     ._19bv1vi7 {
       padding-left: 32px;
+    }
+    ._f8pj1x77:focus {
+      color: white;
+    }
+    ._jomr13q2:focus {
+      background-color: blue;
+    }
+    ._4cvx13q2:hover {
+      border-color: blue;
+    }
+    ._30l31x77:hover {
+      color: white;
+    }
+    ._irr313q2:hover {
+      background-color: blue;
     }
     "
   `);

--- a/packages/parcel-transformer/src/__tests__/transformer.parceltest.ts
+++ b/packages/parcel-transformer/src/__tests__/transformer.parceltest.ts
@@ -225,8 +225,8 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
       singleQuote: true,
     })
   ).toMatchInlineSnapshot(`
-    "._19itlf8h {
-      border: 2px solid blue;
+    "._19it1vrj {
+      border: 2px solid transparent;
     }
     ._1wyb12am {
       font-size: 50px;
@@ -255,6 +255,21 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
     ._19bv1vi7 {
       padding-left: 32px;
     }
+    ._f8pj1x77:focus {
+      color: white;
+    }
+    ._jomr13q2:focus {
+      background-color: blue;
+    }
+    ._4cvx13q2:hover {
+      border-color: blue;
+    }
+    ._30l31x77:hover {
+      color: white;
+    }
+    ._irr313q2:hover {
+      background-color: blue;
+    }
     "
   `);
 
@@ -273,7 +288,7 @@ it('transforms assets with compiled and extraction babel plugins', async () => {
             style: __cmpls,
             ref: __cmplr,
             className: (0, _runtime.ax)([
-                "_19itlf8h _ca0q1vi7 _u5f31vi7 _n3td1vi7 _19bv1vi7 _syaz13q2 _1wyb1ul9",
+                "_19it1vrj _ca0q1vi7 _u5f31vi7 _n3td1vi7 _19bv1vi7 _syaz13q2 _1wyb1ul9 _4cvx13q2 _irr313q2 _30l31x77 _jomr13q2 _f8pj1x77",
                 __cmplp.className
             ])
         }));

--- a/packages/react/src/__tests__/browser.test.tsx
+++ b/packages/react/src/__tests__/browser.test.tsx
@@ -94,13 +94,14 @@ describe('browser', () => {
     render(<StyledLink href="https://atlassian.design">Atlassian Design System</StyledLink>);
 
     expect(document.head.innerHTML.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
-      "<style nonce="k0Mp1lEd">._1e0c1txw{display:flex}._1wyb12am{font-size:50px}._syaz1cnh{color:purple}._v0vw1x77:focus-visible, ._ysv71x77:link{color:white}</style>
-      <style nonce="k0Mp1lEd">._ysv75scu:link{color:red}</style>
+      "<style nonce="k0Mp1lEd">._1e0c1txw{display:flex}._1wyb12am{font-size:50px}._syaz1cnh{color:purple}</style>
+      <style nonce="k0Mp1lEd">._ysv75scu:link{color:red}._ysv71x77:link{color:white}</style>
       <style nonce="k0Mp1lEd">._105332ev:visited{color:pink}</style>
       <style nonce="k0Mp1lEd">._f8pjbf54:focus{color:green}</style>
+      <style nonce="k0Mp1lEd">._v0vw1x77:focus-visible{color:white}</style>
       <style nonce="k0Mp1lEd">._30l31gy6:hover{color:yellow}</style>
       <style nonce="k0Mp1lEd">._9h8h13q2:active{color:blue}</style>
-      <style nonce="k0Mp1lEd">@media (max-width:800px){._1o8z1gy6:focus{color:yellow}._jbabtwqo:focus-visible, ._6146twqo:hover{color:grey}._1cld11x8:active{color:black}}@supports (display:grid){._1df61gy6:focus{color:yellow}._7okp11x8:active{color:black}}</style>
+      <style nonce="k0Mp1lEd">@media (max-width:800px){._1o8z1gy6:focus{color:yellow}._jbabtwqo:focus-visible{color:grey}._6146twqo:hover{color:grey}._1cld11x8:active{color:black}}@supports (display:grid){._1df61gy6:focus{color:yellow}._7okp11x8:active{color:black}}</style>
       "
     `);
   });

--- a/website/packages/docs/src/pages/pkg-babel-plugin.mdx
+++ b/website/packages/docs/src/pages/pkg-babel-plugin.mdx
@@ -127,10 +127,8 @@ css({
 });
 ```
 
-This will be enabled by default in a future minor release once impact is validated.
-
 - Type: `boolean`
-- Default: `false`
+- Default: `true`
 
 #### importReact
 

--- a/website/packages/docs/src/pages/pkg-babel-plugin.mdx
+++ b/website/packages/docs/src/pages/pkg-babel-plugin.mdx
@@ -50,6 +50,7 @@ If you choose to configure Compiled through Webpack or Parcel (recommended), you
 - `classHashPrefix`
 - `classNameCompressionMap`
 - `extensions`
+- `flattenMultipleSelectors`
 - `importReact`
 - `importSources`
 - `increaseSpecificity`
@@ -104,6 +105,32 @@ Extensions that we should consider code. We use these to identify if a file shou
 
 - Type: `string[]`
 - Default: `['.js', '.jsx', '.ts', '.tsx']`
+
+#### flattenMultipleSelectors
+
+Flatten multiple selectors into separate rules to better deduplicate and sort styles, eg.:
+
+```tsx
+css({
+  '&:hover, &:focus': {
+    color: 'red',
+  },
+});
+```
+
+Is transformed into the same code as this would be:
+
+```tsx
+css({
+  '&:hover': { color: 'red' },
+  '&:focus': { color: 'red' },
+});
+```
+
+This will be enabled by default in a future minor release once impact is validated.
+
+- Type: `boolean`
+- Default: `false`
 
 #### importReact
 


### PR DESCRIPTION
### What is this change?

Flatten multiple selectors into separate rules to better deduplicate and sort styles.

```tsx
css({
  '&:hover, &:focus': {
    color: 'red',
  },
});
```

Is transformed into the same code as this would be:

```tsx
css({
  '&:hover': { color: 'red' },
  '&:focus': { color: 'red' },
});
```

This will be enabled by default in a future minor release once impact is validated.

### Why are we making this change?

Without this, pseudo-selectors aren't sorted properly in some scenarios, eg. we always expect `&:active` to override `&:hover` styles, eg. `._1di61dty:active` not be losing to `._irr3166n:hover`, but our sorting is based off of the first selector when multiple selectors are found.
```css
._1di61dty:active {
    background-color: var(--ds-background-neutral-subtle-pressed, #091e4224);
}

._1di6166n:active, ._jomr166n:focus, ._10j7166n:focus-within, ._irr3166n:hover {
    background-color: var(--ds-background-neutral-subtle-hovered, #091e420f);
}
```

📔 In active testing, this increased bytesize of the output `compiled.css` by <2%, but could be more (or even negative) depending on the code.

⚠️ This could still be broken with `@media (min-width: 480px) and (min-height: 480px)` and other multi-queries, but that would be unexpected, and no solution is readily available.

---

### PR checklist

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
