### PR TITLE
[SPIKE] dynamic hash increase

### DIFF
--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.ts
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.ts
@@ -23,7 +23,7 @@ describe('atomicify rules', () => {
       color: blue;
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._syazs13q2{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._syaz13q2{color:blue}"`);
   });
 
   it('should prepend atomic class when nesting selector is prepended', () => {
@@ -33,7 +33,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"[data-look='h100']._mi0gz1ule{display:block}"`);
+    expect(actual).toMatchInlineSnapshot(`"[data-look='h100']._mi0g1ule{display:block}"`);
   });
 
   it('should should atomicify multiple declarations', () => {
@@ -42,7 +42,7 @@ describe('atomicify rules', () => {
       font-size: 12px;
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._syazs13q2{color:blue}._1wyb11fwx{font-size:12px}"`);
+    expect(actual).toMatchInlineSnapshot(`"._syaz13q2{color:blue}._1wyb1fwx{font-size:12px}"`);
   });
 
   it('should autoprefix atomic rules', () => {
@@ -50,7 +50,7 @@ describe('atomicify rules', () => {
 
     const result = transform`user-select: none;`;
 
-    expect(result).toMatchInlineSnapshot(`"._uiztiglyw{-ms-user-select:none;user-select:none}"`);
+    expect(result).toMatchInlineSnapshot(`"._uiztglyw{-ms-user-select:none;user-select:none}"`);
   });
 
   it('should double up class selector when two nesting selectors are found', () => {
@@ -60,7 +60,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(result).toMatchInlineSnapshot(`"._if29f1ule._if29f1ule{display:block}"`);
+    expect(result).toMatchInlineSnapshot(`"._if291ule._if291ule{display:block}"`);
   });
 
   it('should autoprefix atomic rules with multiple selectors', () => {
@@ -73,7 +73,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"._180hqglyw:hover, ._1j5pxglyw:focus{-ms-user-select:none;user-select:none}"`
+      `"._180hglyw:hover, ._1j5pglyw:focus{-ms-user-select:none;user-select:none}"`
     );
   });
 
@@ -87,7 +87,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){._ufx4cglyw{-ms-user-select:none;user-select:none}}"`
+      `"@media (min-width: 30rem){._ufx4glyw{-ms-user-select:none;user-select:none}}"`
     );
   });
 
@@ -103,7 +103,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){._195xxglyw div{-ms-user-select:none;user-select:none}}"`
+      `"@media (min-width: 30rem){._195xglyw div{-ms-user-select:none;user-select:none}}"`
     );
   });
 
@@ -119,7 +119,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result1).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){._uf5ehglyw{-ms-user-select:none;user-select:none}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._uf5eglyw{-ms-user-select:none;user-select:none}}}"`
     );
 
     const result2 = transform`
@@ -132,7 +132,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result2).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){@font-face{font-family:Arial;src:url(arial.woff)}._uf5ehglyw{-ms-user-select:none;user-select:none}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){@font-face{font-family:Arial;src:url(arial.woff)}._uf5eglyw{-ms-user-select:none;user-select:none}}}"`
     );
   });
 
@@ -165,12 +165,12 @@ describe('atomicify rules', () => {
 
     expect(classes).toMatchInlineSnapshot(`
       [
-        "_1e0ca1ule",
-        "_y3gnw1h6o",
-        "_uf5ehglyw",
-        "_2a8pdglyw",
-        "_18i0uglyw",
-        "_9iqnhglyw",
+        "_1e0c1ule",
+        "_y3gn1h6o",
+        "_uf5eglyw",
+        "_2a8pglyw",
+        "_18i0glyw",
+        "_9iqnglyw",
       ]
     `);
   });
