### PR TITLE
Update jsx runtime types to be compatible with React 18 & 19

### DIFF
--- a/.changeset/rude-horses-sit.md
+++ b/.changeset/rude-horses-sit.md
@@ -1,0 +1,5 @@
+---
+'@compiled/react': patch
+---
+
+Fix JSX namespace types compatibility with React 19. `CompiledJSX.LibraryManagedAttributes` no longer delegates to `ReactJSXLibraryManagedAttributes`, which caused a circular reference when used with React 19's `@types/react`. The type now directly intersects component props with `{ key?: React.Key }`, which works correctly for both React 18 and React 19.

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
       }
     }
   },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "size-limit": [
     {
       "path": "./packages/react/dist/browser/runtime/css-custom-property.js",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
       }
     }
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+  "packageManager": "yarn@1.22.22",
   "size-limit": [
     {
       "path": "./packages/react/dist/browser/runtime/css-custom-property.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -71,6 +71,11 @@
     "jsx-runtime",
     "jsx-dev-runtime"
   ],
+  "scripts": {
+    "typecheck": "yarn typecheck:react18 && yarn typecheck:react19",
+    "typecheck:react18": "tsc --noEmit --project tsconfig.typecheck-react18.json",
+    "typecheck:react19": "tsc --noEmit --project tsconfig.typecheck-react19.json"
+  },
   "dependencies": {
     "csstype": "^3.2.3"
   },
@@ -80,11 +85,14 @@
     "@fixture/strict-api-test": "*",
     "@testing-library/react": "^16.3.2",
     "@types/jsdom": "^16.2.15",
+    "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "expect-type": "^0.20.0",
     "jsdom": "^19.0.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react18-types": "npm:@types/react@^18.3.1",
+    "react19-types": "npm:@types/react@^19.0.0"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/packages/react/src/jsx/__tests__/jsx-local-namespace-types.test.tsx
+++ b/packages/react/src/jsx/__tests__/jsx-local-namespace-types.test.tsx
@@ -1,0 +1,161 @@
+/** @jsxImportSource @compiled/react */
+import { expectTypeOf } from 'expect-type';
+import React from 'react';
+
+import type { CompiledJSX } from '../jsx-local-namespace';
+
+type ManagedProps<C, P> = CompiledJSX.LibraryManagedAttributes<C, P>;
+
+it('passes component props through LibraryManagedAttributes', () => {
+  type Props = { id: string; count: number };
+  type Managed = ManagedProps<React.FC<Props>, Props>;
+
+  expectTypeOf<Managed>().toMatchTypeOf<{ id: string; count: number }>();
+});
+
+it('always includes an optional key prop', () => {
+  type Props = { id: string };
+  type Managed = ManagedProps<React.FC<Props>, Props>;
+
+  expectTypeOf<Managed>().toMatchTypeOf<{ key?: React.Key }>();
+});
+
+it('adds css prop when className is declared', () => {
+  type Props = { className?: string; children?: React.ReactNode };
+  type Managed = ManagedProps<React.FC<Props>, Props>;
+
+  expectTypeOf<Managed>().toMatchTypeOf<{ css?: unknown }>();
+});
+
+it('does not add css prop when className is absent', () => {
+  type Props = { id: string };
+  type Managed = ManagedProps<React.FC<Props>, Props>;
+
+  type HasCss = 'css' extends keyof Managed ? true : false;
+  expectTypeOf<HasCss>().toEqualTypeOf<false>();
+});
+
+it('accepts css prop on intrinsic elements', () => {
+  const el = <div css={{ fontSize: '12px' }} />;
+  void el;
+});
+
+it('accepts css prop on components that accept className', () => {
+  function Card({ className }: { className?: string }) {
+    return <div className={className} />;
+  }
+
+  const el = <Card css={{ color: 'red' }} />;
+  void el;
+});
+
+it('rejects css prop on components without className', () => {
+  function NoClassName({ id }: { id: string }) {
+    return <div id={id} />;
+  }
+
+  const el = (
+    <NoClassName
+      id="x"
+      // @ts-expect-error css is not allowed when className is not declared
+      css={{ color: 'red' }}
+    />
+  );
+  void el;
+});
+
+it('accepts key prop in JSX', () => {
+  const items = ['a', 'b'];
+  const els = items.map((item) => <div key={item}>{item}</div>);
+  void els;
+});
+
+it('preserves inferred prop types for forwardRef components', () => {
+  const Input = React.forwardRef<HTMLInputElement, { value: string; className?: string }>(
+    ({ value, className }, ref) => <input ref={ref} value={value} className={className} readOnly />
+  );
+
+  type Managed = ManagedProps<typeof Input, { value: string; className?: string }>;
+
+  expectTypeOf<Managed>().toMatchTypeOf<{ value: string }>();
+  expectTypeOf<Managed>().toMatchTypeOf<{ css?: unknown }>();
+});
+
+it('preserves optional props with default values', () => {
+  function Badge({ label, count = 0 }: { label: string; count?: number; className?: string }) {
+    return <span className={label}>{count}</span>;
+  }
+
+  type Managed = ManagedProps<typeof Badge, { label: string; count?: number; className?: string }>;
+
+  expectTypeOf<Managed>().toMatchTypeOf<{ label: string; count?: number }>();
+  expectTypeOf<Managed>().toMatchTypeOf<{ css?: unknown }>();
+});
+
+it('handles render prop pattern — css on outer component requires className', () => {
+  type FieldProps = {
+    name: string;
+    defaultValue: string;
+    label: string;
+    isRequired?: boolean;
+    children: (bag: { fieldProps: { className?: string }; error?: string }) => React.ReactNode;
+  };
+
+  function Field({ children, name }: FieldProps) {
+    return <div>{children({ fieldProps: { className: name }, error: undefined })}</div>;
+  }
+
+  // Field does not declare className, so css prop should not be allowed on it
+  type Managed = ManagedProps<typeof Field, FieldProps>;
+  type HasCss = 'css' extends keyof Managed ? true : false;
+  expectTypeOf<HasCss>().toEqualTypeOf<false>();
+
+  // Elements inside the render prop are intrinsic elements so css is always allowed
+  const el = (
+    <Field name="name" defaultValue="" label="Name" isRequired>
+      {({ fieldProps, error }) => (
+        <input {...fieldProps} css={{ color: error ? 'red' : 'black' }} />
+      )}
+    </Field>
+  );
+  void el;
+});
+
+it('handles render prop pattern — css on outer component when className is declared', () => {
+  type FieldProps = {
+    name: string;
+    className?: string;
+    children: (bag: { fieldProps: { className?: string }; error?: string }) => React.ReactNode;
+  };
+
+  function Field({ children, className }: FieldProps) {
+    return <div className={className}>{children({ fieldProps: {}, error: undefined })}</div>;
+  }
+
+  type Managed = ManagedProps<typeof Field, FieldProps>;
+  expectTypeOf<Managed>().toMatchTypeOf<{ css?: unknown }>();
+});
+
+it('correctly infers types for generic child components', () => {
+  function List<T extends { id: string }>({
+    items,
+    className,
+  }: {
+    items: T[];
+    className?: string;
+  }) {
+    return (
+      <ul className={className}>
+        {items.map((item) => (
+          <li key={item.id}>{item.id}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  type Props = { items: { id: string }[]; className?: string };
+  type Managed = ManagedProps<typeof List, Props>;
+
+  expectTypeOf<Managed>().toMatchTypeOf<{ items: { id: string }[] }>();
+  expectTypeOf<Managed>().toMatchTypeOf<{ css?: unknown }>();
+});

--- a/packages/react/src/jsx/jsx-local-namespace.ts
+++ b/packages/react/src/jsx/jsx-local-namespace.ts
@@ -71,6 +71,7 @@ export namespace CompiledJSX {
   // that created a circular reference through our own definition. React 19's @types/react removed that
   // indirection, breaking the old code. We avoid the issue entirely by not delegating to
   // ReactJSXLibraryManagedAttributes and instead intersecting P with { key?: React.Key } directly.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   export type LibraryManagedAttributes<_C, P> = WithConditionalCSSProp<P> & P & { key?: React.Key };
   export type IntrinsicAttributes = ReactJSXIntrinsicAttributes;
   export type IntrinsicClassAttributes<T> = ReactJSXIntrinsicClassAttributes<T>;

--- a/packages/react/src/jsx/jsx-local-namespace.ts
+++ b/packages/react/src/jsx/jsx-local-namespace.ts
@@ -56,7 +56,6 @@ type ReactJSXElement = JSX.Element;
 type ReactJSXElementClass = JSX.ElementClass;
 type ReactJSXElementAttributesProperty = JSX.ElementAttributesProperty;
 type ReactJSXElementChildrenAttribute = JSX.ElementChildrenAttribute;
-type ReactJSXLibraryManagedAttributes<C, P> = JSX.LibraryManagedAttributes<C, P>;
 type ReactJSXIntrinsicAttributes = JSX.IntrinsicAttributes;
 type ReactJSXIntrinsicClassAttributes<T> = JSX.IntrinsicClassAttributes<T>;
 type ReactJSXIntrinsicElements = JSX.IntrinsicElements;
@@ -67,8 +66,12 @@ export namespace CompiledJSX {
   export type ElementClass = ReactJSXElementClass;
   export type ElementAttributesProperty = ReactJSXElementAttributesProperty;
   export type ElementChildrenAttribute = ReactJSXElementChildrenAttribute;
-  export type LibraryManagedAttributes<C, P> = WithConditionalCSSProp<P> &
-    ReactJSXLibraryManagedAttributes<C, P>;
+  // In React 18's @types/react, ReactManagedAttributes delegated to GlobalJSXLibraryManagedAttributes
+  // which aliased back to JSX.LibraryManagedAttributes. When CompiledJSX is used as the JSX namespace
+  // that created a circular reference through our own definition. React 19's @types/react removed that
+  // indirection, breaking the old code. We avoid the issue entirely by not delegating to
+  // ReactJSXLibraryManagedAttributes and instead intersecting P with { key?: React.Key } directly.
+  export type LibraryManagedAttributes<_C, P> = WithConditionalCSSProp<P> & P & { key?: React.Key };
   export type IntrinsicAttributes = ReactJSXIntrinsicAttributes;
   export type IntrinsicClassAttributes<T> = ReactJSXIntrinsicClassAttributes<T>;
   export type IntrinsicElements = {

--- a/packages/react/tsconfig.typecheck-react18.json
+++ b/packages/react/tsconfig.typecheck-react18.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.options.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "resolveJsonModule": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@compiled/react",
+    "typeRoots": ["../../node_modules/react18-types", "../../node_modules/@types"],
+    "types": ["jest", "node"],
+    "paths": {
+      "react": ["../../node_modules/react18-types"],
+      "react/jsx-runtime": ["../../node_modules/react18-types/jsx-runtime"],
+      "@compiled/react": ["./src/index.ts"],
+      "@compiled/react/jsx-runtime": ["./src/jsx/jsx-runtime.ts"],
+      "@compiled/react/jsx-dev-runtime": ["./src/jsx/jsx-dev-runtime.ts"],
+      "@compiled/utils": ["../utils/src/index.ts"]
+    }
+  },
+  "include": ["src/jsx/__tests__/jsx-local-namespace-types.test.tsx"]
+}

--- a/packages/react/tsconfig.typecheck-react19.json
+++ b/packages/react/tsconfig.typecheck-react19.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.options.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "resolveJsonModule": false,
+    "jsx": "react-jsx",
+    "jsxImportSource": "@compiled/react",
+    "typeRoots": ["../../node_modules/react19-types", "../../node_modules/@types"],
+    "types": ["jest", "node"],
+    "paths": {
+      "react": ["../../node_modules/react19-types"],
+      "react/jsx-runtime": ["../../node_modules/react19-types/jsx-runtime"],
+      "@compiled/react": ["./src/index.ts"],
+      "@compiled/react/jsx-runtime": ["./src/jsx/jsx-runtime.ts"],
+      "@compiled/react/jsx-dev-runtime": ["./src/jsx/jsx-dev-runtime.ts"],
+      "@compiled/utils": ["../utils/src/index.ts"]
+    }
+  },
+  "include": ["src/jsx/__tests__/jsx-local-namespace-types.test.tsx"]
+}

--- a/website/packages/docs/src/pages/pkg-react.mdx
+++ b/website/packages/docs/src/pages/pkg-react.mdx
@@ -12,6 +12,7 @@ import { Lozenge, HorizontalStack } from '@compiled/website-ui';
   <Lozenge>React 16</Lozenge>
   <Lozenge>React 17</Lozenge>
   <Lozenge>React 18</Lozenge>
+  <Lozenge>React 19</Lozenge>
 </HorizontalStack>
 
 The primary entrypoint package for Compiled that provides familiar APIs to style your app.

--- a/yarn.lock
+++ b/yarn.lock
@@ -15901,6 +15901,21 @@ react-refresh@^0.9.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
   integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
 
+"react18-types@npm:@types/react@^18.3.1":
+  version "18.3.28"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.28.tgz#0a85b1a7243b4258d9f626f43797ba18eb5f8781"
+  integrity sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.2.2"
+
+"react19-types@npm:@types/react@^19.0.0":
+  version "19.2.14"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.14.tgz#39604929b5e3957e3a6fa0001dafb17c7af70bad"
+  integrity sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==
+  dependencies:
+    csstype "^3.2.2"
+
 react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"


### PR DESCRIPTION
### What is this change?

Updating jsx runtime types to be compatible with React 18 & 19

### Why are we making this change?

`JSX.LibraryManagedAttributes` changed its definition in React 19 types and so now @compiled/react breaks inference and any render-prop callback parameters like { fieldProps, error } in <Field> falls back to any.

```
frontend/components/form/permissions/DropdownPermissions.tsx:54:54 - error TS7031: Binding element 'error' implicitly has an 'any' type.

54                     {({ fieldProps: { id, ...rest }, error }) => (
```

I have verified those changes publishing locally the package and using it against type check in affected code base


### How are we making this change?

(Optional.)

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
