### PR TITLE
feat(react): emit dev warning when ax() receives a non-string input

### DIFF
--- a/.changeset/ax-dev-warning-non-string-input.md
+++ b/.changeset/ax-dev-warning-non-string-input.md
@@ -1,0 +1,26 @@
+---
+'@compiled/react': patch
+---
+
+`ax()` now emits a development-only warning when it receives a non-string value (typically an object) instead of a precompiled className.
+
+The previous failure mode was a cryptic runtime crash — `classNames[0].includes is not a function` — that gave the developer no hint about where in their JSX the bad value was coming from. The most common cause is passing a raw style object to a `css` prop or a styled component without wrapping it with `css({...})` first, for example:
+
+```jsx
+// This makes a raw object flow into ax() at runtime.
+<MyComponent css={someCondition && { color: 'red' }} />
+```
+
+The warning now points at the actual problem and the fix:
+
+```
+@compiled/react/runtime - DEV WARNING
+
+ax() received an object (`{"color":"red"}`) at index 0.
+  Compiled expects precompiled className strings here. If you passed a raw style object to a `css` prop or styled component — for example `<MyComponent css={{ color: 'red' }} />` — wrap it with `css({...})` so Compiled can transform it at build time:
+      <MyComponent css={css({ color: 'red' })} />
+```
+
+The warning is dev-only and deduped per type, so production bundles pay no cost (the `process.env.NODE_ENV === 'development'` guard is tree-shaken) and development consoles aren't spammed on every render.
+
+Closes #1495.

--- a/packages/react/src/runtime/__tests__/ax.test.ts
+++ b/packages/react/src/runtime/__tests__/ax.test.ts
@@ -55,4 +55,82 @@ describe('ax', () => {
   ])('%s', (_, params, expected) => {
     expect(ax(params)).toEqual(expected);
   });
