### PR TITLE
Allow for flattened chained pseudo-selectors, eg. `&:hover::after` in our types

### DIFF
--- a/.changeset/slick-waves-punch.md
+++ b/.changeset/slick-waves-punch.md
@@ -1,5 +1,5 @@
 ---
-'@compiled/react': minor
+'@compiled/react': patch
 ---
 
 Allow for flattened chained pseudo-selectors, eg. `&:hover::after` in our type syntaxes

--- a/.changeset/wild-aliens-hug.md
+++ b/.changeset/wild-aliens-hug.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': minor
+---
+
+Allow for flattened chained pseudo-selectors, eg. `&:hover::after` in our type syntaxes

--- a/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
+++ b/packages/react/src/create-strict-api/__tests__/__fixtures__/strict-api-recursive.ts
@@ -24,9 +24,15 @@ interface PressedProperties {
   backgroundColor: BackgroundPressed;
 }
 
+interface ChainedProperties {
+  color: ColorPressed;
+  backgroundColor: BackgroundPressed;
+}
+
 interface CSSPropertiesSchema extends Properties {
   '&:hover': HoveredProperties;
   '&:active': PressedProperties;
+  '&:hover::after': ChainedProperties;
 }
 
 const { css, cssMap, cx, XCSSProp } = createStrictAPI<CSSPropertiesSchema>();