@@ -182,7 +182,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._13mlx13q2 div.primary{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._13ml13q2 div.primary{color:blue}"`);
   });
 
   it('should atomicify a nested multi selector rule', () => {
@@ -193,7 +193,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"._65g0r13q2 div, ._1tjqh13q2 span, ._thocb13q2 li{color:blue}"`
+      `"._65g013q2 div, ._1tjq13q2 span, ._thoc13q2 li{color:blue}"`
     );
   });
 
@@ -205,7 +205,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._30l3p13q2:hover, ._f8pjp13q2:focus{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._30l313q2:hover, ._f8pj13q2:focus{color:blue}"`);
   });
 
   it('should atomicify a nested tag rule', () => {
@@ -215,7 +215,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._65g0r13q2 div{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._65g013q2 div{color:blue}"`);
   });
 
   it('should generate the same class hash for semantically same but different rules', () => {
@@ -245,8 +245,8 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual.split('}').join('}\n')).toMatchInlineSnapshot(`
-      "._169rl1j6v._169rl1j6v > *{margin-bottom:1rem}
-      ._1wzb7idpf._1wzb7idpf > *:last-child{margin-bottom:0}
+      "._169r1j6v._169r1j6v > *{margin-bottom:1rem}
+      ._1wzbidpf._1wzbidpf > *:last-child{margin-bottom:0}
       "
     `);
   });
@@ -259,7 +259,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._ngwg81q9v:first-child ._ngwg81q9v{color:hotpink}"`);
+    expect(actual).toMatchInlineSnapshot(`"._ngwg1q9v:first-child ._ngwg1q9v{color:hotpink}"`);
   });
 
   it('should reference the atomic class with the nesting selector', () => {
@@ -269,7 +269,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._prp2d13q2 :first-child{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._prp213q2 :first-child{color:blue}"`);
   });
 
   it('should atomicify a double tag rule', () => {
@@ -279,7 +279,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._8gspk13q2 div span{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._8gsp13q2 div span{color:blue}"`);
   });
 
   it('should atomicify a double tag with pseudos rule', () => {
@@ -289,7 +289,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._f1kdm13q2 div:hover span:active{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._f1kd13q2 div:hover span:active{color:blue}"`);
   });
 
   it('should atomicify a nested tag pseudo rule', () => {
@@ -299,7 +299,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1tuig13q2 div:hover{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._1tui13q2 div:hover{color:blue}"`);
   });
 
   it('should skip comments', () => {
@@ -317,7 +317,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"._1tuig13q2 div:hover{color:blue}@media screen{._4347s5scu{color:red}}"`
+      `"._1tui13q2 div:hover{color:blue}@media screen{._43475scu{color:red}}"`
     );
   });
 
@@ -349,7 +349,7 @@ describe('atomicify rules', () => {
       }
     );
 
-    expect(result.css).toMatchInlineSnapshot(`"._73mn71fwx div div{font-size:12px}"`);
+    expect(result.css).toMatchInlineSnapshot(`"._73mn1fwx div div{font-size:12px}"`);
   });
 
   it('should atomicify at-rule styles', () => {
@@ -391,7 +391,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@container (width > 300px){._eq9835scu h2{color:red}}@when font-tech(color-COLRv1) and font-tech(variations){@font-face{font-family:test;src:url(test.woff2)}}@else font-tech(color-SVG){@font-face{font-family:test;src:url(test2.woff2)}}@else{@font-face{font-family:test;src:url(test3.woff2)}}@-moz-document url-prefix(){._qrala13q2{color:blue}}@layer state{._8tgmx6x50{background-color:brown}}@media (min-width: 30rem){._hi7ci1ule{display:block}._1l5zmgktf{font-size:20px}}@supports selector(h2 > p){._1ll7032ev{color:pink}}@starting-style{._p77hdbf54{color:green}}"`
+      `"@container (width > 300px){._eq985scu h2{color:red}}@when font-tech(color-COLRv1) and font-tech(variations){@font-face{font-family:test;src:url(test.woff2)}}@else font-tech(color-SVG){@font-face{font-family:test;src:url(test2.woff2)}}@else{@font-face{font-family:test;src:url(test3.woff2)}}@-moz-document url-prefix(){._qral13q2{color:blue}}@layer state{._8tgm6x50{background-color:brown}}@media (min-width: 30rem){._hi7c1ule{display:block}._1l5zgktf{font-size:20px}}@supports selector(h2 > p){._1ll732ev{color:pink}}@starting-style{._p77hbf54{color:green}}"`
     );
   });
 
@@ -405,7 +405,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){._1l9lq1ule{display:block}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._1l9l1ule{display:block}}}"`
     );
   });
 
