### PR TITLE
feat(codemods): handle Interpolation and CSSProperties when migrating from emotion

### DIFF
--- a/.changeset/emotion-codemod-unsupported-types.md
+++ b/.changeset/emotion-codemod-unsupported-types.md
@@ -1,0 +1,32 @@
+---
+'@compiled/codemods': minor
+---
+
+The `emotion-to-compiled` codemod now handles `Interpolation` and `CSSProperties` imports from `@emotion/core` / `@emotion/react`.
+
+Previously these type-only imports were silently left behind so the migrated file still pulled in `@emotion/*` (and so wouldn't compile cleanly without manual cleanup). The codemod now:
+
+- replaces every usage of the unsupported type with `any`,
+- adds a `TODO(@compiled/react codemod): …` block comment above the enclosing statement so the developer can pick a Compiled-compatible alternative,
+- removes the now-unused import specifier, and removes the emotion import entirely if no other specifiers remain.
+
+Closes #898.
+
+**Example**
+
+```ts
+// Before
+import { css, Interpolation } from '@emotion/core';
+
+const styles: Interpolation = css`
+  color: red;
+`;
+```
+
+```ts
+// After
+import { css } from '@compiled/react';
+
+/* TODO(@compiled/react codemod): Compiled does not provide an equivalent for "Interpolation" from "@emotion/core". This type has been replaced with `any` — replace it with a Compiled-compatible alternative when migrating. */
+const styles: any = `color: red`;
+```

--- a/packages/codemods/src/transforms/emotion-to-compiled/__tests__/transformer.test.ts
+++ b/packages/codemods/src/transforms/emotion-to-compiled/__tests__/transformer.test.ts
@@ -594,4 +594,62 @@ describe('emotion-to-compiled transformer', () => {
     "console.log('Bring back Netscape');\nimport { styled } from '@compiled/react';",
     'it should use the program visitor from the plugin'
   );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    { plugins: [] },
+    `
+    import { css, Interpolation } from '@emotion/core';
+
+    const styles: Interpolation = css\`color: red\`;
+    `,
+    `
+    import { css } from '@compiled/react';
+
+    /* TODO(@compiled/react codemod): Compiled does not provide an equivalent for "Interpolation" from "@emotion/core". This type has been replaced with \`any\` — replace it with a Compiled-compatible alternative when migrating. */
+    const styles: any = \`color: red\`;
+    `,
+    'it replaces Interpolation type usages with any when migrating @emotion/core'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    { plugins: [] },
+    `
+    import { CSSProperties } from '@emotion/react';
+
+    const sx: CSSProperties = { color: 'red' };
+    `,
+    `
+    /* TODO(@compiled/react codemod): Compiled does not provide an equivalent for "CSSProperties" from "@emotion/react". This type has been replaced with \`any\` — replace it with a Compiled-compatible alternative when migrating. */
+    const sx: any = { color: 'red' };
+    `,
+    'it removes the emotion import when only unsupported types were imported'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    { plugins: [] },
+    `
+    import { Interpolation as Int } from '@emotion/core';
+
+    const styles: Int = { color: 'red' };
+    `,
+    `
+    /* TODO(@compiled/react codemod): Compiled does not provide an equivalent for "Interpolation" from "@emotion/core". This type has been replaced with \`any\` — replace it with a Compiled-compatible alternative when migrating. */
+    const styles: any = { color: 'red' };
+    `,
+    'it follows the local alias when resolving the unsupported type name'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    { plugins: [] },
+    `
+    import { Interpolation } from '@emotion/core';
+    `,
+    `
+    `,
+    'it removes the emotion import when an unsupported type is imported but never used'
+  );
 });

