### PR TITLE
fix jsx-local-namespace type issue

### DIFF
--- a/.changeset/fix-library-managed-attributes-react18.md
+++ b/.changeset/fix-library-managed-attributes-react18.md
@@ -1,0 +1,15 @@
+---
+'@compiled/react': patch
+---
+
+Fix `LibraryManagedAttributes` to restore React 18 compatibility and `defaultProps` stripping.
+
+Commit `9a805f7` introduced two regressions:
+
+1. `key` no longer accepted `null`, contradicting `React.Attributes` which defines `key?: Key | null | undefined`. This caused `TS2322` errors in React 18 codebases when passing a nullable key (e.g. `key={item?.id ?? null}`).
+
+2. Using `P` directly instead of `React.JSX.LibraryManagedAttributes<C, P>` broke `defaultProps` stripping for class components — props covered by `defaultProps` were no longer treated as optional at the call site (`TS2740`).
+
+The fix delegates to `React.JSX.LibraryManagedAttributes<C, P>` (which correctly strips `defaultProps`) and explicitly restores `key?: React.Key | null` to align with `React.Attributes`. This avoids the circular reference issue since `React.JSX.LibraryManagedAttributes` does not route through the global `JSX` namespace.
+
+Also fixes the `typecheck:react18` test which used `toMatchTypeOf` (which does not catch type narrowing regressions) — replaced with `toEqualTypeOf` on `Managed['key']`.

--- a/.changeset/fix-library-managed-attributes-react18.md
+++ b/.changeset/fix-library-managed-attributes-react18.md
@@ -4,8 +4,6 @@
 
 Fix `LibraryManagedAttributes` to restore React 18 compatibility and `defaultProps` stripping.
 
-Commit `9a805f7` introduced two regressions:
-
 1. `key` no longer accepted `null`, contradicting `React.Attributes` which defines `key?: Key | null | undefined`. This caused `TS2322` errors in React 18 codebases when passing a nullable key (e.g. `key={item?.id ?? null}`).
 
 2. Using `P` directly instead of `React.JSX.LibraryManagedAttributes<C, P>` broke `defaultProps` stripping for class components — props covered by `defaultProps` were no longer treated as optional at the call site (`TS2740`).