@@ -419,7 +419,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){._1v9qq1ule div{display:block}}"`
+      `"@media (min-width: 30rem){._1v9q1ule div{display:block}}"`
     );
   });
 
@@ -435,7 +435,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){._1acs11ule div{display:block}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._1acs1ule div{display:block}}}"`
     );
   });
 
@@ -500,7 +500,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"._syazs1qpq{color:red!important}._1wyb1it0u{font-size:var(--font-size)!important}"`
+      `"._syaz1qpq{color:red!important}._1wybit0u{font-size:var(--font-size)!important}"`
     );
   });
 
@@ -510,9 +510,7 @@ describe('atomicify rules', () => {
       color: red;
     `;
 
-    expect(actual).toMatchInlineSnapshot(
-      `"._syazs1qpq{color:red!important}._syazs5scu{color:red}"`
-    );
+    expect(actual).toMatchInlineSnapshot(`"._syaz1qpq{color:red!important}._syaz5scu{color:red}"`);
   });
 
   it('should throw an error for unknown at-rules', () => {

--- a/packages/css/src/plugins/__tests__/atomicify-rules.test.ts
+++ b/packages/css/src/plugins/__tests__/atomicify-rules.test.ts
@@ -23,7 +23,7 @@ describe('atomicify rules', () => {
       color: blue;
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._syaz13q2{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._syazs13q2{color:blue}"`);
   });
 
   it('should prepend atomic class when nesting selector is prepended', () => {
@@ -33,7 +33,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"[data-look='h100']._mi0g1ule{display:block}"`);
+    expect(actual).toMatchInlineSnapshot(`"[data-look='h100']._mi0gz1ule{display:block}"`);
   });
 
   it('should should atomicify multiple declarations', () => {
@@ -42,7 +42,7 @@ describe('atomicify rules', () => {
       font-size: 12px;
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._syaz13q2{color:blue}._1wyb1fwx{font-size:12px}"`);
+    expect(actual).toMatchInlineSnapshot(`"._syazs13q2{color:blue}._1wyb11fwx{font-size:12px}"`);
   });
 
   it('should autoprefix atomic rules', () => {
@@ -50,7 +50,7 @@ describe('atomicify rules', () => {
 
     const result = transform`user-select: none;`;
 
-    expect(result).toMatchInlineSnapshot(`"._uiztglyw{-ms-user-select:none;user-select:none}"`);
+    expect(result).toMatchInlineSnapshot(`"._uiztiglyw{-ms-user-select:none;user-select:none}"`);
   });
 
   it('should double up class selector when two nesting selectors are found', () => {
@@ -60,7 +60,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(result).toMatchInlineSnapshot(`"._if291ule._if291ule{display:block}"`);
+    expect(result).toMatchInlineSnapshot(`"._if29f1ule._if29f1ule{display:block}"`);
   });
 
   it('should autoprefix atomic rules with multiple selectors', () => {
@@ -73,7 +73,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"._180hglyw:hover, ._1j5pglyw:focus{-ms-user-select:none;user-select:none}"`
+      `"._180hqglyw:hover, ._1j5pxglyw:focus{-ms-user-select:none;user-select:none}"`
     );
   });
 
@@ -87,7 +87,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){._ufx4glyw{-ms-user-select:none;user-select:none}}"`
+      `"@media (min-width: 30rem){._ufx4cglyw{-ms-user-select:none;user-select:none}}"`
     );
   });
 
@@ -103,7 +103,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){._195xglyw div{-ms-user-select:none;user-select:none}}"`
+      `"@media (min-width: 30rem){._195xxglyw div{-ms-user-select:none;user-select:none}}"`
     );
   });
 
