### PR TITLE
Fix ESM Vite Plugin support now that we distribute multiple variants

### DIFF
--- a/.changeset/cool-apes-end.md
+++ b/.changeset/cool-apes-end.md
@@ -1,0 +1,5 @@
+---
+'@compiled/vite-plugin': patch
+---
+
+Fix ESM support with require() call now that we distribute multiple versions

--- a/packages/vite-plugin/src/utils.ts
+++ b/packages/vite-plugin/src/utils.ts
@@ -2,16 +2,9 @@ import * as fs from 'fs';
 import { dirname } from 'path';
 
 import type { Resolver } from '@compiled/babel-plugin';
+import { CachedInputFileSystem, ResolverFactory } from 'enhanced-resolve';
 
 import type { PluginOptions } from './types';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const enhancedResolve = require('enhanced-resolve');
-
-// Handle both ESM and CJS imports
-const { CachedInputFileSystem, ResolverFactory } = enhancedResolve.CachedInputFileSystem
-  ? enhancedResolve
-  : enhancedResolve.default || enhancedResolve;
 
 /**
  * Creates a default resolver using enhanced-resolve.
@@ -23,6 +16,7 @@ const { CachedInputFileSystem, ResolverFactory } = enhancedResolve.CachedInputFi
  */
 export function createDefaultResolver(config: PluginOptions): Resolver {
   const resolver = ResolverFactory.createResolver({
+    // @ts-expect-error - enhanced-resolve CachedInputFileSystem types are not compatible with Node.js fs types, but work at runtime
     fileSystem: new CachedInputFileSystem(fs, 4000),
     ...(config.extensions && {
       extensions: config.extensions,


### PR DESCRIPTION
### What is this change?

Fix ESM Vite Plugin support now that we distribute multiple variants.

### Why are we making this change?

Bumping to `v1.1.0` had this issue:
```sh
const enhancedResolve = require('enhanced-resolve');
                        ^
ReferenceError: require is not defined in ES module scope, you can use import instead
    at <anonymous> (/home/runner/workspace/node_modules/@compiled/vite-plugin/src/utils.ts:9:25)
```

tl;dr: I overlooked this one-off hack and the `dist/esm/*` shouldn't have `require()` in it.

### PR checklist

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