--- a/packages/codemods/src/transforms/emotion-to-compiled/__tests__/transformer.test.ts
+++ b/packages/codemods/src/transforms/emotion-to-compiled/__tests__/transformer.test.ts
@@ -652,4 +652,50 @@ describe('emotion-to-compiled transformer', () => {
     `,
     'it removes the emotion import when an unsupported type is imported but never used'
   );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    { plugins: [] },
+    `
+    import { Interpolation } from '@emotion/core';
+    import { Interpolation as EmotionInterpolation } from '@emotion/core';
+
+    const a: Interpolation = {};
+    const b: EmotionInterpolation = {};
+    `,
+    `
+    /* TODO(@compiled/react codemod): Compiled does not provide an equivalent for "Interpolation" from "@emotion/core". This type has been replaced with \`any\` — replace it with a Compiled-compatible alternative when migrating. */
+    const a: any = {};
+    /* TODO(@compiled/react codemod): Compiled does not provide an equivalent for "Interpolation" from "@emotion/core". This type has been replaced with \`any\` — replace it with a Compiled-compatible alternative when migrating. */
+    const b: any = {};
+    `,
+    'it rewrites every alias when the same unsupported type is imported with multiple names'
+  );
+
+  defineInlineTest(
+    { default: transformer, parser: 'tsx' },
+    { plugins: [] },
+    `
+    import { Interpolation } from '@emotion/core';
+
+    function makeLocal() {
+      type Interpolation = string;
+      const value: Interpolation = 'ok';
+      return value;
+    }
+
+    const outer: Interpolation = {};
+    `,
+    `
+    function makeLocal() {
+      type Interpolation = string;
+      const value: Interpolation = 'ok';
+      return value;
+    }
+
+    /* TODO(@compiled/react codemod): Compiled does not provide an equivalent for "Interpolation" from "@emotion/core". This type has been replaced with \`any\` — replace it with a Compiled-compatible alternative when migrating. */
+    const outer: any = {};
+    `,
+    'it does not rewrite a locally shadowed type that happens to share the unsupported name'
+  );
 });

--- a/packages/codemods/src/transforms/emotion-to-compiled/index.ts
+++ b/packages/codemods/src/transforms/emotion-to-compiled/index.ts
@@ -1,10 +1,12 @@
 import { COMPILED_IMPORT } from '@compiled/utils';
 import type {
   API,
+  ASTPath,
   Collection,
   CommentBlock,
   CommentLine,
   FileInfo,
+  ImportDeclaration,
   ObjectPattern,
   Options,
   Program,
@@ -24,6 +26,15 @@ import {
 } from '../../utils';
 
 import { addReactIdentifier, findImportSpecifierName, mergeImportSpecifiers } from './utils';
+
+/**
+ * Type-only imports from `@emotion/core` / `@emotion/react` that Compiled does
+ * not provide an equivalent for. The codemod replaces their usages with `any`
+ * and leaves a TODO so the developer can manually pick a Compiled-friendly
+ * replacement instead of being stuck with a half-migrated file that still
+ * pulls in `@emotion/*`.
+ */
+const emotionUnsupportedTypeNames = ['Interpolation', 'CSSProperties'];
 
 const imports = {
   compiledStyledImportName: 'styled',
@@ -200,6 +211,82 @@ const handleClassNamesBehavior = (
     });
 };
 
+const replaceUnsupportedEmotionTypes = (
+  j: core.JSCodeshift,
+  collection: Collection,
+  importPath: string
+) => {
+  const importDeclarationCollection = getImportDeclarationCollection({
+    j,
+    collection,
+    importPath,
+  });
+
+  if (importDeclarationCollection.length === 0) {
+    return;
+  }
+
+  emotionUnsupportedTypeNames.forEach((emotionTypeName) => {
+    const localAlias = findImportSpecifierName({
+      j,
+      importDeclarationCollection,
+      importName: emotionTypeName,
+    });
+
+    if (localAlias == null) {
+      return;
+    }
+
+    collection
+      .find(j.TSTypeReference)
+      .filter((path) => {
+        const typeName = path.node.typeName;
+        return typeName.type === 'Identifier' && typeName.name === localAlias;
+      })
+      .forEach((path) => {
+        // Attach the TODO to the closest enclosing statement so it lands above
+        // the code that owns the type — not above some intermediate type node
+        // that has no comment slot of its own.
+        let stmtPath: ASTPath<any> = path;
+        while (stmtPath.parent && !j.Statement.check(stmtPath.parent.node)) {
+          stmtPath = stmtPath.parent;
+        }
+        if (stmtPath.parent) {
+          addCommentBefore({
+            j,
+            collection: j(stmtPath.parent.node) as Collection<Program>,
+            message: `Compiled does not provide an equivalent for "${emotionTypeName}" from "${importPath}". This type has been replaced with \`any\` — replace it with a Compiled-compatible alternative when migrating.`,
+          });
+        }
+        j(path).replaceWith(j.tsAnyKeyword());
+      });
+
+    // Drop the now-unused emotion type specifier so the developer ends up with
+    // either a smaller import or no emotion import at all.
+    importDeclarationCollection.forEach((importDeclPath: ASTPath<ImportDeclaration>) => {
+      const node = importDeclPath.node;
+      if (!node.specifiers) {
+        return;
+      }
+      node.specifiers = node.specifiers.filter(
+        (spec) =>
+          !(
+            spec.type === 'ImportSpecifier' &&
+            spec.imported.type === 'Identifier' &&
+            spec.imported.name === emotionTypeName
+          )
+      );
+    });
+  });
+
+  // If the emotion declaration is now empty, remove it entirely.
+  importDeclarationCollection.forEach((importDeclPath: ASTPath<ImportDeclaration>) => {
+    if (!importDeclPath.node.specifiers || importDeclPath.node.specifiers.length === 0) {
+      j(importDeclPath).remove();
+    }
+  });
+};
+
 const mergeCompiledImportSpecifiers = (j: core.JSCodeshift, collection: Collection) => {
   const allowedCompiledNames = [
     imports.compiledStyledImportName,
@@ -264,6 +351,7 @@ const transformer = (fileInfo: FileInfo, api: API, options: Options): string => 
   }
 
   if (hasEmotionCoreImportDeclaration) {
+    replaceUnsupportedEmotionTypes(j, collection, imports.emotionCorePackageName);
     replaceEmotionCoreCSSTaggedTemplateExpression(j, collection, imports.emotionCorePackageName);
     handleClassNamesBehavior(j, collection, imports.emotionCorePackageName);
     convertMixedImportToNamedImport({
@@ -277,6 +365,7 @@ const transformer = (fileInfo: FileInfo, api: API, options: Options): string => 
   }
 
   if (hasEmotionReactImportDeclaration) {
+    replaceUnsupportedEmotionTypes(j, collection, imports.emotionReactPackageName);
     replaceEmotionCoreCSSTaggedTemplateExpression(j, collection, imports.emotionReactPackageName);
     handleClassNamesBehavior(j, collection, imports.emotionReactPackageName);
     convertMixedImportToNamedImport({

--- a/packages/codemods/src/transforms/emotion-to-compiled/index.ts
+++ b/packages/codemods/src/transforms/emotion-to-compiled/index.ts
@@ -7,6 +7,7 @@ import type {
   CommentLine,
   FileInfo,
   ImportDeclaration,
+  ImportSpecifier,
   ObjectPattern,
   Options,
   Program,
@@ -211,6 +212,53 @@ const handleClassNamesBehavior = (
     });
 };
 
+/**
+ * Returns true if the given type reference is shadowed by a local TS type
+ * declaration in an enclosing function/block/module scope. Used to avoid
+ * rewriting a local `type Interpolation = string` just because the file also
+ * happens to import `Interpolation` from `@emotion/*`.
+ */
+const isTypeNameShadowedInScope = (
+  j: core.JSCodeshift,
+  refPath: ASTPath<any>,
+  typeName: string
+): boolean => {
+  let cursor: ASTPath<any> | null = refPath.parent;
+  while (cursor) {
+    const node = cursor.node;
+    // Pull the statement list of any lexical scope we recognise.
+    let body: unknown = null;
+    if (j.BlockStatement.check(node)) {
+      body = node.body;
+    } else if (
+      (j.FunctionDeclaration.check(node) ||
+        j.FunctionExpression.check(node) ||
+        j.ArrowFunctionExpression.check(node)) &&
+      j.BlockStatement.check(node.body)
+    ) {
+      body = node.body.body;
+    } else if (j.TSModuleDeclaration.check(node) && j.TSModuleBlock.check(node.body)) {
+      body = node.body.body;
+    }
+
+    if (Array.isArray(body)) {
+      for (const stmt of body) {
+        if (
+          (j.TSTypeAliasDeclaration.check(stmt) || j.TSInterfaceDeclaration.check(stmt)) &&
+          stmt.id &&
+          stmt.id.type === 'Identifier' &&
+          stmt.id.name === typeName
+        ) {
+          return true;
+        }
+      }
+    }
+
+    cursor = cursor.parent;
+  }
+  return false;
+};
+
 const replaceUnsupportedEmotionTypes = (
   j: core.JSCodeshift,
   collection: Collection,
@@ -227,55 +275,67 @@ const replaceUnsupportedEmotionTypes = (
   }
 
   emotionUnsupportedTypeNames.forEach((emotionTypeName) => {
-    const localAlias = findImportSpecifierName({
-      j,
-      importDeclarationCollection,
-      importName: emotionTypeName,
+    // Collect every import specifier for this unsupported emotion type. Users
+    // can legitimately import the same name in multiple declarations with
+    // different local aliases, e.g.
+    //
+    //   import { Interpolation } from '@emotion/core';
+    //   import { Interpolation as Int } from '@emotion/core';
+    //
+    // Both aliases need their references replaced, and only the matching
+    // specifiers should be removed afterwards.
+    const matchingSpecifiers: { path: ASTPath<ImportSpecifier>; localName: string }[] = [];
+    importDeclarationCollection.find(j.ImportSpecifier).forEach((specPath) => {
+      const spec = specPath.node;
+      if (
+        spec.imported.type === 'Identifier' &&
+        spec.imported.name === emotionTypeName &&
+        spec.local
+      ) {
+        matchingSpecifiers.push({ path: specPath, localName: spec.local.name });
+      }
     });
 
-    if (localAlias == null) {
+    if (matchingSpecifiers.length === 0) {
       return;
     }
 
-    collection
-      .find(j.TSTypeReference)
-      .filter((path) => {
-        const typeName = path.node.typeName;
-        return typeName.type === 'Identifier' && typeName.name === localAlias;
-      })
-      .forEach((path) => {
-        // Attach the TODO to the closest enclosing statement so it lands above
-        // the code that owns the type — not above some intermediate type node
-        // that has no comment slot of its own.
-        let stmtPath: ASTPath<any> = path;
-        while (stmtPath.parent && !j.Statement.check(stmtPath.parent.node)) {
-          stmtPath = stmtPath.parent;
-        }
-        if (stmtPath.parent) {
-          addCommentBefore({
-            j,
-            collection: j(stmtPath.parent.node) as Collection<Program>,
-            message: `Compiled does not provide an equivalent for "${emotionTypeName}" from "${importPath}". This type has been replaced with \`any\` — replace it with a Compiled-compatible alternative when migrating.`,
-          });
-        }
-        j(path).replaceWith(j.tsAnyKeyword());
-      });
+    matchingSpecifiers.forEach(({ localName }) => {
+      collection
+        .find(j.TSTypeReference)
+        .filter((path) => {
+          const typeName = path.node.typeName;
+          if (typeName.type !== 'Identifier' || typeName.name !== localName) {
+            return false;
+          }
+          // Don't rewrite references that resolve to a local `type` or
+          // `interface` with the same name — those aren't the emotion import.
+          return !isTypeNameShadowedInScope(j, path, localName);
+        })
+        .forEach((path) => {
+          // Attach the TODO to the closest enclosing statement so it lands above
+          // the code that owns the type — not above some intermediate type node
+          // that has no comment slot of its own.
+          let stmtPath: ASTPath<any> = path;
+          while (stmtPath.parent && !j.Statement.check(stmtPath.parent.node)) {
+            stmtPath = stmtPath.parent;
+          }
+          if (stmtPath.parent) {
+            addCommentBefore({
+              j,
+              collection: j(stmtPath.parent.node) as Collection<Program>,
+              message: `Compiled does not provide an equivalent for "${emotionTypeName}" from "${importPath}". This type has been replaced with \`any\` — replace it with a Compiled-compatible alternative when migrating.`,
+            });
+          }
+          j(path).replaceWith(j.tsAnyKeyword());
+        });
+    });
 
-    // Drop the now-unused emotion type specifier so the developer ends up with
-    // either a smaller import or no emotion import at all.
-    importDeclarationCollection.forEach((importDeclPath: ASTPath<ImportDeclaration>) => {
-      const node = importDeclPath.node;
-      if (!node.specifiers) {
-        return;
-      }
-      node.specifiers = node.specifiers.filter(
-        (spec) =>
-          !(
-            spec.type === 'ImportSpecifier' &&
-            spec.imported.type === 'Identifier' &&
-            spec.imported.name === emotionTypeName
-          )
-      );
+    // Drop only the specifiers we just rewrote — leave any other specifiers
+    // on the same declaration untouched. (`convertMixedImportToNamedImport`
+    // runs after this and handles re-homing the supported ones.)
+    matchingSpecifiers.forEach(({ path }) => {
+      j(path).remove();
     });
   });
 


### PR DESCRIPTION
## What

Extends the `emotion-to-compiled` codemod to handle `Interpolation` and `CSSProperties` — two type-only imports from `@emotion/core` / `@emotion/react` that Compiled doesn't provide an equivalent for.

Closes #898.

## Why

The codemod's "Gotchas" section already calls out that some emotion imports are unsupported and get silently left behind in the original `@emotion/*` import. For value imports like `CSSObject` that's fine — they need real, user-driven decisions. For type-only imports like `Interpolation` and `CSSProperties` it's a worse outcome: the migrated file still pulls in `@emotion/*` (just for one type) and the developer has to chase it down manually before the migration is complete.

#898 suggests annotating these with a `TODO` and shifting them to `any` so the file compiles cleanly after the codemod runs, and the developer can come back to pick a real replacement.

## How

In `packages/codemods/src/transforms/emotion-to-compiled/index.ts`:

- Added a constant `emotionUnsupportedTypeNames = ['Interpolation', 'CSSProperties']`.
- Added `replaceUnsupportedEmotionTypes(j, collection, importPath)` which, for each unsupported type:
    1. resolves the local alias from the import declaration (so `import { Interpolation as Int }` still works),
    2. finds every `TSTypeReference` whose `typeName` matches that local alias,
    3. replaces each match with `j.tsAnyKeyword()` and attaches a `TODO(@compiled/react codemod): …` block comment to the enclosing statement using the existing `addCommentBefore` helper,
    4. strips the specifier from the emotion import; removes the import entirely if no specifiers remain.
- Calls it before `convertMixedImportToNamedImport` for both `@emotion/core` and `@emotion/react` so the downstream import-rewriting steps see a clean set of specifiers.

## Examples

### Mixed value + unsupported type — emotion import shrinks instead of being left behind

```ts
// Before
import { css, Interpolation } from '@emotion/core';

const styles: Interpolation = css`color: red`;
```

```ts
// After
import { css } from '@compiled/react';

/* TODO(@compiled/react codemod): Compiled does not provide an equivalent for "Interpolation" from "@emotion/core". This type has been replaced with `any` — replace it with a Compiled-compatible alternative when migrating. */
const styles: any = `color: red`;
```

### Type-only emotion import — declaration removed entirely

```ts
// Before
import { CSSProperties } from '@emotion/react';

const sx: CSSProperties = { color: 'red' };
```

```ts
// After
/* TODO(@compiled/react codemod): Compiled does not provide an equivalent for "CSSProperties" from "@emotion/react". This type has been replaced with `any` — replace it with a Compiled-compatible alternative when migrating. */
const sx: any = { color: 'red' };
```

### Aliased import — local alias is followed

```ts
// Before
import { Interpolation as Int } from '@emotion/core';

const styles: Int = { color: 'red' };
```

```ts
// After
/* TODO(@compiled/react codemod): Compiled does not provide an equivalent for "Interpolation" from "@emotion/core". This type has been replaced with `any` — replace it with a Compiled-compatible alternative when migrating. */
const styles: any = { color: 'red' };
```

### Unused unsupported import — declaration dropped silently

```ts
// Before
import { Interpolation } from '@emotion/core';
```

```ts
// After
(empty)
```

## Tests

Four new `defineInlineTest` cases in `packages/codemods/src/transforms/emotion-to-compiled/__tests__/transformer.test.ts` cover the four shapes above.

- `yarn jest packages/codemods/` — 84/84 pass (0 regressions across both emotion-to-compiled and styled-components-to-compiled).
- `yarn build` — clean.
- `yarn prettier --check` — clean.

## Scope notes

- Only the named-import form is handled. Namespace imports (`import * as E from '@emotion/core'; const x: E.Interpolation = …`) are not addressed — they're rarer in real migrations and worth a separate change so the diff stays reviewable.
- `'Interpolation'` and `'CSSProperties'` are the two cases called out in the issue. Easy to extend the constant if more unsupported types come up.
- Changeset is `minor` for `@compiled/codemods` (new codemod behavior, no breaking change to existing migrations).

## Changeset

`.changeset/emotion-codemod-unsupported-types.md` — `minor` bump for `@compiled/codemods`.