### PR TITLE
fix: clearer error when object property key cannot be statically evaluated

### DIFF
--- a/.changeset/clearer-static-eval-error.md
+++ b/.changeset/clearer-static-eval-error.md
@@ -1,0 +1,32 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Improve the error message thrown when Compiled cannot statically evaluate an object property key.
+
+When an object property key references a value Compiled cannot resolve at build time (for example, a constant re-exported through a barrel file), the babel plugin now:
+
+- Prints the full source-level name of the expression (e.g. `theme.color.primary` or `theme["breakpoint-sm"]`) instead of the AST node type (`MemberExpression`).
+- Lists the most common causes (barrel files, `let`/`var` bindings, runtime values, unresolved module imports, TypeScript-only constructs) so the developer can self-diagnose without digging into Compiled internals.
+
+Also fixes a small bug where the previous message dropped the closing quote (`"...UNSAFE_container` instead of `"...UNSAFE_container"`).
+
+**Before**
+
+```
+Cannot statically evaluate the value of "MemberExpression
+```
+
+**After**
+
+```
+Cannot statically evaluate the value of "UNSAFE_container.below.xs" at build time.
+Compiled needs to know the value of object property keys at build time, but could not resolve "UNSAFE_container.below.xs". This commonly happens when:
+  - The value is re-exported through a barrel file (e.g. `export * from './foo'`). Try importing directly from the source module.
+  - The binding is declared with `let` or `var`, or is reassigned. Use `const` and avoid mutation.
+  - The value is produced at runtime (e.g. function calls, dynamic imports, values from `process.env`). Use a literal expression Compiled can read at build time.
+  - The value comes from a module Compiled cannot statically resolve. Check the import path and any custom resolver configuration.
+  - The expression relies on TypeScript-only constructs (e.g. `as const` widening) that Compiled does not yet evaluate.
+```
+
+Closes #1606.

--- a/packages/babel-plugin/src/utils/__tests__/object-property-to-string.test.ts
+++ b/packages/babel-plugin/src/utils/__tests__/object-property-to-string.test.ts
@@ -214,4 +214,69 @@ describe('objectPropertyToString', () => {
       }).toThrow();
     });
   });
+
+  describe('error messages when static evaluation fails', () => {
+    // When `evaluateExpression` cannot resolve the expression it returns the
+    // original node back, which is the signal `expressionToString` uses to
+    // throw. Returning the input identifier/member expression here simulates
+    // a failed static evaluation (e.g. a value imported through a barrel file).
+    const returnInputUnevaluated: typeof evaluateExpression = (expression, meta) => ({
+      value: expression as t.Expression,
+      meta,
+    });
+
+    it('includes the identifier name in the error so it can be located in source', () => {
+      evaluateExpressionMock.mockImplementation(returnInputUnevaluated);
+
+      expect(() => {
+        transform(`
+          import { UNSAFE_value } from './barrel';
+          const obj = { [UNSAFE_value]: "value" };
+        `);
+      }).toThrow(/Cannot statically evaluate the value of "UNSAFE_value" at build time\./);
+    });
+
+    it('reconstructs the dotted path for member expression keys instead of printing "MemberExpression"', () => {
+      evaluateExpressionMock.mockImplementation(returnInputUnevaluated);
+
+      expect(() => {
+        transform(`
+          import { UNSAFE_container } from './barrel';
+          const obj = { [UNSAFE_container.below.xs]: "value" };
+        `);
+      }).toThrow(
+        /Cannot statically evaluate the value of "UNSAFE_container\.below\.xs" at build time\./
+      );
+    });
+
+    it('renders computed string member access as bracket notation', () => {
+      evaluateExpressionMock.mockImplementation(returnInputUnevaluated);
+
+      expect(() => {
+        transform(`
+          import { theme } from './barrel';
+          const obj = { [theme['breakpoint-sm']]: "value" };
+        `);
+      }).toThrow(
+        /Cannot statically evaluate the value of "theme\["breakpoint-sm"\]" at build time\./
+      );
+    });
+
+    it('explains common causes (barrel files, mutation, runtime values) so the developer can self-diagnose', () => {
+      evaluateExpressionMock.mockImplementation(returnInputUnevaluated);
+
+      try {
+        transform(`
+          import { UNSAFE_value } from './barrel';
+          const obj = { [UNSAFE_value]: "value" };
+        `);
+        throw new Error('expected transform() to throw');
+      } catch (err) {
+        const message = (err as Error).message;
+        expect(message).toContain('barrel file');
+        expect(message).toContain('`let`');
+        expect(message).toContain('runtime');
+      }
+    });
+  });
 });

--- a/packages/babel-plugin/src/utils/object-property-to-string.ts
+++ b/packages/babel-plugin/src/utils/object-property-to-string.ts
@@ -128,6 +128,36 @@ const concatToString = (
   }, callee.object.value);
 };
 