--- a/packages/react/src/create-strict-api/__tests__/generics.test.tsx
+++ b/packages/react/src/create-strict-api/__tests__/generics.test.tsx
@@ -9,6 +9,7 @@ describe('createStrictAPI()', () => {
     const styles = css({
       '&:hover': {},
       '&:active': {},
+      '&:hover::after': {},
       '&::before': {},
       '&::after': {},
     });
@@ -23,6 +24,7 @@ describe('createStrictAPI()', () => {
       nested: {
         '&:hover': {},
         '&:active': {},
+        '&:hover::after': {},
         '&::before': {},
         '&::after': {},
       },
@@ -40,7 +42,7 @@ describe('createStrictAPI()', () => {
       xcss: ReturnType<
         typeof XCSSProp<
           'backgroundColor' | 'color',
-          '&:hover' | '&:active' | '&::before' | '&::after'
+          '&:hover' | '&:active' | '&::before' | '&::after' | '&:hover::after'
         >
       >;
     }) {
@@ -49,7 +51,13 @@ describe('createStrictAPI()', () => {
 
     const { getByTestId } = render(
       <Component
-        xcss={{ '&:hover': {}, '&:active': {}, '&::before': {}, '&::after': {} }}
+        xcss={{
+          '&:hover': {},
+          '&:active': {},
+          '&::before': {},
+          '&::after': {},
+          '&:hover::after': {},
+        }}
         data-testid="div"
       />
     );
@@ -71,6 +79,12 @@ describe('createStrictAPI()', () => {
           backgroundColor: '',
         },
         '&:active': {
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          color: '',
+          // @ts-expect-error — Type '""' is not assignable to type ...
+          backgroundColor: '',
+        },
+        '&:hover::after': {
           // @ts-expect-error — Type '""' is not assignable to type ...
           color: '',
           // @ts-expect-error — Type '""' is not assignable to type ...
@@ -114,6 +128,12 @@ describe('createStrictAPI()', () => {
             // @ts-expect-error — Type '""' is not assignable to type ...
             backgroundColor: '',
           },
+          '&:hover::after': {
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            color: '',
+            // @ts-expect-error — Type '""' is not assignable to type ...
+            backgroundColor: '',
+          },
           '&::before': {
             // @ts-expect-error — Type '""' is not assignable to type ...
             color: '',
@@ -139,7 +159,7 @@ describe('createStrictAPI()', () => {
         xcss: ReturnType<
           typeof XCSSProp<
             'backgroundColor' | 'color',
-            '&:hover' | '&:active' | '&::before' | '&::after'
+            '&:hover' | '&:active' | '&::before' | '&::after' | '&:hover::after'
           >
         >;
       }) {
@@ -160,6 +180,12 @@ describe('createStrictAPI()', () => {
               backgroundColor: 'var(--ds-success)',
             },
             '&:active': {
+              // @ts-expect-error — Type '""' is not assignable to type ...
+              color: 'var(--ds-text)',
+              // @ts-expect-error — Type '""' is not assignable to type ...
+              backgroundColor: 'var(--ds-success)',
+            },
+            '&:hover::after': {
               // @ts-expect-error — Type '""' is not assignable to type ...
               color: 'var(--ds-text)',
               // @ts-expect-error — Type '""' is not assignable to type ...
@@ -197,6 +223,12 @@ describe('createStrictAPI()', () => {
           padding: '10px',
           color: 'var(--ds-text-hovered)',
           backgroundColor: 'var(--ds-bold-hovered)',
+        },
+        '&:hover::after': {
+          // @ts-expect-error — should be a value from the schema
+          padding: '10px',
+          color: 'var(--ds-text-pressed)',
+          backgroundColor: 'var(--ds-bold-pressed)',
         },
         '&:active': {
           // @ts-expect-error — should be a value from the schema
@@ -243,6 +275,12 @@ describe('createStrictAPI()', () => {
             color: 'var(--ds-text-pressed)',
             backgroundColor: 'var(--ds-bold-pressed)',
           },
+          '&:hover::after': {
+            // @ts-expect-error — should be a value from the schema
+            padding: '10px',
+            color: 'var(--ds-text-pressed)',
+            backgroundColor: 'var(--ds-bold-pressed)',
+          },
           '&::before': {
             // @ts-expect-error — should be a value from the schema
             padding: '10px',
@@ -270,7 +308,7 @@ describe('createStrictAPI()', () => {
         xcss: ReturnType<
           typeof XCSSProp<
             'backgroundColor' | 'color',
-            '&:hover' | '&:active' | '&::before' | '&::after'
+            '&:hover' | '&:active' | '&::before' | '&::after' | '&:hover::after'
           >
         >;
       }) {
@@ -287,6 +325,10 @@ describe('createStrictAPI()', () => {
               backgroundColor: 'var(--ds-bold-hovered)',
             },
             '&:active': {
+              color: 'var(--ds-text-pressed)',
+              backgroundColor: 'var(--ds-bold-pressed)',
+            },
+            '&:hover::after': {
               color: 'var(--ds-text-pressed)',
               backgroundColor: 'var(--ds-bold-pressed)',
             },

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -1,9 +1,8 @@
 import type {
   StrictCSSProperties,
-  CSSPseudoClasses,
   CSSPseudoElements,
   CSSPseudos,
-  FlattenedChainedCSSPseudos,
+  AllCSSPseudoClasses,
 } from '../types';
 
 /**
@@ -12,7 +11,7 @@ import type {
  * and pseudo elements.
  */
 export type CompiledSchemaShape = StrictCSSProperties & {
-  [Q in CSSPseudoClasses | FlattenedChainedCSSPseudos]?: StrictCSSProperties;
+  [Q in AllCSSPseudoClasses]?: StrictCSSProperties;
 };
 
 export type PseudosDeclarations = { [Q in CSSPseudos]?: StrictCSSProperties };
@@ -28,7 +27,7 @@ export type AllowedStyles<TMediaQuery extends string> = StrictCSSProperties &
 export type ApplySchemaValue<
   TSchema,
   TKey extends keyof StrictCSSProperties,
-  TPseudoKey extends CSSPseudoClasses | FlattenedChainedCSSPseudos | ''
+  TPseudoKey extends AllCSSPseudoClasses | ''
 > = TKey extends keyof TSchema
   ? // TKey is a valid property on the schema
     TPseudoKey extends keyof TSchema
@@ -47,15 +46,11 @@ export type ApplySchemaValue<
  * value if present, else fallback to its value from {@link StrictCSSProperties}. If
  * the property isn't a known property its value will be resolved to `never`.
  */
-export type ApplySchema<
-  TObject,
-  TSchema,
-  TPseudoKey extends CSSPseudoClasses | FlattenedChainedCSSPseudos | '' = ''
-> = {
+export type ApplySchema<TObject, TSchema, TPseudoKey extends AllCSSPseudoClasses | '' = ''> = {
   [TKey in keyof TObject]?: TKey extends keyof StrictCSSProperties
     ? // TKey is a valid CSS property, try to resolve its value.
       ApplySchemaValue<TSchema, TKey, TPseudoKey>
-    : TKey extends CSSPseudoClasses | FlattenedChainedCSSPseudos
+    : TKey extends AllCSSPseudoClasses
     ? // TKey is a valid pseudo class, recursively resolve its child properties
       // while passing down the parent pseudo key to resolve any specific schema types.
       ApplySchema<TObject[TKey], TSchema, TKey>

--- a/packages/react/src/create-strict-api/types.ts
+++ b/packages/react/src/create-strict-api/types.ts
@@ -3,6 +3,7 @@ import type {
   CSSPseudoClasses,
   CSSPseudoElements,
   CSSPseudos,
+  FlattenedChainedCSSPseudos,
 } from '../types';
 
 /**
@@ -11,7 +12,7 @@ import type {
  * and pseudo elements.
  */
 export type CompiledSchemaShape = StrictCSSProperties & {
-  [Q in CSSPseudoClasses]?: StrictCSSProperties;
+  [Q in CSSPseudoClasses | FlattenedChainedCSSPseudos]?: StrictCSSProperties;
 };
 
 export type PseudosDeclarations = { [Q in CSSPseudos]?: StrictCSSProperties };
@@ -27,7 +28,7 @@ export type AllowedStyles<TMediaQuery extends string> = StrictCSSProperties &
 export type ApplySchemaValue<
   TSchema,
   TKey extends keyof StrictCSSProperties,
-  TPseudoKey extends CSSPseudoClasses | ''
+  TPseudoKey extends CSSPseudoClasses | FlattenedChainedCSSPseudos | ''
 > = TKey extends keyof TSchema
   ? // TKey is a valid property on the schema
     TPseudoKey extends keyof TSchema
@@ -46,11 +47,15 @@ export type ApplySchemaValue<
  * value if present, else fallback to its value from {@link StrictCSSProperties}. If
  * the property isn't a known property its value will be resolved to `never`.
  */
-export type ApplySchema<TObject, TSchema, TPseudoKey extends CSSPseudoClasses | '' = ''> = {
+export type ApplySchema<
+  TObject,
+  TSchema,
+  TPseudoKey extends CSSPseudoClasses | FlattenedChainedCSSPseudos | '' = ''
+> = {
   [TKey in keyof TObject]?: TKey extends keyof StrictCSSProperties
     ? // TKey is a valid CSS property, try to resolve its value.
       ApplySchemaValue<TSchema, TKey, TPseudoKey>
-    : TKey extends CSSPseudoClasses
+    : TKey extends CSSPseudoClasses | FlattenedChainedCSSPseudos
     ? // TKey is a valid pseudo class, recursively resolve its child properties
       // while passing down the parent pseudo key to resolve any specific schema types.
       ApplySchema<TObject[TKey], TSchema, TKey>

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -89,6 +89,16 @@ export type CSSPseudoClasses =
   | '&:valid'
   | '&:visited';
 
+type ChainedCSSPseudos =
+  | '&:visited:active'
+  | '&:visited:hover'
+  | '&:active:visited'
+  | '&:hover::before'
+  | '&:hover::after'
+  | '&:focus-visible::before'
+  | '&:focus-visible::after'
+  | '&:focus:not(:focus-visible)';
+
 /*
  * This list of pseudo-classes and pseudo-elements are from csstype
  * but with & added to the front. Compiled supports both &-ful
@@ -96,7 +106,7 @@ export type CSSPseudoClasses =
  * (`&:hover` <==> `:hover`), however we force the use of the
  * &-ful form for consistency with the nested spec for new APIs.
  */
-export type CSSPseudos = CSSPseudoElements | CSSPseudoClasses;
+export type CSSPseudos = CSSPseudoElements | CSSPseudoClasses | ChainedCSSPseudos;
 
 /**
  * The XCSSProp must be given all known available properties even

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -51,6 +51,16 @@ export type CSSPseudoElements =
   | '&::target-text'
   | '&::view-transition';
 
+export type FlattenedChainedCSSPseudosClasses =
+  | '&:visited:active'
+  | '&:visited:hover'
+  | '&:active:visited'
+  | '&:hover::before'
+  | '&:hover::after'
+  | '&:focus-visible::before'
+  | '&:focus-visible::after'
+  | '&:focus:not(:focus-visible)';
+
 export type CSSPseudoClasses =
   | '&:active'
   | '&:autofill'
@@ -89,15 +99,7 @@ export type CSSPseudoClasses =
   | '&:valid'
   | '&:visited';
 
-export type FlattenedChainedCSSPseudos =
-  | '&:visited:active'
-  | '&:visited:hover'
-  | '&:active:visited'
-  | '&:hover::before'
-  | '&:hover::after'
-  | '&:focus-visible::before'
-  | '&:focus-visible::after'
-  | '&:focus:not(:focus-visible)';
+export type AllCSSPseudoClasses = CSSPseudoClasses | FlattenedChainedCSSPseudosClasses;
 
 /*
  * This list of pseudo-classes, chained pseudo-classes, and pseudo-elements are from csstype
@@ -106,7 +108,7 @@ export type FlattenedChainedCSSPseudos =
  * (`&:hover` <==> `:hover`), however we force the use of the
  * &-ful form for consistency with the nested spec for new APIs.
  */
-export type CSSPseudos = CSSPseudoElements | CSSPseudoClasses | FlattenedChainedCSSPseudos;
+export type CSSPseudos = CSSPseudoElements | AllCSSPseudoClasses;
 
 /**
  * The XCSSProp must be given all known available properties even

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -89,7 +89,7 @@ export type CSSPseudoClasses =
   | '&:valid'
   | '&:visited';
 
-type FlattenedChainedCSSPseudos =
+export type FlattenedChainedCSSPseudos =
   | '&:visited:active'
   | '&:visited:hover'
   | '&:active:visited'

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -89,7 +89,7 @@ export type CSSPseudoClasses =
   | '&:valid'
   | '&:visited';
 
-type ChainedCSSPseudos =
+type FlattenedChainedCSSPseudos =
   | '&:visited:active'
   | '&:visited:hover'
   | '&:active:visited'
@@ -100,13 +100,13 @@ type ChainedCSSPseudos =
   | '&:focus:not(:focus-visible)';
 
 /*
- * This list of pseudo-classes and pseudo-elements are from csstype
+ * This list of pseudo-classes, chained pseudo-classes, and pseudo-elements are from csstype
  * but with & added to the front. Compiled supports both &-ful
  * and &-less forms and both will target the current element
  * (`&:hover` <==> `:hover`), however we force the use of the
  * &-ful form for consistency with the nested spec for new APIs.
  */
-export type CSSPseudos = CSSPseudoElements | CSSPseudoClasses | ChainedCSSPseudos;
+export type CSSPseudos = CSSPseudoElements | CSSPseudoClasses | FlattenedChainedCSSPseudos;
 
 /**
  * The XCSSProp must be given all known available properties even

--- a/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
+++ b/packages/react/src/xcss-prop/__tests__/xcss-prop.test.tsx
@@ -260,4 +260,35 @@ describe('xcss prop', () => {
       />
     ).toBeObject();
   });
+
+  it('should allow chained pseudo elements', () => {
+    function CSSPropComponent({ xcss }: { xcss: XCSSProp<XCSSAllProperties, '&:hover::after'> }) {
+      return <div className={xcss}>foo</div>;
+    }
+
+    const styles = cssMap({
+      redColor: { color: 'red', '&:hover::after': { backgroundColor: 'green' } },
+    });
+
+    const { getByText } = render(<CSSPropComponent xcss={styles.redColor} />);
+
+    expect(getByText('foo')).toHaveCompiledCss('color', 'red');
+  });
+
+  it('should type error when given a chained pseudo element and none are allowed', () => {
+    function CSSPropComponent({ xcss }: { xcss: XCSSProp<XCSSAllProperties, '&:hover'> }) {
+      return <div className={xcss}>foo</div>;
+    }
+
+    const styles = cssMap({
+      redColor: { color: 'red', '&:hover::after': { backgroundColor: 'green' } },
+    });
+
+    expectTypeOf(
+      <CSSPropComponent
+        // @ts-expect-error — Types of property '"&:hover::after"' are incompatible.
+        xcss={styles.redColor}
+      />
+    ).toBeObject();
+  });
 });

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -2,20 +2,14 @@ import type * as CSS from 'csstype';
 
 import type { ApplySchemaValue } from '../create-strict-api/types';
 import { ax } from '../runtime';
-import type {
-  CSSPseudos,
-  CSSPseudoClasses,
-  CSSProperties,
-  StrictCSSProperties,
-  FlattenedChainedCSSPseudos,
-} from '../types';
+import type { CSSPseudos, CSSProperties, StrictCSSProperties, AllCSSPseudoClasses } from '../types';
 
 type MarkAsRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 type XCSSValue<
   TStyleDecl extends keyof CSSProperties,
   TSchema,
-  TPseudoKey extends CSSPseudoClasses | FlattenedChainedCSSPseudos | ''
+  TPseudoKey extends AllCSSPseudoClasses | ''
 > = {
   [Q in keyof StrictCSSProperties]: Q extends TStyleDecl
     ? ApplySchemaValue<TSchema, Q, TPseudoKey>
@@ -30,11 +24,7 @@ type XCSSPseudo<
 > = {
   [Q in CSSPseudos]?: Q extends TAllowedPseudos
     ? MarkAsRequired<
-        XCSSValue<
-          TAllowedProperties,
-          TSchema,
-          Q extends CSSPseudoClasses | FlattenedChainedCSSPseudos ? Q : ''
-        >,
+        XCSSValue<TAllowedProperties, TSchema, Q extends AllCSSPseudoClasses ? Q : ''>,
         TRequiredProperties['requiredProperties']
       >
     : never;

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -2,14 +2,20 @@ import type * as CSS from 'csstype';
 
 import type { ApplySchemaValue } from '../create-strict-api/types';
 import { ax } from '../runtime';
-import type { CSSPseudos, CSSPseudoClasses, CSSProperties, StrictCSSProperties } from '../types';
+import type {
+  CSSPseudos,
+  CSSPseudoClasses,
+  CSSProperties,
+  StrictCSSProperties,
+  FlattenedChainedCSSPseudos,
+} from '../types';
 
 type MarkAsRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 type XCSSValue<
   TStyleDecl extends keyof CSSProperties,
   TSchema,
-  TPseudoKey extends CSSPseudoClasses | ''
+  TPseudoKey extends CSSPseudoClasses | FlattenedChainedCSSPseudos | ''
 > = {
   [Q in keyof StrictCSSProperties]: Q extends TStyleDecl
     ? ApplySchemaValue<TSchema, Q, TPseudoKey>
@@ -24,7 +30,11 @@ type XCSSPseudo<
 > = {
   [Q in CSSPseudos]?: Q extends TAllowedPseudos
     ? MarkAsRequired<
-        XCSSValue<TAllowedProperties, TSchema, Q extends CSSPseudoClasses ? Q : ''>,
+        XCSSValue<
+          TAllowedProperties,
+          TSchema,
+          Q extends CSSPseudoClasses | FlattenedChainedCSSPseudos ? Q : ''
+        >,
         TRequiredProperties['requiredProperties']
       >
     : never;


### PR DESCRIPTION
### What is this change?

Adding the types to the types file and copying the specific selectors from xcss 
- should we have more types here ? Are there any other flat pseudos we want? 

### Why are we making this change?

Allow for flattened chained pseudo-selectors, eg. `&:hover::after` in our type syntaxes. Kylor's PR https://github.com/atlassian-labs/compiled/pull/1834 allows for the nesting to occur, but sometimes a flattened selector can be cleaner for some users and I don't think it's supported with that PR 🤔 
Happy to decline if i'm misunderstanding that PR !

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
