### PR TITLE
perf(react): map XCSSValue over allowed properties only

### DIFF
--- a/.changeset/xcss-value-allowed-properties-perf.md
+++ b/.changeset/xcss-value-allowed-properties-perf.md
@@ -1,0 +1,20 @@
+---
+'@compiled/react': patch
+---
+
+Improve TypeScript type-checking performance of the `xcss` prop / strict API by mapping
+`XCSSValue` over only the allowed properties (via a key-remapping `as` clause) instead of
+mapping over all ~490 `StrictCSSProperties` and discarding the rest with `never`.
+
+`XCSSValue` is instantiated once for the base properties plus once per allowed pseudo and
+once per allowed media query, so the original all-properties map was a large, repeated cost
+at every `xcss` usage site. The new form keeps only the allowed keys, with an explicit
+blocking half (`{ [Q in Exclude...]?: never }`) so disallowed/excess properties remain type
+violations — type safety is unchanged.
+
+Impact (measured against Atlassian Design System `@atlaskit/css` + `@atlaskit/primitives`):
+narrow `xcss` declarations drop type instantiations substantially, and the wide
+`StrictXCSSProp<XCSSAllProperties, XCSSAllPseudos>` used by primitives like `Box` goes from
+producing a `TS2589` "type instantiation is excessively deep" error to type-checking
+cleanly, with a ~74% reduction in instantiated types and check time on that import path.
+Wide/all-property consumers see a negligible (<1%) change.

--- a/packages/react/src/xcss-prop/index.ts
+++ b/packages/react/src/xcss-prop/index.ts
@@ -9,16 +9,30 @@ import type {
   AllCSSPseudoClasses,
 } from '../types.js';
 
-type MarkAsRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+// `K` is intentionally `PropertyKey` (not `keyof T`) so this works with the key-remapped
+// `XCSSValue` whose `keyof` is a complex conditional union TypeScript can't cheaply prove a
+// required-property key belongs to. Required properties are always valid allowed properties,
+// so they resolve via the `P extends keyof T` branch; anything else resolves to `never`.
+type MarkAsRequired<T, K extends PropertyKey> = T & {
+  [P in K]-?: P extends keyof T ? T[P] : never;
+};
 
 type XCSSValue<
   TStyleDecl extends keyof CSSProperties,
   TSchema,
   TPseudoKey extends AllCSSPseudoClasses | ''
 > = {
-  [Q in keyof StrictCSSProperties]: Q extends TStyleDecl
-    ? ApplySchemaValue<TSchema, Q, TPseudoKey>
-    : never;
+  // Performance: use a key-remapping `as` clause to drop non-allowed properties from the
+  // key set entirely (rather than keeping ~490 keys with `never` values). This avoids
+  // instantiating a value for every property on every base/pseudo/media usage.
+  [Q in keyof StrictCSSProperties as Q extends TStyleDecl ? Q : never]: ApplySchemaValue<
+    TSchema,
+    Q,
+    TPseudoKey
+  >;
+} & {
+  // Correctness: keep blocking non-allowed properties so excess values remain violations.
+  [Q in keyof StrictCSSProperties as Q extends TStyleDecl ? never : Q]?: never;
 };
 
 type XCSSPseudo<


### PR DESCRIPTION
### What is this change?

Cuts type instantiations substantially for narrow `xcss`, and takes the wide `StrictXCSSProp<all, all>` path (e.g. primitives' Box) from a TS2589 'excessively deep' error to clean type-checking (**~74% fewer types on that import path measured against** `@atlaskit/css` + `@atlaskit/primitives`).

### Why are we making this change?

`XCSSValue` mapped over all **~490** `StrictCSSProperties` and discarded the rest with never, and is instantiated once per base + per allowed pseudo + per allowed media query. Switch to a key-remapping 'as' clause so only allowed properties are kept, with an explicit blocking half so disallowed/excess properties remain type violations (type safety unchanged).

### Benchmarks before/after 
<img width="1359" height="166" alt="image" src="https://github.com/user-attachments/assets/e217296e-2fdf-4a3e-a369-a0101c7109d4" />

---

### PR checklist

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