+/**
+ * Returns a human-readable source-level name for an expression. Used in error
+ * messages so the developer sees the identifier they wrote (e.g.
+ * `theme.color.primary`) rather than an AST node type (`MemberExpression`).
+ */
+const expressionToReadableName = (expression: t.Expression | t.PrivateName): string => {
+  if (t.isIdentifier(expression)) {
+    return expression.name;
+  }
+  if (t.isPrivateName(expression)) {
+    return `#${expression.id.name}`;
+  }
+  if (t.isMemberExpression(expression)) {
+    const object = t.isExpression(expression.object)
+      ? expressionToReadableName(expression.object)
+      : expression.object.type;
+    if (expression.computed) {
+      if (t.isStringLiteral(expression.property) || t.isNumericLiteral(expression.property)) {
+        return `${object}[${JSON.stringify(expression.property.value)}]`;
+      }
+      return `${object}[…]`;
+    }
+    return `${object}.${expressionToReadableName(expression.property)}`;
+  }
+  if (t.isThisExpression(expression)) {
+    return 'this';
+  }
+  return expression.type;
+};
+
 export const expressionToString: ExpressionToString = (expression, meta) => {
   // handles {'key-name': 'value'} or {1: 'value'}
   if (t.isStringLiteral(expression) || t.isNumericLiteral(expression)) {
@@ -137,10 +167,15 @@ export const expressionToString: ExpressionToString = (expression, meta) => {
   if (t.isIdentifier(expression) || t.isMemberExpression(expression)) {
     const evaluatedExpression = evaluateExpression(expression, meta);
     if (evaluatedExpression.value === expression) {
+      const name = expressionToReadableName(expression);
       throw new Error(
-        `Cannot statically evaluate the value of "${
-          t.isIdentifier(expression) ? expression.name : expression.type
-        }`
+        `Cannot statically evaluate the value of "${name}" at build time.\n` +
+          `Compiled needs to know the value of object property keys at build time, but could not resolve "${name}". This commonly happens when:\n` +
+          `  - The value is re-exported through a barrel file (e.g. \`export * from './foo'\`). Try importing directly from the source module.\n` +
+          `  - The binding is declared with \`let\` or \`var\`, or is reassigned. Use \`const\` and avoid mutation.\n` +
+          `  - The value is produced at runtime (e.g. function calls, dynamic imports, values from \`process.env\`). Use a literal expression Compiled can read at build time.\n` +
+          `  - The value comes from a module Compiled cannot statically resolve. Check the import path and any custom resolver configuration.\n` +
+          `  - The expression relies on TypeScript-only constructs (e.g. \`as const\` widening) that Compiled does not yet evaluate.`
       );
     }
 


### PR DESCRIPTION
## What

Improves the error thrown by `@compiled/babel-plugin` when an object property key references a value it cannot statically evaluate (most often a value re-exported through a barrel file, as described in #1606).

## Why

Today the error reads:

```
Cannot statically evaluate the value of "MemberExpression
```

Two problems with that:

1. **It loses the closing quote**, so the message is visibly truncated.
2. **It prints the AST node type** (`MemberExpression`, `Identifier`, …) instead of the source-level name. For anything more complex than a bare identifier the developer has no way to know *which* expression Compiled choked on, let alone *why*.

The issue (#1606) asks for a more actionable message that names the expression and enumerates the common causes (barrel files, mutated bindings, runtime values, unresolved modules, TS-only constructs).

## How

In `packages/babel-plugin/src/utils/object-property-to-string.ts`:

- Added a small helper `expressionToReadableName` that reconstructs the source-level name of an expression — handling `Identifier`, `MemberExpression` (dotted and bracket), `PrivateName`, `ThisExpression`, falling back to the AST type for anything unhandled.
- Rewrote the thrown error to use that name, restore the missing closing quote, and list the most common causes a developer can act on without reading Compiled internals.

### Example

Before:

```
Cannot statically evaluate the value of "MemberExpression
```

After:

```
Cannot statically evaluate the value of "UNSAFE_container.below.xs" at build time.
Compiled needs to know the value of object property keys at build time, but could not resolve "UNSAFE_container.below.xs". This commonly happens when:
  - The value is re-exported through a barrel file (e.g. `export * from './foo'`). Try importing directly from the source module.
  - The binding is declared with `let` or `var`, or is reassigned. Use `const` and avoid mutation.
  - The value is produced at runtime (e.g. function calls, dynamic imports, values from `process.env`). Use a literal expression Compiled can read at build time.
  - The value comes from a module Compiled cannot statically resolve. Check the import path and any custom resolver configuration.
  - The expression relies on TypeScript-only constructs (e.g. `as const` widening) that Compiled does not yet evaluate.
```

## Tests

Added four cases to `packages/babel-plugin/src/utils/__tests__/object-property-to-string.test.ts`:

- the identifier name appears in the error,
- a dotted member-expression key is rendered as e.g. `UNSAFE_container.below.xs` instead of `MemberExpression`,
- a computed string key is rendered as `theme["breakpoint-sm"]`,
- the message mentions the common causes (barrel files, `let`, runtime).

Full `yarn jest packages/babel-plugin/` passes (620/620, 0 regressions), `yarn lint` and `yarn prettier --check` clean.

## Changeset

`patch` bump for `@compiled/babel-plugin` — no API change, just a clearer diagnostic.

Closes #1606