### PR TITLE
perf(xcss): XCSSPseudo to map TAllowedPseudos instead of CSSPseudos

### DIFF
--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -27,12 +27,23 @@ type XCSSPseudo<
   TRequiredProperties extends { requiredProperties: TAllowedProperties },
   TSchema
 > = {
-  [Q in CSSPseudos]?: Q extends TAllowedPseudos
-    ? MarkAsRequired<
-        XCSSValue<TAllowedProperties, TSchema, Q extends AllCSSPseudoClasses ? Q : ''>,
-        TRequiredProperties['requiredProperties']
-      >
-    : never;
+  // PERF FIX: Was `[Q in CSSPseudos]` which always generated all 67 CSS pseudo keys,
+  // marking ~62 of them as `never` when not in TAllowedPseudos. TypeScript had to
+  // instantiate 67 × ~300 = 20,100 type nodes for every xcss prop reference in every
+  // consumer file — even for StrictXCSSProp<XCSSAllProperties, never> (which should
+  // produce 0 pseudo keys). Confirmed by tsc --generateTrace in AFM.
+  //
+  // Fix: map over TAllowedPseudos directly. Now:
+  //   StrictXCSSProp<XCSSAllProperties, never>          → 0 pseudo keys  (was 67)
+  //   StrictXCSSProp<XCSSAllProperties, '&:hover'>      → 1 pseudo key   (was 67)
+  //   StrictXCSSProp<XCSSAllProperties, XCSSAllPseudos> → 67 keys        (unchanged)
+  //
+  // Impact in AFM: consumer file check time dropped from ×17.2 → ×4.0 baseline.
+  // See: platform/packages/ts-perf-bench/INVESTIGATION-REPORT.md
+  [Q in TAllowedPseudos]?: MarkAsRequired<
+    XCSSValue<TAllowedProperties, TSchema, Q extends AllCSSPseudoClasses ? Q : ''>,
+    TRequiredProperties['requiredProperties']
+  >;
 };
 
 type XCSSMediaQuery<


### PR DESCRIPTION
### What is this change?

`XCSSPseudo` was mapping `[Q in CSSPseudos]` (all 67 pseudo-selectors) and using a conditional `Q extends TAllowedPseudos ? ... : never` to filter. This always generated 67 type nodes regardless of how narrow TAllowedPseudos was — even `XCSSProp<XCSSAllProperties, never>` created 67 `never` keys.

This change maps directly over `TAllowedPseudos` instead, which:
- Generates 0 keys for `never`  (was 67)
- Generates N keys for a union of N pseudos  (was always 67)
- Generates 67 keys for `XCSSAllPseudos`  (unchanged)

### Why are we making this change?

In AFM `tsc --generateTrace` profiling that `BasePrimitiveProps` (containing `StrictXCSSProp<XCSSAllProperties, XCSSAllPseudos>`) was the source type in 4 of the 5 hottest `structuredTypeRelatedTo` events, each costing **~1,337ms per consumer file**. Every file importing `@atlaskit/primitives` (Box, Flex, Inline, Stack) paid this penalty.

**Results after fix:**
- Import-only check time:   3,923ms x13.7 -> 423ms x1.5  (-89%)
- Consumer file check time: 5,100ms x17.2 -> 1,152ms x4.0 (-77%)
- Types instantiated:       161,000 -> 56,000 (-65%)

---

### PR checklist

Don't delete me!

I have...

- [ ] Updated or added applicable tests
- [ ] Updated the documentation in `website/`
- [ ] Added a changeset (if making any changes that affect Compiled's behaviour)
