### PR TITLE
add more flattened pseudos to allowed types

### DIFF
--- a/.changeset/thin-towns-invent.md
+++ b/.changeset/thin-towns-invent.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Add more chained pseudos to type

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -51,7 +51,7 @@ export type CSSPseudoElements =
   | '&::target-text'
   | '&::view-transition';
 
-export type FlattenedChainedCSSPseudosClasses =
+export type CSSFlattenedChainedPsuedos =
   | '&:visited:active'
   | '&:visited:hover'
   | '&:visited:focus'
@@ -106,7 +106,7 @@ export type CSSPseudoClasses =
   | '&:valid'
   | '&:visited';
 
-export type AllCSSPseudoClasses = CSSPseudoClasses | FlattenedChainedCSSPseudosClasses;
+export type AllCSSPseudoClasses = CSSPseudoClasses | CSSFlattenedChainedPsuedos;
 
 /*
  * This list of pseudo-classes, chained pseudo-classes, and pseudo-elements are from csstype

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -54,11 +54,18 @@ export type CSSPseudoElements =
 export type FlattenedChainedCSSPseudosClasses =
   | '&:visited:active'
   | '&:visited:hover'
+  | '&:visited:focus'
+  | '&:visited:focus-visible'
+  | '&:visited:focus-within'
   | '&:active:visited'
   | '&:hover::before'
   | '&:hover::after'
   | '&:focus-visible::before'
   | '&:focus-visible::after'
+  | '&:focus::before'
+  | '&:focus::after'
+  | '&:focus-within::before'
+  | '&:focus-within::after'
   | '&:focus:not(:focus-visible)';
 
 export type CSSPseudoClasses =


### PR DESCRIPTION
### What is this change?

- add a few more flattened pseudos, 

### Why are we making this change?

one of them was used in atlaskit -> &:visited:focus', want to avoid having more ts-expect-errors so trying to anticipate other potential combinations 


---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
