### PR TITLE
Allow chained pseudo-selectors, eg. `&:hover { &::after { … } }` in our type syntaxes. May have some unexpected side-effects.

### DIFF
--- a/.changeset/ready-queens-change.md
+++ b/.changeset/ready-queens-change.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': minor
+---
+
+Allow chained pseudo-selectors, eg. `&:hover { &::after { … } }` in our type syntaxes. May have some unexpected side-effects.

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
       }
     }
   },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "size-limit": [
     {
       "path": "./packages/react/dist/browser/runtime/css-custom-property.js",

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -69,6 +69,10 @@ describe('createStrictAPI()', () => {
           color: '',
           // @ts-expect-error — Type '""' is not assignable to type ...
           backgroundColor: '',
+          '&::after': {
+            // @ts-expect-error — Type '"none"' is not assignable to type ...
+            padding: 'none',
+          },
         },
         '&:active': {
           // @ts-expect-error — Type '""' is not assignable to type ...
@@ -138,7 +142,7 @@ describe('createStrictAPI()', () => {
       function Component(_: {
         xcss: ReturnType<
           typeof XCSSProp<
-            'backgroundColor' | 'color',
+            'backgroundColor' | 'color' | 'display',
             '&:hover' | '&:active' | '&::before' | '&::after'
           >
         >;
@@ -147,38 +151,92 @@ describe('createStrictAPI()', () => {
       }
 
       const { getByTestId } = render(
-        <Component
-          xcss={{
-            // @ts-expect-error — Type '""' is not assignable to type ...
-            color: '',
-            // @ts-expect-error — Type '""' is not assignable to type ...
-            backgroundColor: '',
-            '&:hover': {
-              // @ts-expect-error — Type '""' is not assignable to type ...
-              color: 'var(--ds-text)',
-              // @ts-expect-error — Type '""' is not assignable to type ...
-              backgroundColor: 'var(--ds-success)',
-            },
-            '&:active': {
-              // @ts-expect-error — Type '""' is not assignable to type ...
-              color: 'var(--ds-text)',
-              // @ts-expect-error — Type '""' is not assignable to type ...
-              backgroundColor: 'var(--ds-success)',
-            },
-            '&::before': {
-              // @ts-expect-error — Type '""' is not assignable to type ...
-              color: '',
-              // @ts-expect-error — Type '""' is not assignable to type ...
-              backgroundColor: '',
-            },
-            '&::after': {
-              // @ts-expect-error — Type '""' is not assignable to type ...
-              color: '',
-              // @ts-expect-error — Type '""' is not assignable to type ...
-              backgroundColor: '',
-            },
-          }}
-        />
+        <div>
+          <Component
+            // @ts-expect-error — Invalid token
+            xcss={{ color: 'var(--ds-color)' }}
+          />
+          <Component
+            // @ts-expect-error — Disallowed property
+            xcss={{ padding: '0px' }}
+          />
+          <Component
+            xcss={{
+              '&:hover': {
+                // @ts-expect-error — Should be a hovered state
+                color: 'var(--ds-text)',
+                // @ts-expect-error — Should be a hovered state
+                backgroundColor: 'var(--ds-success)',
+              },
+              '&:active': {
+                // @ts-expect-error — Should be a hovered state
+                color: 'var(--ds-text)',
+                // @ts-expect-error — Should be a hovered state
+                backgroundColor: 'var(--ds-success)',
+              },
+            }}
+          />
+          <Component
+            xcss={{
+              '&:hover': {
+                // @ts-expect-error – Bad nesting
+                '&:focus': {
+                  display: 'none',
+                },
+              },
+              '&:active': {
+                // @ts-expect-error – Bad nesting
+                '&:focus': {
+                  display: 'none',
+                },
+              },
+            }}
+          />
+          <Component
+            xcss={{
+              '&::before': {
+                // @ts-expect-error — Type '""' is not assignable to type ...
+                color: '',
+                // @ts-expect-error — Type '""' is not assignable to type ...
+                backgroundColor: '',
+              },
+              '&::after': {
+                // @ts-expect-error — Type '""' is not assignable to type ...
+                color: '',
+                // @ts-expect-error — Type '""' is not assignable to type ...
+                backgroundColor: '',
+              },
+            }}
+          />
+          <Component
+            xcss={{
+              '&:hover': {
+                // @ts-expect-error – Bad nesting
+                '&:focus': {
+                  display: 'none',
+                },
+              },
+              '&:active': {
+                // @ts-expect-error — Type '""' is not assignable to type ...
+                color: 'var(--ds-text)',
+                // @ts-expect-error — Type '""' is not assignable to type ...
+                backgroundColor: 'var(--ds-success)',
+              },
+              '&::before': {
+                // @ts-expect-error — Type '""' is not assignable to type ...
+                color: '',
+                // @ts-expect-error — Type '""' is not assignable to type ...
+                backgroundColor: '',
+              },
+              '&::after': {
+                // @ts-expect-error — Type '""' is not assignable to type ...
+                color: '',
+                // @ts-expect-error — Type '""' is not assignable to type ...
+                backgroundColor: '',
+              },
+            }}
+          />
+        </div>
       );
 
       expect(getByTestId('div')).toBeDefined();
@@ -197,6 +255,12 @@ describe('createStrictAPI()', () => {
           padding: '10px',
           color: 'var(--ds-text-hovered)',
           backgroundColor: 'var(--ds-bold-hovered)',
+          '&::after': {
+            display: 'block',
+            content: '"Hello world"',
+            color: 'var(--ds-text)',
+            backgroundColor: 'var(--ds-bold)',
+          },
         },
         '&:active': {
           // @ts-expect-error — should be a value from the schema
@@ -236,6 +300,12 @@ describe('createStrictAPI()', () => {
             padding: '10px',
             color: 'var(--ds-text-hovered)',
             backgroundColor: 'var(--ds-bold-hovered)',
+            '&::after': {
+              display: 'block',
+              content: '"Hello world"',
+              color: 'var(--ds-text)',
+              backgroundColor: 'var(--ds-bold)',
+            },
           },
           '&:active': {
             // @ts-expect-error — should be a value from the schema
@@ -258,7 +328,24 @@ describe('createStrictAPI()', () => {
         },
       });
 
-      const { getByTestId } = render(<div css={stylesMap.primary} data-testid="div" />);
+      const stylesMap2 = cssMap({
+        primary: {
+          '&::after': {
+            display: 'block',
+            content: '"Hello world"',
+            color: 'var(--ds-text)',
+            backgroundColor: 'var(--ds-bold)',
+            // @ts-expect-error -- Does not allow nested `&::after &:hover`
+            '&:hover': {
+              color: 'var(--ds-text-hovered)',
+            },
+          },
+        },
+      });
+
+      const { getByTestId } = render(
+        <div css={[stylesMap.primary, stylesMap2.primary]} data-testid="div" />
+      );
 
       expect(getByTestId('div')).toHaveCompiledCss('color', 'var(--ds-text)');
     });
@@ -285,6 +372,10 @@ describe('createStrictAPI()', () => {
             '&:hover': {
               color: 'var(--ds-text-hovered)',
               backgroundColor: 'var(--ds-bold-hovered)',
+              '&::after': {
+                color: 'var(--ds-text)',
+                backgroundColor: 'var(--ds-bold)',
+              },
             },
             '&:active': {
               color: 'var(--ds-text-pressed)',

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -2,7 +2,13 @@ import type * as CSS from 'csstype';
 
 import type { ApplySchemaValue } from '../create-strict-api/types';
 import { ax } from '../runtime';
-import type { CSSPseudos, CSSPseudoClasses, CSSProperties, StrictCSSProperties } from '../types';
+import type {
+  CSSPseudos,
+  CSSPseudoClasses,
+  CSSProperties,
+  StrictCSSProperties,
+  CSSPseudoElements,
+} from '../types';
 
 type MarkAsRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
@@ -23,10 +29,17 @@ type XCSSPseudo<
   TSchema
 > = {
   [Q in CSSPseudos]?: Q extends TAllowedPseudos
-    ? MarkAsRequired<
-        XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''>,
-        TRequiredProperties['requiredProperties']
-      >
+    ? Q extends CSSPseudoClasses
+      ? MarkAsRequired<
+          XCSSValue<TAllowedProperties, TSchema, Q>,
+          TRequiredProperties['requiredProperties']
+        > & {
+          [R in CSSPseudoElements]?: XCSSValue<TAllowedProperties, TSchema, ''>;
+        }
+      : MarkAsRequired<
+          XCSSValue<TAllowedProperties, TSchema, ''>,
+          TRequiredProperties['requiredProperties']
+        >
     : never;
 };
 


### PR DESCRIPTION
### What is this change?

Allow for chained psuedo-selectors to work, eg. `CSSPseudoClasses` > `CSSPseudoElements` as in `&:hover { &::cue { … } }`.  This already worked in https://github.com/atlassian-labs/compiled/blob/4b2e5eeb17e4d0f2359723e484cbe73f26320531/packages/react/src/create-strict-api/types.ts#L57, but wasn't setup in `packages/react/src/xcss-prop/index.ts`

### Why are we making this change?

To allow for clearer migration internal to Atlassian.

### How are we making this change?

TypeScript!

### PR checklist

- [ ] Updated or added applicable tests
- [ ] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
