### PR TITLE
[SPIKE] smart ax with dynamic length and prefix family matching

### DIFF
--- a/packages/react/src/runtime/__tests__/ax.test.ts
+++ b/packages/react/src/runtime/__tests__/ax.test.ts
@@ -51,9 +51,9 @@ describe('ax', () => {
         '_aaaaeeee',
       ],
       [
-        'should treat non-standard shorter atomic-looking class names consistently with suffix parsing',
+        'should treat non-standard shorter atomic-looking class names as independent groups',
         ['_aaaabbbb', '_aaaaaaa', '_ddddbbb', '_ddddcccc'],
-        '_aaaaaaa _ddddcccc',
+        '_aaaabbbb _aaaaaaa _ddddbbb _ddddcccc',
       ],
       [
         'should not remove any atomic declarations if there are no duplicate groups',
@@ -81,6 +81,11 @@ describe('ax', () => {
         'should keep variable-length classes with different groups',
         ['_aaaa12bbbb', '_bbbb12cccc'],
         '_aaaa12bbbb _bbbb12cccc',
+      ],
+      [
+        'should keep variable-length groups that share a legacy prefix but are not in the same prefix family',
+        ['_aabbcc1234', '_aabbdd1234'],
+        '_aabbcc1234 _aabbdd1234',
       ],
       [
         'should allow a longer group to override its shorter prefix family',

--- a/packages/react/src/runtime/__tests__/ax.test.ts
+++ b/packages/react/src/runtime/__tests__/ax.test.ts
@@ -53,7 +53,7 @@ describe('ax', () => {
       [
         'should treat non-standard shorter atomic-looking class names consistently with suffix parsing',
         ['_aaaabbbb', '_aaaaaaa', '_ddddbbb', '_ddddcccc'],
-        '_aaaabbbb _aaaaaaa _ddddcccc',
+        '_aaaaaaa _ddddcccc',
       ],
       [
         'should not remove any atomic declarations if there are no duplicate groups',
@@ -87,6 +87,16 @@ describe('ax', () => {
         ['_aaaabbbb', '_aaaa12cccc'],
         '_aaaa12cccc',
       ],
+      [
+        'should allow a shorter group to override its longer prefix family when order is flipped',
+        ['_aaaa12cccc', '_aaaabbbb'],
+        '_aaaabbbb',
+      ],
+      [
+        'should keep the most recent declaration when multiple prefix-family groups are provided',
+        ['_aaaabbbb', '_aaaa12cccc', '_aaaa1234dddd'],
+        '_aaaa1234dddd',
+      ],
     ])('%s', (_, params, expected) => {
       expect(ax(params)).toEqual(expected);
     });
@@ -103,6 +113,16 @@ describe('ax', () => {
         'should allow a variable-length longer group to override its legacy prefix family',
         ['_aaaabbbb', '_aaaa12cccc'],
         '_aaaa12cccc',
+      ],
+      [
+        'should allow a legacy group to override its variable-length prefix family when order is flipped',
+        ['_aaaa12cccc', '_aaaabbbb'],
+        '_aaaabbbb',
+      ],
+      [
+        'should keep the most recent declaration across legacy and multiple variable-length prefix-family groups',
+        ['_aaaabbbb', '_aaaa12cccc', '_aaaa1234dddd'],
+        '_aaaa1234dddd',
       ],
       [
         'should keep different variable-length families when no prefix relationship exists',

--- a/packages/react/src/runtime/__tests__/ax.test.ts
+++ b/packages/react/src/runtime/__tests__/ax.test.ts
@@ -3,56 +3,114 @@ import ax from '../ax';
 describe('ax', () => {
   const isEnabled: boolean = (() => false)();
 
-  it.each([
-    ['should handle empty array', [], undefined],
-    ['should handle array with undefined', [undefined], undefined],
-    ['should handle array with falsy values', [undefined, null, false as const, ''], undefined],
-    ['should join single classes together', ['foo', 'bar'], 'foo bar'],
-    ['should join multi classes together', ['foo baz', 'bar'], 'foo baz bar'],
-    ['should remove undefined', ['foo', 'bar', undefined], 'foo bar'],
-    [
-      'should ensure the last atomic declaration of a single group wins',
-      ['_aaaabbbb', '_aaaacccc'],
-      '_aaaacccc',
-    ],
-    [
-      'should ensure the last atomic declaration of many single groups wins',
-      ['_aaaabbbb', '_aaaacccc', '_aaaadddd', '_aaaaeeee'],
-      '_aaaaeeee',
-    ],
-    [
-      'should ensure the last atomic declaration of a multi group wins',
-      ['_aaaabbbb _aaaacccc'],
-      '_aaaacccc',
-    ],
-    [
-      'should ensure the last atomic declaration of many multi groups wins',
-      ['_aaaabbbb _aaaacccc _aaaadddd _aaaaeeee'],
-      '_aaaaeeee',
-    ],
-    [
-      'should ensure the last atomic declaration of many multi groups with short class name wins',
-      ['_aaaabbbb', '_aaaaaaa', '_ddddbbb', '_ddddcccc'],
-      '_aaaaaaa _ddddcccc',
-    ],
-    [
-      'should not remove any atomic declarations if there are no duplicate groups',
-      ['_aaaabbbb', '_bbbbcccc'],
-      '_aaaabbbb _bbbbcccc',
-    ],
-    ['should not apply conditional class', [isEnabled && 'foo', 'bar'], 'bar'],
-    [
-      'should ignore non atomic declarations',
-      ['hello_there', 'hello_world'],
-      'hello_there hello_world',
-    ],
-    [
-      'should ignore non atomic declarations when atomic declarations exist',
-      ['hello_there', 'hello_world', '_aaaabbbb'],
-      'hello_there hello_world _aaaabbbb',
-    ],
-    ['should remove duplicate custom class names', ['a', 'a'], 'a'],
-  ])('%s', (_, params, expected) => {
-    expect(ax(params)).toEqual(expected);
+  describe('general class merging', () => {
+    it.each([
+      ['should handle empty array', [], undefined],
+      ['should handle array with undefined', [undefined], undefined],
+      ['should handle array with falsy values', [undefined, null, false as const, ''], undefined],
+      ['should join single classes together', ['foo', 'bar'], 'foo bar'],
+      ['should join multi classes together', ['foo baz', 'bar'], 'foo baz bar'],
+      ['should remove undefined', ['foo', 'bar', undefined], 'foo bar'],
+      ['should not apply conditional class', [isEnabled && 'foo', 'bar'], 'bar'],
+      [
+        'should ignore non atomic declarations',
+        ['hello_there', 'hello_world'],
+        'hello_there hello_world',
+      ],
+      [
+        'should ignore non atomic declarations when atomic declarations exist',
+        ['hello_there', 'hello_world', '_aaaabbbb'],
+        'hello_there hello_world _aaaabbbb',
+      ],
+      ['should remove duplicate custom class names', ['a', 'a'], 'a'],
+    ])('%s', (_, params, expected) => {
+      expect(ax(params)).toEqual(expected);
+    });
+  });
+
+  describe('legacy atomic class format', () => {
+    it.each([
+      [
+        'should ensure the last atomic declaration of a single group wins',
+        ['_aaaabbbb', '_aaaacccc'],
+        '_aaaacccc',
+      ],
+      [
+        'should ensure the last atomic declaration of many single groups wins',
+        ['_aaaabbbb', '_aaaacccc', '_aaaadddd', '_aaaaeeee'],
+        '_aaaaeeee',
+      ],
+      [
+        'should ensure the last atomic declaration of a multi group wins',
+        ['_aaaabbbb _aaaacccc'],
+        '_aaaacccc',
+      ],
+      [
+        'should ensure the last atomic declaration of many multi groups wins',
+        ['_aaaabbbb _aaaacccc _aaaadddd _aaaaeeee'],
+        '_aaaaeeee',
+      ],
+      [
+        'should treat non-standard shorter atomic-looking class names consistently with suffix parsing',
+        ['_aaaabbbb', '_aaaaaaa', '_ddddbbb', '_ddddcccc'],
+        '_aaaabbbb _aaaaaaa _ddddcccc',
+      ],
+      [
+        'should not remove any atomic declarations if there are no duplicate groups',
+        ['_aaaabbbb', '_bbbbcccc'],
+        '_aaaabbbb _bbbbcccc',
+      ],
+    ])('%s', (_, params, expected) => {
+      expect(ax(params)).toEqual(expected);
+    });
+  });
+
+  describe('variable-length atomic group hash format', () => {
+    it.each([
+      [
+        'should dedup variable-length classes with the same group',
+        ['_aaaa12bbbb', '_aaaa12cccc'],
+        '_aaaa12cccc',
+      ],
+      [
+        'should dedup variable-length classes in a multi class string',
+        ['_aaaa12bbbb _aaaa12cccc'],
+        '_aaaa12cccc',
+      ],
+      [
+        'should keep variable-length classes with different groups',
+        ['_aaaa12bbbb', '_bbbb12cccc'],
+        '_aaaa12bbbb _bbbb12cccc',
+      ],
+      [
+        'should allow a longer group to override its shorter prefix family',
+        ['_aaaabbbb', '_aaaa12cccc'],
+        '_aaaa12cccc',
+      ],
+    ])('%s', (_, params, expected) => {
+      expect(ax(params)).toEqual(expected);
+    });
+  });
+
+  describe('mixed legacy and variable-length atomic class formats', () => {
+    it.each([
+      [
+        'should dedup legacy and variable-length classes when they share the same exact group',
+        ['_aaaabbbb', '_aaaacccc'],
+        '_aaaacccc',
+      ],
+      [
+        'should allow a variable-length longer group to override its legacy prefix family',
+        ['_aaaabbbb', '_aaaa12cccc'],
+        '_aaaa12cccc',
+      ],
+      [
+        'should keep different variable-length families when no prefix relationship exists',
+        ['_aaaabbbb', '_bbbb12cccc'],
+        '_aaaabbbb _bbbb12cccc',
+      ],
+    ])('%s', (_, params, expected) => {
+      expect(ax(params)).toEqual(expected);
+    });
   });
 });

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -7,6 +7,7 @@
  * the group key.
  */
 const ATOMIC_VALUE_HASH_LENGTH = 4;
+const ATOMIC_LEGACY_GROUP_LENGTH = 5;
 
 /**
  * Create a single string containing all the classnames provided, separated by a space (`" "`).
@@ -47,14 +48,94 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
   // Using an object rather than a `Map` as it performed better in our benchmarks.
   // Would be happy to move to `Map` if it proved to be better under real conditions.
   const map: Record<string, string> = {};
+  const activeGroupKeysByLegacyPrefix: Record<string, string[]> = {};
 
-  const removePrefixFamilyEntries = (key: string) => {
-    for (const existingKey in map) {
-      if (key.startsWith(existingKey) || existingKey.startsWith(key)) {
-        delete map[existingKey];
+  // Two group keys belong to the same prefix family when one fully contains the
+  // other from the start. This is how a longer variable-length group hash can
+  // override its legacy 4-character ancestor, and vice versa.
+  const isSameFamily = (a: string, b: string): boolean => a.startsWith(b) || b.startsWith(a);
+
+  /**
+   * Bucketed setter (default).
+   *
+   * Records the latest atomic class for a group key, replacing any previous
+   * class from the same prefix family.
+   *
+   * Atomic group keys can be either:
+   * - legacy: exactly 4 characters after the leading `_` (e.g. `_aaaa`)
+   * - variable-length: 4 or more characters (e.g. `_aaaa12`)
+   *
+   * To support both formats together, we bucket active group keys by their
+   * legacy 5-character prefix. Only keys in the same bucket can possibly be in
+   * the same prefix family, so we only need to scan a small array per insert
+   * instead of the full result map.
+   *
+   * For runtime performance, the bucket is mutated in place using swap-and-pop
+   * so we avoid allocating a fresh array on every insert.
+   */
+  const setAtomicClassInGroupMapBucketed = (groupKey: string, className: string) => {
+    // Find the bucket of group keys that share this legacy prefix.
+    const legacyPrefix = groupKey.slice(0, ATOMIC_LEGACY_GROUP_LENGTH);
+    const activeGroupKeys = activeGroupKeysByLegacyPrefix[legacyPrefix];
+
+    if (!activeGroupKeys) {
+      // First group key seen for this legacy prefix.
+      activeGroupKeysByLegacyPrefix[legacyPrefix] = [groupKey];
+      map[groupKey] = className;
+      return;
+    }
+
+    // Drop any keys in the same prefix family so the new key wins.
+    // Unrelated keys that just happen to share the legacy prefix are kept
+    // (e.g. `_aabbcc` and `_aabbdd` share `_aabb` but are not prefix-family
+    // related).
+    for (let i = activeGroupKeys.length - 1; i >= 0; i--) {
+      const existingGroupKey = activeGroupKeys[i];
+      if (isSameFamily(groupKey, existingGroupKey)) {
+        delete map[existingGroupKey];
+        // Swap-and-pop: O(1) removal that preserves the rest of the bucket.
+        activeGroupKeys[i] = activeGroupKeys[activeGroupKeys.length - 1];
+        activeGroupKeys.pop();
       }
     }
+
+    activeGroupKeys.push(groupKey);
+    map[groupKey] = className;
   };
+
+  /**
+   * Simple-scan setter (alternative).
+   *
+   * Same prefix-family semantics as the bucketed version, but implemented as a
+   * direct scan over the full result map. Easier to read, but per-insert cost
+   * grows with the total map size rather than the small same-prefix bucket.
+   *
+   * Useful for comparison benchmarks or as a fallback if the bucketed version
+   * ever needs to be disabled.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const setAtomicClassInGroupMapSimpleScan = (groupKey: string, className: string) => {
+    for (const existingGroupKey in map) {
+      if (existingGroupKey.startsWith('_') && isSameFamily(groupKey, existingGroupKey)) {
+        delete map[existingGroupKey];
+      }
+    }
+    map[groupKey] = className;
+  };
+
+  // Original map setter, doesn't support mix of legacy group key and longer group key
+  const setAtomicClassInGroupMapDefault = (groupKey: string, className: string) => {
+    map[groupKey] = className;
+  };
+
+  const mapStrategy = {
+    default: setAtomicClassInGroupMapDefault,
+    simple: setAtomicClassInGroupMapSimpleScan,
+    bucket: setAtomicClassInGroupMapBucketed,
+  };
+
+  // Switch implementation here to compare strategies.
+  const setAtomicClassInGroupMap = mapStrategy['bucket'];
 
   // Note: using loops to minimize iterations over the collection
   for (const value of classNames) {
@@ -86,10 +167,11 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
         : className;
 
       if (isAtomic) {
-        removePrefixFamilyEntries(key);
+        // map[key] = className;
+        setAtomicClassInGroupMap(key, className);
+      } else {
+        map[key] = className;
       }
-
-      map[key] = className;
     }
   }
 

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -50,7 +50,7 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
 
   const removePrefixFamilyEntries = (key: string) => {
     for (const existingKey in map) {
-      if (key.startsWith(existingKey)) {
+      if (key.startsWith(existingKey) || existingKey.startsWith(key)) {
         delete map[existingKey];
       }
     }

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -1,8 +1,12 @@
 /**
- * This length includes the underscore,
- * e.g. `"_1s4A"` would be a valid atomic group hash.
+ * Length of the value hash suffix at the end of every atomic class name.
+ *
+ * Atomic classes have the shape `_<groupHash><valueHash>`, where the value hash
+ * is always exactly {@link ATOMIC_VALUE_HASH_LENGTH} chars. This lets us support
+ * variable-length group hashes by treating everything before the value suffix as
+ * the group key.
  */
-const ATOMIC_GROUP_LENGTH = 5;
+const ATOMIC_VALUE_HASH_LENGTH = 4;
 
 /**
  * Create a single string containing all the classnames provided, separated by a space (`" "`).
@@ -44,6 +48,14 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
   // Would be happy to move to `Map` if it proved to be better under real conditions.
   const map: Record<string, string> = {};
 
+  const removePrefixFamilyEntries = (key: string) => {
+    for (const existingKey in map) {
+      if (key.startsWith(existingKey)) {
+        delete map[existingKey];
+      }
+    }
+  };
+
   // Note: using loops to minimize iterations over the collection
   for (const value of classNames) {
     // Exclude all falsy values, which leaves us with populated strings
@@ -68,7 +80,15 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
        * - Okay to remove duplicates as doing so does not impact specificity
        *
        * */
-      const key = className.startsWith('_') ? className.slice(0, ATOMIC_GROUP_LENGTH) : className;
+      const isAtomic = className.startsWith('_');
+      const key = isAtomic
+        ? className.slice(0, className.length - ATOMIC_VALUE_HASH_LENGTH)
+        : className;
+
+      if (isAtomic) {
+        removePrefixFamilyEntries(key);
+      }
+
       map[key] = className;
     }
   }


### PR DESCRIPTION
### What is this change?

Make `ax` supports longer classes like `_ggggggvvvv`, and can detect group hash is `gggggg`.
Support overrides legacy short classnames: `ax('_ggggvvvv', '_ggggttvvvv') => '_ggggttvvvv'`

### Why are we making this change?

The 4 char group hash is too short, cause class collision and drop styles silently. 

---

### PR checklist

Don't delete me!

I have...

- [ x ] Updated or added applicable tests
- [ ] Updated the documentation in `website/`
- [ ] Added a changeset (if making any changes that affect Compiled's behaviour)
