### PR TITLE
Use Array.isArray instead of instanceof Array for assertion

### DIFF
--- a/.changeset/clean-streets-clap.md
+++ b/.changeset/clean-streets-clap.md
@@ -1,0 +1,5 @@
+---
+'@compiled/parcel-optimizer': patch
+---
+
+Use Array.isArray instead of instanceof for more reliable check.

--- a/packages/parcel-optimizer/src/index.ts
+++ b/packages/parcel-optimizer/src/index.ts
@@ -52,7 +52,7 @@ export default new Optimizer<ParcelOptimizerOpts, unknown>({
           return;
         }
 
-        assert(rules instanceof Array);
+        assert(Array.isArray(rules));
 
         for (const rule of rules) {
           styleRules.add(rule as string);


### PR DESCRIPTION
### What is this change?

Changing `assert(rules instanceof Array)` to `assert(Array.isArray(rules))`.

### Why are we making this change?

The previous check can fail in an environment where the array was created in a different "context" (i.e. workers)

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