@@ -119,7 +119,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result1).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){._uf5eglyw{-ms-user-select:none;user-select:none}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._uf5ehglyw{-ms-user-select:none;user-select:none}}}"`
     );
 
     const result2 = transform`
@@ -132,7 +132,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(result2).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){@font-face{font-family:Arial;src:url(arial.woff)}._uf5eglyw{-ms-user-select:none;user-select:none}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){@font-face{font-family:Arial;src:url(arial.woff)}._uf5ehglyw{-ms-user-select:none;user-select:none}}}"`
     );
   });
 
@@ -165,12 +165,12 @@ describe('atomicify rules', () => {
 
     expect(classes).toMatchInlineSnapshot(`
       [
-        "_1e0c1ule",
-        "_y3gn1h6o",
-        "_uf5eglyw",
-        "_2a8pglyw",
-        "_18i0glyw",
-        "_9iqnglyw",
+        "_1e0ca1ule",
+        "_y3gnw1h6o",
+        "_uf5ehglyw",
+        "_2a8pdglyw",
+        "_18i0uglyw",
+        "_9iqnhglyw",
       ]
     `);
   });
@@ -182,7 +182,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._13ml13q2 div.primary{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._13mlx13q2 div.primary{color:blue}"`);
   });
 
   it('should atomicify a nested multi selector rule', () => {
@@ -193,7 +193,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"._65g013q2 div, ._1tjq13q2 span, ._thoc13q2 li{color:blue}"`
+      `"._65g0r13q2 div, ._1tjqh13q2 span, ._thocb13q2 li{color:blue}"`
     );
   });
 
@@ -205,7 +205,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._30l313q2:hover, ._f8pj13q2:focus{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._30l3p13q2:hover, ._f8pjp13q2:focus{color:blue}"`);
   });
 
   it('should atomicify a nested tag rule', () => {
@@ -215,7 +215,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._65g013q2 div{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._65g0r13q2 div{color:blue}"`);
   });
 
   it('should generate the same class hash for semantically same but different rules', () => {
@@ -245,8 +245,8 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual.split('}').join('}\n')).toMatchInlineSnapshot(`
-      "._169r1j6v._169r1j6v > *{margin-bottom:1rem}
-      ._1wzbidpf._1wzbidpf > *:last-child{margin-bottom:0}
+      "._169rl1j6v._169rl1j6v > *{margin-bottom:1rem}
+      ._1wzb7idpf._1wzb7idpf > *:last-child{margin-bottom:0}
       "
     `);
   });
