### PR TITLE
Fix vite-plugin with ESM (v2)

### DIFF
--- a/.changeset/young-zoos-own.md
+++ b/.changeset/young-zoos-own.md
@@ -1,0 +1,5 @@
+---
+'@compiled/vite-plugin': patch
+---
+
+Fix vite-plugin with ESM (`v1.1.1` was a broken version for proper ESM)

--- a/packages/vite-plugin/src/utils.ts
+++ b/packages/vite-plugin/src/utils.ts
@@ -2,7 +2,13 @@ import * as fs from 'fs';
 import { dirname } from 'path';
 
 import type { Resolver } from '@compiled/babel-plugin';
-import { CachedInputFileSystem, ResolverFactory } from 'enhanced-resolve';
+import * as EnhancedResolve from 'enhanced-resolve';
+
+// enhanced-resolve doesn't work well across CJS/ESM boundaries
+const { CachedInputFileSystem, ResolverFactory } =
+  typeof EnhancedResolve === 'object' && 'default' in EnhancedResolve && EnhancedResolve.default
+    ? EnhancedResolve.default
+    : EnhancedResolve;
 
 import type { PluginOptions } from './types';
 


### PR DESCRIPTION
### What is this change?

Re-implements https://github.com/atlassian-labs/compiled/pull/1855 as that incorrectly removed this mapping which is likely required, eg. `enhanced-resolve` doesn't appear to export properly for both CJS/ESM so we require this hack.

### Why are we making this change?

To get pure ESM working with Compiled

---

### PR checklist

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