--- a/packages/react/src/jsx/__tests__/jsx-local-namespace-types.test.tsx
+++ b/packages/react/src/jsx/__tests__/jsx-local-namespace-types.test.tsx
@@ -17,7 +17,7 @@ it('always includes an optional key prop', () => {
   type Props = { id: string };
   type Managed = ManagedProps<React.FC<Props>, Props>;
 
-  expectTypeOf<Managed>().toMatchTypeOf<{ key?: React.Key }>();
+  expectTypeOf<Managed['key']>().toEqualTypeOf<React.Key | null | undefined>();
 });
 
 it('adds css prop when className is declared', () => {

--- a/packages/react/src/jsx/__tests__/jsx-local-namespace-types.test.tsx
+++ b/packages/react/src/jsx/__tests__/jsx-local-namespace-types.test.tsx
@@ -189,3 +189,39 @@ it('correctly infers types for generic child components', () => {
   expectTypeOf<Managed>().toMatchTypeOf<{ items: { id: string }[] }>();
   expectTypeOf<Managed>().toMatchTypeOf<{ css?: unknown }>();
 });
+
+it('class components with defaultProps — props covered by defaultProps should be optional at call site', () => {
+  // Regression test for 9a805f7: using `P` directly instead of
+  // `React.JSX.LibraryManagedAttributes<C, P>` broke defaultProps stripping,
+  // causing TS2740 errors when class components with defaultProps were used
+  // without passing the defaulted props.
+  interface Props {
+    required: string;
+    withDefault: string;
+    className?: string;
+  }
+
+  class MyComponent extends React.Component<Props> {
+    static defaultProps = { withDefault: 'hello' };
+    render() {
+      return <div className={this.props.className}>{this.props.required}</div>;
+    }
+  }
+
+  type Managed = ManagedProps<typeof MyComponent, Props>;
+
+  // `withDefault` should be optional (covered by defaultProps)
+  expectTypeOf<Managed['withDefault']>().toEqualTypeOf<string | undefined>();
+
+  // `required` should stay required (no defaultProp)
+  expectTypeOf<Managed['required']>().toEqualTypeOf<string>();
+
+  // Should compile without error — `withDefault` is covered by defaultProps
+  const el = <MyComponent required="hello" />;
+  void el;
+
+  // key should still accept null
+  const nullableKey: React.Key | null = null;
+  const el2 = <MyComponent required="hello" key={nullableKey} />;
+  void el2;
+});

--- a/packages/react/src/jsx/jsx-local-namespace.ts
+++ b/packages/react/src/jsx/jsx-local-namespace.ts
@@ -83,7 +83,8 @@ export namespace CompiledJSX {
   // intersecting P with { key?: React.Key } directly. With a correct ElementAttributesProperty,
   // TypeScript pre-extracts the props type from class instances before passing P here.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  export type LibraryManagedAttributes<_C, P> = WithConditionalCSSProp<P> & P & { key?: React.Key };
+  export type LibraryManagedAttributes<C, P> = WithConditionalCSSProp<P> &
+    React.JSX.LibraryManagedAttributes<C, P> & { key?: React.Key | null };
   export type IntrinsicAttributes = ReactJSXIntrinsicAttributes;
   export type IntrinsicClassAttributes<T> = ReactJSXIntrinsicClassAttributes<T>;
   export type IntrinsicElements = {

--- a/packages/react/tsconfig.typecheck-react18.json
+++ b/packages/react/tsconfig.typecheck-react18.json
@@ -9,7 +9,7 @@
     "jsx": "react-jsx",
     "jsxImportSource": "@compiled/react",
     "typeRoots": ["../../node_modules/react18-types", "../../node_modules/@types"],
-    "types": ["jest", "node"],
+    "types": ["jest"],
     "paths": {
       "react": ["../../node_modules/react18-types"],
       "react/jsx-runtime": ["../../node_modules/react18-types/jsx-runtime"],

--- a/packages/react/tsconfig.typecheck-react19.json
+++ b/packages/react/tsconfig.typecheck-react19.json
@@ -9,7 +9,7 @@
     "jsx": "react-jsx",
     "jsxImportSource": "@compiled/react",
     "typeRoots": ["../../node_modules/react19-types", "../../node_modules/@types"],
-    "types": ["jest", "node"],
+    "types": ["jest"],
     "paths": {
       "react": ["../../node_modules/react19-types"],
       "react/jsx-runtime": ["../../node_modules/react19-types/jsx-runtime"],

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@compiled/benchmark": ["packages/benchmark/src/index.ts"],


### PR DESCRIPTION
### What is this change?

Fix `LibraryManagedAttributes` to restore React 18 compatibility and `defaultProps` stripping.

1. `key` no longer accepted `null`, contradicting `React.Attributes` which defines `key?: Key | null | undefined`. This caused `TS2322` errors in React 18 codebases when passing a nullable key (e.g. `key={item?.id ?? null}`).

2. Using `P` directly instead of `React.JSX.LibraryManagedAttributes<C, P>` broke `defaultProps` stripping for class components — props covered by `defaultProps` were no longer treated as optional at the call site (`TS2740`).

The fix delegates to `React.JSX.LibraryManagedAttributes<C, P>` (which correctly strips `defaultProps`) and explicitly restores `key?: React.Key | null` to align with `React.Attributes`. This avoids the circular reference issue since `React.JSX.LibraryManagedAttributes` does not route through the global `JSX` namespace.

Also fixes the `typecheck:react18` test which used `toMatchTypeOf` (which does not catch type narrowing regressions) — replaced with `toEqualTypeOf` on `Managed['key']`.

Verified typecheck tests via:
* `yarn workspace @compiled/react typecheck:react18`
* `yarn workspace @compiled/react typecheck:react19`

### Why are we making this change?

The regression in type `LibraryManagedAttributes` would cause type errors when consumers bump to ^0.21.1

Give the full context for your change here.

### How are we making this change?

(Optional.)

---

### PR checklist

Don't delete me!

I have...

- [/] Updated or added applicable tests
- [/] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