@@ -259,7 +259,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._ngwg1q9v:first-child ._ngwg1q9v{color:hotpink}"`);
+    expect(actual).toMatchInlineSnapshot(`"._ngwg81q9v:first-child ._ngwg81q9v{color:hotpink}"`);
   });
 
   it('should reference the atomic class with the nesting selector', () => {
@@ -269,7 +269,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._prp213q2 :first-child{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._prp2d13q2 :first-child{color:blue}"`);
   });
 
   it('should atomicify a double tag rule', () => {
@@ -279,7 +279,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._8gsp13q2 div span{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._8gspk13q2 div span{color:blue}"`);
   });
 
   it('should atomicify a double tag with pseudos rule', () => {
@@ -289,7 +289,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._f1kd13q2 div:hover span:active{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._f1kdm13q2 div:hover span:active{color:blue}"`);
   });
 
   it('should atomicify a nested tag pseudo rule', () => {
@@ -299,7 +299,7 @@ describe('atomicify rules', () => {
       }
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._1tui13q2 div:hover{color:blue}"`);
+    expect(actual).toMatchInlineSnapshot(`"._1tuig13q2 div:hover{color:blue}"`);
   });
 
   it('should skip comments', () => {
@@ -317,7 +317,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"._1tui13q2 div:hover{color:blue}@media screen{._43475scu{color:red}}"`
+      `"._1tuig13q2 div:hover{color:blue}@media screen{._4347s5scu{color:red}}"`
     );
   });
 
@@ -349,7 +349,7 @@ describe('atomicify rules', () => {
       }
     );
 
-    expect(result.css).toMatchInlineSnapshot(`"._73mn1fwx div div{font-size:12px}"`);
+    expect(result.css).toMatchInlineSnapshot(`"._73mn71fwx div div{font-size:12px}"`);
   });
 
   it('should atomicify at-rule styles', () => {
@@ -391,7 +391,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@container (width > 300px){._eq985scu h2{color:red}}@when font-tech(color-COLRv1) and font-tech(variations){@font-face{font-family:test;src:url(test.woff2)}}@else font-tech(color-SVG){@font-face{font-family:test;src:url(test2.woff2)}}@else{@font-face{font-family:test;src:url(test3.woff2)}}@-moz-document url-prefix(){._qral13q2{color:blue}}@layer state{._8tgm6x50{background-color:brown}}@media (min-width: 30rem){._hi7c1ule{display:block}._1l5zgktf{font-size:20px}}@supports selector(h2 > p){._1ll732ev{color:pink}}@starting-style{._p77hbf54{color:green}}"`
+      `"@container (width > 300px){._eq9835scu h2{color:red}}@when font-tech(color-COLRv1) and font-tech(variations){@font-face{font-family:test;src:url(test.woff2)}}@else font-tech(color-SVG){@font-face{font-family:test;src:url(test2.woff2)}}@else{@font-face{font-family:test;src:url(test3.woff2)}}@-moz-document url-prefix(){._qrala13q2{color:blue}}@layer state{._8tgmx6x50{background-color:brown}}@media (min-width: 30rem){._hi7ci1ule{display:block}._1l5zmgktf{font-size:20px}}@supports selector(h2 > p){._1ll7032ev{color:pink}}@starting-style{._p77hdbf54{color:green}}"`
     );
   });
 
@@ -405,7 +405,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){._1l9l1ule{display:block}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._1l9lq1ule{display:block}}}"`
     );
   });
 
@@ -419,7 +419,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){._1v9q1ule div{display:block}}"`
+      `"@media (min-width: 30rem){._1v9qq1ule div{display:block}}"`
     );
   });
 
@@ -435,7 +435,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"@media (min-width: 30rem){@media (min-width: 20rem){._1acs1ule div{display:block}}}"`
+      `"@media (min-width: 30rem){@media (min-width: 20rem){._1acs11ule div{display:block}}}"`
     );
   });
 
@@ -500,7 +500,7 @@ describe('atomicify rules', () => {
     `;
 
     expect(actual).toMatchInlineSnapshot(
-      `"._syaz1qpq{color:red!important}._1wybit0u{font-size:var(--font-size)!important}"`
+      `"._syazs1qpq{color:red!important}._1wyb1it0u{font-size:var(--font-size)!important}"`
     );
   });
 