+
+  describe('dev warning for non-string inputs', () => {
+    type AxFn = (input: unknown[]) => string | undefined;
+
+    const originalNodeEnv = process.env.NODE_ENV;
+    let consoleErrorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
+      consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      process.env.NODE_ENV = originalNodeEnv;
+      consoleErrorSpy.mockRestore();
+    });
+
+    // ax() itself still throws once execution reaches the existing
+    // string-only code path. That is intentional — the dev warning fires
+    // first to give the developer actionable context, and the original
+    // runtime behavior is unchanged in production (where the warning is
+    // tree-shaken out entirely).
+    const callAxIgnoringThrow = (axImpl: AxFn, input: unknown[]) => {
+      try {
+        axImpl(input);
+      } catch {
+        // expected for invalid inputs
+      }
+    };
+
+    // Each test runs ax in its own module scope so the dev-warning dedup
+    // state (`hasWarned`) does not leak between tests.
+    const withFreshAx = (body: (axImpl: AxFn) => void) => {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const axImpl = require('../ax').default as AxFn;
+        body(axImpl);
+      });
+    };
+
+    it('warns when an object is passed where a className string is expected', () => {
+      withFreshAx((axImpl) => {
+        callAxIgnoringThrow(axImpl, [{ color: 'red' }]);
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      const message = consoleErrorSpy.mock.calls[0][0] as string;
+      expect(message).toContain('ax() received an object');
+      expect(message).toContain('css({...})');
+    });
+
+    it('does not warn for valid inputs (string, undefined, null, false, empty string)', () => {
+      withFreshAx((axImpl) => {
+        axImpl(['_aaaabbbb', '_aaaacccc', undefined, null, false, '']);
+      });
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    it('dedupes the warning so it does not spam on every render', () => {
+      withFreshAx((axImpl) => {
+        callAxIgnoringThrow(axImpl, [{ color: 'red' }]);
+        callAxIgnoringThrow(axImpl, [{ color: 'blue' }]);
+        callAxIgnoringThrow(axImpl, [{ color: 'green' }]);
+      });
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not warn in production builds', () => {
+      process.env.NODE_ENV = 'production';
+      withFreshAx((axImpl) => {
+        callAxIgnoringThrow(axImpl, [{ color: 'red' }]);
+      });
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -1,3 +1,5 @@
+import { analyzeAxInputInDev } from './dev-warnings.js';
+
 /**
  * This length includes the underscore,
  * e.g. `"_1s4A"` would be a valid atomic group hash.
@@ -25,6 +27,10 @@ const ATOMIC_GROUP_LENGTH = 5;
  * ```
  */
 export default function ax(classNames: (string | undefined | null | false)[]): string | undefined {
+  if (process.env.NODE_ENV === 'development') {
+    analyzeAxInputInDev(classNames);
+  }
+
   // Shortcut: nothing to do
   if (!classNames.length) {
     return;

--- a/packages/react/src/runtime/dev-warnings.ts
+++ b/packages/react/src/runtime/dev-warnings.ts
@@ -36,3 +36,58 @@ export const analyzeCssInDev = (sheet: string): void => {
 
   hasWarned[sheet] = true;
 };
+
+const previewValue = (value: unknown): string => {
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) {
+      return String(value);
+    }
+    return serialized.length > 60 ? `${serialized.slice(0, 57)}...` : serialized;
+  } catch {
+    return String(value);
+  }
+};
+
+/**
+ * Warn when `ax()` is given anything other than a precompiled class-name
+ * string (or one of its supported falsy placeholders).
+ *
+ * The most common cause is forgetting to wrap a raw style object with
+ * `css({...})` before passing it to a `css` prop or a styled component, which
+ * lets a plain `{ color: 'red' }` flow into `ax()` and produces a cryptic
+ * runtime crash (`classNames[0].includes is not a function`) instead of an
+ * actionable error.
+ *
+ * Dev-only — production callers do not pay any cost because the call site in
+ * `ax()` is gated behind `process.env.NODE_ENV === 'development'`, which
+ * bundlers DCE in production builds.
+ */
+export const analyzeAxInputInDev = (classNames: readonly unknown[]): void => {
+  for (let i = 0; i < classNames.length; i++) {
+    const value = classNames[i];
+    // The same falsy values `ax()` itself ignores.
+    if (value == null || value === false || value === '') {
+      continue;
+    }
+    if (typeof value === 'string') {
+      continue;
+    }
+
+    const key = `ax-input-${typeof value}`;
+    if (hasWarned[key]) {
+      return;
+    }
+    hasWarned[key] = true;
+
+    warn(
+      `ax() received ${
+        typeof value === 'object' ? 'an object' : `a ${typeof value}`
+      } (\`${previewValue(value)}\`) at index ${i}.
+  Compiled expects precompiled className strings here. If you passed a raw style object to a \`css\` prop or styled component — for example \`<MyComponent css={{ color: 'red' }} />\` — wrap it with \`css({...})\` so Compiled can transform it at build time:
+      <MyComponent css={css({ color: 'red' })} />`
+    );
+
+    return;
+  }
+};


### PR DESCRIPTION
## What

Adds a development-only check at the top of `ax()` that detects when the runtime is given anything other than the supported `string | undefined | null | false | ''` shape, and emits an actionable warning before the existing code path crashes.

Closes #1495.

## Why

The reproducer in #1495 — passing a raw style object directly to a `css` prop, e.g. `<MyComponent css={someParameter || styles}>` where `someParameter` is `{ color: 'yellow', fontSize: '50px' }` — surfaces today as a cryptic crash:

```
TypeError: classNames[0].includes is not a function
```

That error message doesn't name the bad value, doesn't say where in the JSX tree the value came from, and gives the developer no hint of the actual fix (wrap the object with `css({...})` so Compiled can transform it at build time). The reporter explicitly notes that ESLint can't catch this cross-file, so a runtime/build-time signal is the practical place to fix it.

This PR keeps the existing runtime behavior (the crash still happens) but emits a clear warning *first* so the developer has somewhere to start from:

```
@compiled/react/runtime - DEV WARNING

ax() received an object (`{"color":"red"}`) at index 0.
  Compiled expects precompiled className strings here. If you passed a raw style object to a `css` prop or styled component — for example `<MyComponent css={{ color: 'red' }} />` — wrap it with `css({...})` so Compiled can transform it at build time:
      <MyComponent css={css({ color: 'red' })} />
```

## How

In `packages/react/src/runtime/dev-warnings.ts`:

- Added `analyzeAxInputInDev(classNames)` that walks the input, ignores the supported falsy/string values, and warns via the existing `warn` helper for anything else. Deduped by `typeof value` so consoles don't get spammed on every render.
- Reused the existing `hasWarned` cache + the same Compiled ASCII-art banner as `analyzeCssInDev`.

In `packages/react/src/runtime/ax.ts`:

- Imported `analyzeAxInputInDev` and called it at the very top of `ax()`, gated behind `process.env.NODE_ENV === 'development'`. The gate matches the pattern already used by `analyzeCssInDev` in `style.tsx`, and lets the consumer's bundler tree-shake the entire check + import in production builds.

## Tests

Four new cases in `packages/react/src/runtime/__tests__/ax.test.ts`:

- warns when an object is passed where a className string is expected (and the message contains the actionable hint),
- does not warn for valid inputs (`'_abc'`, `undefined`, `null`, `false`, `''`),
- dedupes — calling `ax()` repeatedly with bad inputs of the same type only warns once,
- does not warn when `process.env.NODE_ENV === 'production'`.

Each test uses `jest.isolateModules` to give `ax` (and therefore the dev-warnings dedup state) a fresh module scope, so tests don't leak `hasWarned` state between each other.

- `yarn jest packages/react/` — 272/272 pass (0 regressions).
- `yarn build` — clean.
- `yarn prettier --check` / `yarn lint` — clean.

## Scope notes

- Only `ax` is checked; `ac` has a similar surface and could get the same treatment in a follow-up if you want, but kept this PR small to make review easier.
- The check fires for any non-string non-supported-falsy value (object, number, function, …) rather than just objects — same actionable hint helps in all of them.
- Changeset: `patch` for `@compiled/react`.