@@ -510,7 +510,9 @@ describe('atomicify rules', () => {
       color: red;
     `;
 
-    expect(actual).toMatchInlineSnapshot(`"._syaz1qpq{color:red!important}._syaz5scu{color:red}"`);
+    expect(actual).toMatchInlineSnapshot(
+      `"._syazs1qpq{color:red!important}._syazs5scu{color:red}"`
+    );
   });
 
   it('should throw an error for unknown at-rules', () => {

--- a/packages/css/src/plugins/atomicify-rules.ts
+++ b/packages/css/src/plugins/atomicify-rules.ts
@@ -47,7 +47,7 @@ const isCssIdentifierValid = (value: string): boolean => {
  * correctly for atomic deduplication.
  */
 const collisionMap: Record<string, string> = {};
-const START_HASH_LEN = 5;
+const START_HASH_LEN = 4;
 const VALUE_HASH_LEN = 4;
 
 const atomicClassName = (node: Declaration, opts: PluginOpts) => {

--- a/packages/css/src/plugins/atomicify-rules.ts
+++ b/packages/css/src/plugins/atomicify-rules.ts
@@ -35,13 +35,41 @@ const isCssIdentifierValid = (value: string): boolean => {
  * @param node CSS declaration
  * @param opts AtomicifyOpts
  */
+/**
+ * Collision-resistant group hash:
+ * - Start with a group hash of {@link START_HASH_LEN} characters.
+ * - Track the (group → full input key) mapping in {@link collisionMap}.
+ * - If a different input produces the same group, grow the hash length for that
+ *   one class by one character and retry, until no collision exists.
+ *
+ * The runtime `ax()` function strips the value suffix by length (the last
+ * {@link VALUE_HASH_LEN} characters), so variable-length groups still work
+ * correctly for atomic deduplication.
+ */
+const collisionMap: Record<string, string> = {};
+const START_HASH_LEN = 5;
+const VALUE_HASH_LEN = 4;
+
 const atomicClassName = (node: Declaration, opts: PluginOpts) => {
   const selectors = opts.selectors ? opts.selectors.join('') : '';
   const prefix = opts.classHashPrefix ?? '';
-  const group = hash(`${prefix}${opts.atRule}${selectors}${node.prop}`).slice(0, 4);
+  const key = `${prefix}${opts.atRule}${selectors}${node.prop}`;
+  const fullGroupHash = hash(key);
+  let hashSize = START_HASH_LEN;
+  let group = fullGroupHash.slice(0, hashSize);
 
   const value = node.important ? node.value + node.important : node.value;
-  const valueHash = hash(value).slice(0, 4);
+  const valueHash = hash(value).slice(0, VALUE_HASH_LEN);
+
+  while (group in collisionMap) {
+    if (collisionMap[group] !== key) {
+      group = fullGroupHash.slice(0, ++hashSize);
+    } else {
+      break;
+    }
+  }
+
+  collisionMap[group] = key;
 
   return `_${group}${valueHash}`;
 };

--- a/packages/react/src/runtime/__tests__/ax.test.ts
+++ b/packages/react/src/runtime/__tests__/ax.test.ts
@@ -30,10 +30,52 @@ describe('ax', () => {
       ['_aaaabbbb _aaaacccc _aaaadddd _aaaaeeee'],
       '_aaaaeeee',
     ],
+    // ── tests for the 10-char default class name shape: `_` + 5 group + 4 value ──
     [
-      'should ensure the last atomic declaration of many multi groups with short class name wins',
+      'should dedup 10-char classes with the same 5-char group (single classes)',
+      ['_aaaaabbbb', '_aaaaacccc'],
+      '_aaaaacccc',
+    ],
+    [
+      'should dedup 10-char classes with the same 5-char group (multi class)',
+      ['_aaaaabbbb _aaaaacccc _aaaaadddd _aaaaaeeee'],
+      '_aaaaaeeee',
+    ],
+    [
+      'should keep 10-char classes from different 5-char groups',
+      ['_aaaaabbbb', '_bbbbbcccc'],
+      '_aaaaabbbb _bbbbbcccc',
+    ],
+    // ── tests for variable-length group (e.g. when the compiler grew the hash to resolve a collision) ──
+    [
+      'should dedup 11-char classes with the same 6-char extended group',
+      ['_aaaaa1bbbb', '_aaaaa1cccc'],
+      '_aaaaa1cccc',
+    ],
+    [
+      'should treat 10-char and 11-char classes as different groups (group length differs)',
+      ['_aaaaaxxxx', '_aaaaa1xxxx'],
+      '_aaaaaxxxx _aaaaa1xxxx',
+    ],
+    // ── tests for mixed legacy 9-char and current 10-char class names ──
+    [
+      'should treat a 9-char legacy class and a 10-char class as different groups',
+      ['_aaaabbbb', '_aaaaabbbb'],
+      '_aaaabbbb _aaaaabbbb',
+    ],
+    [
+      'should dedup 10-char classes even when 9-char classes share their value suffix',
+      ['_aaaaabbbb', '_aaaabbbb', '_aaaaacccc'],
+      '_aaaaacccc _aaaabbbb',
+    ],
+    [
+      // Under the dynamic group-length scheme, class names of different total length
+      // are treated as different groups (the group is everything except the last 4 chars).
+      // Here `_aaaaaaa` (8 chars) has group `_aaaa`, while `_aaaabbbb` (9 chars) has
+      // group `_aaaab` — they intentionally do not deduplicate.
+      'should treat classes of different total length as different groups',
       ['_aaaabbbb', '_aaaaaaa', '_ddddbbb', '_ddddcccc'],
-      '_aaaaaaa _ddddcccc',
+      '_aaaabbbb _aaaaaaa _ddddbbb _ddddcccc',
     ],
     [
       'should not remove any atomic declarations if there are no duplicate groups',

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -1,8 +1,14 @@
 /**
- * This length includes the underscore,
- * e.g. `"_1s4A"` would be a valid atomic group hash.
+ * Length of the value hash suffix at the end of every atomic class name.
+ *
+ * Each atomic class name has the shape `_<groupHash><valueHash>`, where the
+ * group hash is variable length (≥ 5 chars — grows dynamically when the
+ * compiler needs to resolve a collision) and the value hash is always exactly
+ * {@link ATOMIC_VALUE_HASH_LENGTH} chars. So we compute the group key by
+ * stripping this known fixed-size value suffix from the end, rather than
+ * slicing a fixed prefix from the start.
  */
-const ATOMIC_GROUP_LENGTH = 5;
+const ATOMIC_VALUE_HASH_LENGTH = 4;
 
 /**
  * Create a single string containing all the classnames provided, separated by a space (`" "`).
@@ -68,7 +74,9 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
        * - Okay to remove duplicates as doing so does not impact specificity
        *
        * */
-      const key = className.startsWith('_') ? className.slice(0, ATOMIC_GROUP_LENGTH) : className;
+      const key = className.startsWith('_')
+        ? className.slice(0, className.length - ATOMIC_VALUE_HASH_LENGTH)
+        : className;
       map[key] = className;
     }
   }


### PR DESCRIPTION
### What is this change?

Makes the atomic class group hash length in atomicify-rules adaptive instead of fixed at 4 characters: it starts at 5 chars and grows by one character per class only when the compiler detects a collision with an already-emitted class. The runtime ax() is updated to compute group keys by stripping the (still fixed) value-hash suffix, so variable-length groups work transparently.
Net result: class names grow from _GGGGVVVV (9 chars) to _GGGGGVVVV (10 chars), and group hash collisions are eliminated deterministically.

### Why are we making this change?

The current hash(...).slice(0, 4) produces a meaningful collision rate even in modestly-sized CSS bundles. When two different CSS axes (different selector + property combinations) end up with the same 4-char group hash, the runtime ax() function silently drops one of them — causing styles to disappear at runtime with no error.
We measured this on @atlaskit/editor-core's EditorContentContainer-compiled.compiled.css:

•  3,453 atomic rules in this single file
•  46+ harmful group collisions before this fix, across variants like tableSharedStyle, blockMarksStyles, mediaStyles, syncBlockStylesBase, etc.
•  Each collision = a CSS property silently dropped at runtime
The base-36 slice(0, 4) also has a leading-digit bias (the first character is '1' ~50% of the time, because every 7-character base-36 string starts with '1'), which further shrinks the effective hash space. The dynamic-length approach sidesteps the bias entirely and gives a deterministic guarantee rather than a statistical one.

### How are we making this change?

(Optional.)

---

### PR checklist

Don't delete me!

I have...

- [ x ] Updated or added applicable tests
- [ ] Updated the documentation in `website/`
- [ ] Added a changeset (if making any changes that affect Compiled's behaviour)
