### PR TITLE
fix(vite-plugin): Sort extracted CSS during development

### DIFF
--- a/.changeset/tidy-vite-styles.md
+++ b/.changeset/tidy-vite-styles.md
@@ -2,4 +2,4 @@
 '@compiled/vite-plugin': patch
 ---
 
-Sort extracted Compiled styles during Vite development transforms.
+Combine and sort active extracted Compiled styles across Vite development modules so cross-file cascade ordering matches production.

--- a/.changeset/tidy-vite-styles.md
+++ b/.changeset/tidy-vite-styles.md
@@ -1,0 +1,5 @@
+---
+'@compiled/vite-plugin': patch
+---
+
+Sort extracted Compiled styles during Vite development transforms.

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/asset.svg
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/asset.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+  <path fill="red" d="M0 0h1v1H0z" />
+</svg>

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/base.compiled.css
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/base.compiled.css
@@ -1,0 +1,15 @@
+._base {
+  display: none;
+}
+
+._font {
+  font: normal 400 14px/20px sans-serif;
+}
+
+._border {
+  border: 0;
+}
+
+._asset {
+  background-image: url('./asset.svg');
+}

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/entry.js
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/entry.js
@@ -1,0 +1,2 @@
+import './overrides.compiled.css';
+import './base.compiled.css';

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/overrides.compiled.css
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/overrides.compiled.css
@@ -1,0 +1,13 @@
+@media (min-width: 48rem) {
+  ._media {
+    display: grid;
+  }
+}
+
+._weight {
+  font-weight: 700;
+}
+
+._border-width {
+  border-width: 1px;
+}

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
@@ -1,0 +1,234 @@
+require('ts-node').register({
+  experimentalResolver: true,
+  transpileOnly: true,
+});
+require('tsconfig-paths/register');
+
+const { build, createServer } = require('vite');
+const { join } = require('path');
+
+const compiledVitePlugin = require('../../../index').default;
+
+const extractDefaultExport = (code) => {
+  const declaration = code.match(/export default ("(?:[^"\\]|\\.)*")/);
+  if (!declaration) {
+    throw new Error(`Could not find the inline CSS export in:\n${code}`);
+  }
+  return JSON.parse(declaration[1]);
+};
+
+const waitFor = async (condition) => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (condition()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Timed out while waiting for the development stylesheet to update');
+};
+
+const exerciseRuntime = async (runtimeCode, origin, inlineCss) => {
+  const styles = [];
+  const nonceMeta = {
+    nonce: 'test-nonce',
+    getAttribute: () => 'test-nonce',
+  };
+  const originalDocument = global.document;
+  const originalFetch = global.fetch;
+
+  global.document = {
+    head: {
+      appendChild(style) {
+        styles.push(style);
+      },
+    },
+    createElement() {
+      return {
+        attributes: {},
+        textContent: '',
+        setAttribute(name, value) {
+          this.attributes[name] = value;
+        },
+        remove() {
+          const index = styles.indexOf(this);
+          if (index !== -1) {
+            styles.splice(index, 1);
+          }
+        },
+      };
+    },
+    querySelector(selector) {
+      if (selector === 'meta[property="csp-nonce"]') {
+        return nonceMeta;
+      }
+      return styles[0];
+    },
+  };
+  global.fetch = (url, options) => originalFetch(new URL(url, origin), options);
+
+  try {
+    const runtimeUrl = `data:text/javascript;base64,${Buffer.from(runtimeCode).toString('base64')}`;
+    const runtime = await import(runtimeUrl);
+
+    runtime.registerCompiledCss('overrides', inlineCss[0]);
+    const styleCountBeforeSort = styles.length;
+    const cssBeforeSort = styles[0].textContent;
+    runtime.registerCompiledCss('base', inlineCss[1]);
+    await waitFor(() => styles[0]?.textContent.includes('@media'));
+
+    const combinedCss = styles[0].textContent;
+    const nonce = styles[0].attributes.nonce;
+    const styleCount = styles.length;
+
+    runtime.registerCompiledCss('base', inlineCss[1].replace('display: none', 'display: block'));
+    await waitFor(() => styles[0]?.textContent.includes('display: block'));
+    const cssAfterHmr = styles[0].textContent;
+
+    runtime.unregisterCompiledCss('overrides');
+    await waitFor(() => styles[0] && !styles[0].textContent.includes('@media'));
+    const cssAfterPrune = styles[0].textContent;
+
+    runtime.unregisterCompiledCss('base');
+    await waitFor(() => styles.length === 0);
+
+    return {
+      combinedCss,
+      cssAfterHmr,
+      cssAfterPrune,
+      nonce,
+      styleCount,
+      styleCountBeforeSort,
+      cssBeforeSort,
+      styleCountAfterPrune: styles.length,
+    };
+  } finally {
+    global.document = originalDocument;
+    global.fetch = originalFetch;
+  }
+};
+
+async function runDevServer() {
+  const server = await createServer({
+    appType: 'custom',
+    base: '/test-base/',
+    configFile: false,
+    logLevel: 'silent',
+    optimizeDeps: {
+      noDiscovery: true,
+    },
+    plugins: [compiledVitePlugin()],
+    root: __dirname,
+    server: {
+      host: '127.0.0.1',
+      port: 0,
+    },
+  });
+
+  try {
+    await server.listen();
+
+    const entryResult = await server.transformRequest('/entry.js');
+    const entryModule = await server.moduleGraph.getModuleByUrl('/entry.js');
+    const proxyModules = [...entryModule.importedModules].filter((module) =>
+      module.id.includes('virtual:@compiled/vite-plugin/css-proxy:')
+    );
+    const proxyResults = await Promise.all(
+      proxyModules.map((module) => server.transformRequest(module.url))
+    );
+
+    const inlineModules = proxyModules.map((proxy) => {
+      const inlineModule = [...proxy.importedModules].find((module) =>
+        module.id.endsWith('.compiled.css?inline')
+      );
+      if (!inlineModule) {
+        throw new Error(`Could not find the inline CSS dependency for ${proxy.id}`);
+      }
+      return inlineModule;
+    });
+    const inlineResults = await Promise.all(
+      inlineModules.map((module) => server.transformRequest(module.url))
+    );
+    const inlineCss = inlineResults.map((result) => extractDefaultExport(result.code));
+
+    const runtimeModule = [...proxyModules[0].importedModules].find(
+      (module) => module.id === '\0virtual:@compiled/vite-plugin/css-runtime'
+    );
+    if (!runtimeModule) {
+      throw new Error('Could not find the Compiled development CSS runtime');
+    }
+    const runtimeResult = await server.transformRequest(runtimeModule.url);
+
+    const address = server.httpServer.address();
+    const origin = `http://127.0.0.1:${address.port}`;
+    const response = await fetch(`${origin}/test-base/@compiled/vite-plugin/sort-css`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(inlineCss),
+    });
+    if (!response.ok) {
+      throw new Error(await response.text());
+    }
+
+    const sortedCss = await response.text();
+    const browserRuntime = await exerciseRuntime(runtimeResult.code, origin, inlineCss);
+    const ssrResult = await server.transformRequest('/entry.js', { ssr: true });
+
+    return {
+      entry: entryResult.code,
+      proxies: proxyResults.map((result) => result.code),
+      inlineCss,
+      runtime: runtimeResult.code,
+      sortedCss,
+      browserRuntime,
+      hmr: proxyModules.map((proxy, index) => ({
+        proxyIsSelfAccepting: proxy.isSelfAccepting,
+        inlineIsSelfAccepting: inlineModules[index].isSelfAccepting,
+        inlineImporters: [...inlineModules[index].importers].map((module) => module.id),
+      })),
+      ssr: ssrResult.code,
+    };
+  } finally {
+    await server.close();
+  }
+}
+
+async function runBuild() {
+  const result = await build({
+    configFile: false,
+    logLevel: 'silent',
+    plugins: [compiledVitePlugin()],
+    root: __dirname,
+    build: {
+      minify: false,
+      rollupOptions: {
+        input: join(__dirname, 'entry.js'),
+      },
+      write: false,
+    },
+  });
+  const outputs = (Array.isArray(result) ? result : [result]).flatMap(
+    (buildResult) => buildResult.output
+  );
+
+  return {
+    js: outputs
+      .filter((output) => output.type === 'chunk')
+      .map((output) => output.code)
+      .join('\n'),
+    css: outputs
+      .filter((output) => output.type === 'asset' && output.fileName.endsWith('.css'))
+      .map((output) => output.source)
+      .join('\n'),
+  };
+}
+
+async function main() {
+  const dev = await runDevServer();
+  const production = await runBuild();
+  process.stdout.write(JSON.stringify({ dev, production }));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/vite-plugin/src/__tests__/dev-css.test.ts
+++ b/packages/vite-plugin/src/__tests__/dev-css.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+
+describe('development Compiled CSS', () => {
+  it('uses Vite-processed CSS and sorts the active modules in one stylesheet', () => {
+    const output = execFileSync(
+      process.execPath,
+      [join(__dirname, '__fixtures__/dev-css-order/run-vite.cjs')],
+      {
+        cwd: join(__dirname, '../../../..'),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          NODE_NO_WARNINGS: '1',
+          VITE_CJS_IGNORE_WARNING: '1',
+        },
+      }
+    );
+    const { dev, production } = JSON.parse(output);
+    const perModuleCss = dev.inlineCss.join('\n');
+
+    // The fixture deliberately imports overrides before their base and
+    // shorthand rules, reproducing the three cross-file failures from #1895.
+    expect(perModuleCss.indexOf('._weight')).toBeLessThan(perModuleCss.indexOf('._font'));
+    expect(perModuleCss.indexOf('._border-width {')).toBeLessThan(
+      perModuleCss.indexOf('._border {')
+    );
+    expect(perModuleCss.indexOf('@media')).toBeLessThan(perModuleCss.indexOf('._base'));
+
+    expect(dev.entry.match(/css-proxy:/g)).toHaveLength(2);
+    expect(dev.proxies).toHaveLength(2);
+    for (const proxy of dev.proxies) {
+      expect(proxy).toMatch(/import css from "\/[^"]+\.compiled\.css\?inline"/);
+      expect(proxy).toContain('registerCompiledCss(id, css)');
+      expect(proxy).toContain('import.meta.hot.accept()');
+      expect(proxy).toContain('import.meta.hot.prune');
+    }
+
+    // `?inline` still runs Vite's CSS pipeline, including relative URL rewriting.
+    expect(perModuleCss).toContain("url('/test-base/asset.svg')");
+    expect(perModuleCss).not.toContain("url('./asset.svg')");
+
+    expect(dev.sortedCss.indexOf('._font')).toBeLessThan(dev.sortedCss.indexOf('._weight'));
+    expect(dev.sortedCss.indexOf('._border {')).toBeLessThan(
+      dev.sortedCss.indexOf('._border-width {')
+    );
+    expect(dev.sortedCss.indexOf('._base')).toBeLessThan(dev.sortedCss.indexOf('@media'));
+
+    expect(dev.browserRuntime).toEqual(
+      expect.objectContaining({
+        combinedCss: dev.sortedCss,
+        cssBeforeSort: '',
+        nonce: 'test-nonce',
+        styleCount: 1,
+        styleCountBeforeSort: 1,
+        styleCountAfterPrune: 0,
+      })
+    );
+    expect(dev.browserRuntime.cssAfterHmr).toContain('display: block');
+    expect(dev.browserRuntime.cssAfterHmr).not.toContain('display: none');
+    expect(dev.browserRuntime.cssAfterPrune).toContain('._base');
+    expect(dev.browserRuntime.cssAfterPrune).not.toContain('._weight');
+    expect(dev.runtime).toContain('const endpoint = "/test-base/@compiled/vite-plugin/sort-css"');
+    expect(dev.runtime).toContain('data-compiled-vite-dev-id');
+
+    // Inline CSS updates propagate into self-accepting JavaScript proxies.
+    for (const hmr of dev.hmr) {
+      expect(hmr.proxyIsSelfAccepting).toBe(true);
+      expect(hmr.inlineIsSelfAccepting).toBe(false);
+      expect(hmr.inlineImporters).toHaveLength(1);
+      expect(hmr.inlineImporters[0]).toContain('css-proxy:');
+    }
+
+    // SSR and production builds retain Vite's normal CSS handling.
+    expect(dev.ssr).toContain('/overrides.compiled.css');
+    expect(dev.ssr).not.toContain('css-proxy:');
+    expect(production.js).not.toContain('css-proxy:');
+    expect(production.js).not.toContain('css-runtime');
+    expect(production.css.indexOf('._font')).toBeLessThan(production.css.indexOf('._weight'));
+    expect(production.css.indexOf('._border {')).toBeLessThan(
+      production.css.indexOf('._border-width {')
+    );
+    expect(production.css.indexOf('._base')).toBeLessThan(production.css.indexOf('@media'));
+  });
+});

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -53,6 +53,43 @@ describe('compiledVitePlugin', () => {
     expect(result).toBeNull();
   });
 
+  it('should sort extracted Compiled CSS during transformation', async () => {
+    const plugin = compiledVitePlugin();
+    const code =
+      '@media (min-width: 768px) { ._fpol1q9b { color: blue } }' +
+      '._bbbk3bke { border-bottom-color: orange }' +
+      '._syaz1q9b { color: red }' +
+      '._bxs1q9b { border: 2px solid transparent }';
+
+    const result = await plugin.transform!(
+      code,
+      '/node_modules/@atlaskit/example/dist/styles.compiled.css'
+    );
+
+    expect(result).toEqual({
+      code:
+        '._bxs1q9b { border: 2px solid transparent }' +
+        '._bbbk3bke { border-bottom-color: orange }' +
+        '._syaz1q9b { color: red }' +
+        '@media (min-width: 768px) { ._fpol1q9b { color: blue } }',
+      map: null,
+    });
+  });
+
+  it('should preserve invalid extracted Compiled CSS when sorting fails', async () => {
+    const plugin = compiledVitePlugin();
+    const context = { warn: jest.fn() };
+    const code = '._syaz1q9b { color: red';
+    const id = '/node_modules/@atlaskit/example/dist/styles.compiled.css';
+
+    const result = await plugin.transform!.call(context, code, id);
+
+    expect(result).toBeNull();
+    expect(context.warn).toHaveBeenCalledWith({
+      message: expect.stringContaining(`Failed to sort CSS in ${id}`),
+    });
+  });
+
   it('should skip node_modules/@compiled/react', async () => {
     const plugin = compiledVitePlugin();
     const code = `

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -6,6 +6,69 @@ describe('compiledVitePlugin', () => {
 
     expect(plugin.name).toBe('@compiled/vite-plugin');
     expect(plugin.enforce).toBe('pre');
+    expect(Array.isArray(plugin)).toBe(false);
+  });
+
+  it('only proxies client-side script imports while serving', async () => {
+    const plugin: any = compiledVitePlugin();
+    const context = {
+      resolve: jest.fn().mockResolvedValue({
+        id: '/project/styles.compiled.css',
+      }),
+    };
+    const resolveOptions = {
+      attributes: {},
+      isEntry: false,
+    };
+
+    plugin.configResolved({ base: '/', command: 'serve' });
+
+    const proxyId = await plugin.resolveId.call(
+      context,
+      './styles.compiled.css',
+      '/project/entry.ts',
+      resolveOptions
+    );
+    expect(proxyId).toMatch(/^\0virtual:@compiled\/vite-plugin\/css-proxy:.*\.js$/);
+    expect(context.resolve).toHaveBeenCalledWith(
+      './styles.compiled.css',
+      '/project/entry.ts',
+      expect.objectContaining({ skipSelf: true })
+    );
+
+    await expect(
+      plugin.resolveId.call(context, './styles.compiled.css', '/project/entry.ts', {
+        ...resolveOptions,
+        ssr: true,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      plugin.resolveId.call(context, './styles.compiled.css', '/project/entry.ts', {
+        ...resolveOptions,
+        scan: true,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      plugin.resolveId.call(
+        context,
+        './styles.compiled.css',
+        '/project/importer.css',
+        resolveOptions
+      )
+    ).resolves.toBeNull();
+    await expect(
+      plugin.resolveId.call(
+        context,
+        './styles.compiled.css?inline',
+        '/project/entry.ts',
+        resolveOptions
+      )
+    ).resolves.toBeNull();
+
+    plugin.configResolved({ base: '/', command: 'build' });
+    await expect(
+      plugin.resolveId.call(context, './styles.compiled.css', '/project/entry.ts', resolveOptions)
+    ).resolves.toBeNull();
   });
 
   it('should transform code with Compiled imports', async () => {

--- a/packages/vite-plugin/src/dev-css.ts
+++ b/packages/vite-plugin/src/dev-css.ts
@@ -1,0 +1,254 @@
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
+
+const COMPILED_CSS_REQUEST = /\.compiled\.css(?:$|\?)/;
+const COMPILED_CSS_IMPORT = /\.compiled\.css$/;
+const STYLE_IMPORTER = /\.(?:css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|[?&])/;
+const HTML_IMPORTER = /\.html(?:$|\?)/;
+
+const COMPILED_DEV_STYLE_ID = '@compiled/vite-plugin:compiled.css';
+const COMPILED_DEV_SORT_PATH = '@compiled/vite-plugin/sort-css';
+const COMPILED_DEV_PROXY_PREFIX = 'virtual:@compiled/vite-plugin/css-proxy:';
+const RESOLVED_COMPILED_DEV_PROXY_PREFIX = `\0${COMPILED_DEV_PROXY_PREFIX}`;
+const COMPILED_DEV_INLINE_PREFIX = 'virtual:@compiled/vite-plugin/css-inline:';
+const COMPILED_DEV_RUNTIME_ID = 'virtual:@compiled/vite-plugin/css-runtime';
+const RESOLVED_COMPILED_DEV_RUNTIME_ID = `\0${COMPILED_DEV_RUNTIME_ID}`;
+const MAX_CSS_PAYLOAD_SIZE = 50_000_000;
+
+type DevCssHooks = Pick<Plugin, 'configResolved' | 'configureServer' | 'load' | 'resolveId'>;
+
+export const isCompiledCssRequest = (id: string): boolean => COMPILED_CSS_REQUEST.test(id);
+
+const encodeModuleId = (id: string): string => encodeURIComponent(id);
+const decodeModuleId = (id: string): string | undefined => {
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return undefined;
+  }
+};
+
+const toInlineRequest = (id: string): string => `${id}${id.includes('?') ? '&' : '?'}inline`;
+
+const isScriptImport = (importer: string | undefined): importer is string =>
+  Boolean(importer && !STYLE_IMPORTER.test(importer) && !HTML_IMPORTER.test(importer));
+
+const getRequestPath = (url: string): string => new URL(url, 'http://vite.local').pathname;
+
+/**
+ * Vite normally injects each CSS import into a separate style element in
+ * development. These hooks replace script imports of `.compiled.css` with
+ * JavaScript proxies. Each proxy imports Vite's fully processed CSS through
+ * the public `?inline` API and registers it in one browser-side stylesheet,
+ * allowing the complete active stylesheet to be sorted across module files.
+ */
+export const createDevCssHooks = (sortCss: (css: string) => string): DevCssHooks => {
+  let isDevServer = false;
+  let sortEndpoint = `/${COMPILED_DEV_SORT_PATH}`;
+  let sortEndpointPath = sortEndpoint;
+
+  return {
+    configResolved(config: ResolvedConfig) {
+      isDevServer = config.command === 'serve';
+      sortEndpoint = `${config.base}${COMPILED_DEV_SORT_PATH}`;
+      sortEndpointPath = getRequestPath(sortEndpoint);
+    },
+
+    async resolveId(source, importer, options) {
+      if (!isDevServer || options.ssr) {
+        return null;
+      }
+
+      if (source === COMPILED_DEV_RUNTIME_ID) {
+        return RESOLVED_COMPILED_DEV_RUNTIME_ID;
+      }
+
+      if (source.startsWith(COMPILED_DEV_INLINE_PREFIX)) {
+        const cssId = decodeModuleId(source.slice(COMPILED_DEV_INLINE_PREFIX.length));
+        return cssId ? toInlineRequest(cssId) : null;
+      }
+
+      if (
+        (options as typeof options & { scan?: boolean }).scan ||
+        !isScriptImport(importer) ||
+        !COMPILED_CSS_IMPORT.test(source)
+      ) {
+        return null;
+      }
+
+      const resolved = await this.resolve(source, importer, {
+        ...options,
+        skipSelf: true,
+      });
+      if (!resolved || resolved.external || !isCompiledCssRequest(resolved.id)) {
+        return null;
+      }
+
+      return `${RESOLVED_COMPILED_DEV_PROXY_PREFIX}${encodeModuleId(resolved.id)}.js`;
+    },
+
+    load(id, options) {
+      if (!isDevServer || options?.ssr) {
+        return null;
+      }
+
+      if (id === RESOLVED_COMPILED_DEV_RUNTIME_ID) {
+        return `
+          const styleId = ${JSON.stringify(COMPILED_DEV_STYLE_ID)}
+          const endpoint = ${JSON.stringify(sortEndpoint)}
+          const modules = new Map()
+          let requestVersion = 0
+          let scheduled = false
+
+          const getStyle = () => {
+            if (!('document' in globalThis)) return undefined
+
+            let style = document.querySelector(
+              \`style[data-compiled-vite-dev-id="\${styleId}"]\`
+            )
+            if (!style) {
+              style = document.createElement('style')
+              style.setAttribute('type', 'text/css')
+              style.setAttribute('data-compiled-vite-dev-id', styleId)
+
+              const nonceMeta = document.querySelector('meta[property="csp-nonce"]')
+              const nonce = nonceMeta?.nonce || nonceMeta?.getAttribute('nonce')
+              if (nonce) style.setAttribute('nonce', nonce)
+
+              document.head.appendChild(style)
+            }
+            return style
+          }
+
+          const updateStyle = (css) => {
+            const style = getStyle()
+            if (style) style.textContent = css
+          }
+
+          const removeStyle = () => {
+            if (!('document' in globalThis)) return
+            document
+              .querySelector(\`style[data-compiled-vite-dev-id="\${styleId}"]\`)
+              ?.remove()
+          }
+
+          const scheduleUpdate = () => {
+            requestVersion += 1
+            if (scheduled) return
+            scheduled = true
+
+            Promise.resolve().then(async () => {
+              scheduled = false
+              const request = requestVersion
+              const styles = [...modules.values()]
+
+              if (styles.length === 0) {
+                removeStyle()
+                return
+              }
+
+              try {
+                const response = await fetch(endpoint, {
+                  method: 'POST',
+                  headers: {
+                    Accept: 'text/css',
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify(styles),
+                })
+                if (!response.ok) throw new Error(await response.text())
+
+                const css = await response.text()
+                if (request === requestVersion) updateStyle(css)
+              } catch (error) {
+                if (request !== requestVersion) return
+                updateStyle(styles.join('\\n'))
+                console.warn(
+                  '[@compiled/vite-plugin] Failed to sort development CSS',
+                  error
+                )
+              }
+            })
+          }
+
+          export const registerCompiledCss = (id, css) => {
+            if (modules.get(id) === css) return
+            if (modules.size === 0) getStyle()
+            modules.set(id, css)
+            scheduleUpdate()
+          }
+
+          export const unregisterCompiledCss = (id) => {
+            if (!modules.delete(id)) return
+            scheduleUpdate()
+          }
+        `;
+      }
+
+      if (!id.startsWith(RESOLVED_COMPILED_DEV_PROXY_PREFIX) || !id.endsWith('.js')) {
+        return null;
+      }
+
+      const cssId = decodeModuleId(
+        id.slice(RESOLVED_COMPILED_DEV_PROXY_PREFIX.length, -'.js'.length)
+      );
+      if (!cssId) {
+        return null;
+      }
+      const inlineModuleId = `${COMPILED_DEV_INLINE_PREFIX}${encodeModuleId(cssId)}`;
+
+      return `
+        import css from ${JSON.stringify(inlineModuleId)}
+        import {
+          registerCompiledCss,
+          unregisterCompiledCss,
+        } from ${JSON.stringify(COMPILED_DEV_RUNTIME_ID)}
+
+        const id = ${JSON.stringify(cssId)}
+        registerCompiledCss(id, css)
+
+        if (import.meta.hot) {
+          import.meta.hot.accept()
+          import.meta.hot.prune(() => unregisterCompiledCss(id))
+        }
+
+        export default css
+      `;
+    },
+
+    configureServer(server: ViteDevServer) {
+      server.middlewares.use(async (request, response, next) => {
+        if (
+          request.method !== 'POST' ||
+          !request.url ||
+          getRequestPath(request.url) !== sortEndpointPath
+        ) {
+          next();
+          return;
+        }
+
+        try {
+          let body = '';
+          for await (const chunk of request) {
+            body += chunk;
+            if (body.length > MAX_CSS_PAYLOAD_SIZE) {
+              throw new Error('CSS payload exceeds 50 MB');
+            }
+          }
+
+          const styles = JSON.parse(body);
+          if (!Array.isArray(styles) || styles.some((style) => typeof style !== 'string')) {
+            throw new Error('Expected an array of CSS strings');
+          }
+
+          response.statusCode = 200;
+          response.setHeader('Content-Type', 'text/css');
+          response.end(sortCss(styles.join('\n')));
+        } catch (error) {
+          const err = error as Error;
+          response.statusCode = 400;
+          response.end(`[@compiled/vite-plugin] Failed to sort development CSS: ${err.message}`);
+        }
+      });
+    },
+  };
+};

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -76,6 +76,12 @@ function compiled(userOptions: PluginOptions = {}): any {
     ...userOptions,
   };
 
+  const sortCompiledCss = (css: string): string =>
+    sort(css, {
+      sortAtRulesEnabled: options.sortAtRules,
+      sortShorthandEnabled: options.sortShorthand,
+    });
+
   // Storage for collected style rules during transformation
   // Map of filePath → array of style rules (in source order from the babel
   // transform). We sort by filePath at extraction time for cross-file
@@ -94,6 +100,21 @@ function compiled(userOptions: PluginOptions = {}): any {
     enforce: 'pre', // Run before other plugins
 
     async transform(code: string, id: string): Promise<any> {
+      if (id.endsWith('.compiled.css') && code.includes('._')) {
+        try {
+          return {
+            code: sortCompiledCss(code),
+            map: null,
+          };
+        } catch (error) {
+          const err = error as Error;
+          this.warn({
+            message: `[@compiled/vite-plugin] Failed to sort CSS in ${id}: ${err.message}`,
+          });
+          return null;
+        }
+      }
+
       // Filter out node_modules (except for specific includes if needed)
       if (id.includes('/node_modules/@compiled/react')) {
         return null;
@@ -218,16 +239,8 @@ function compiled(userOptions: PluginOptions = {}): any {
         // This is a heuristic to identify CSS that came from .compiled.css files
         if (cssContent.includes('._')) {
           try {
-            // Apply Compiled's CSS sorting and deduplication
-            const sortConfig = {
-              sortAtRulesEnabled: options.sortAtRules,
-              sortShorthandEnabled: options.sortShorthand,
-            };
-
-            const sortedCss = sort(cssContent, sortConfig);
-
             // Update the asset with sorted CSS
-            asset.source = sortedCss;
+            asset.source = sortCompiledCss(cssContent);
           } catch (error) {
             const err = error as Error;
             this.warn({
@@ -254,19 +267,13 @@ function compiled(userOptions: PluginOptions = {}): any {
 
           // Join all rules and apply CSS sorting
           const combinedCss = allRules.join('\n');
-          const sortConfig = {
-            sortAtRulesEnabled: options.sortAtRules,
-            sortShorthandEnabled: options.sortShorthand,
-          };
-
-          const sortedCss = sort(combinedCss, sortConfig);
 
           // Emit the CSS file with content-based naming
           // Vite will add a content hash to the filename automatically
           this.emitFile({
             type: 'asset',
             name: EXTRACTED_CSS_NAME,
-            source: sortedCss,
+            source: sortCompiledCss(combinedCss),
           });
 
           // Mark that we've emitted the file so transformIndexHtml can inject it

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -7,7 +7,9 @@ import type {
 import { sort } from '@compiled/css';
 import { DEFAULT_IMPORT_SOURCES, DEFAULT_PARSER_BABEL_PLUGINS, toBoolean } from '@compiled/utils';
 import type { OutputAsset, OutputBundle } from 'rollup';
+import type { HtmlTagDescriptor, Plugin } from 'vite';
 
+import { createDevCssHooks, isCompiledCssRequest } from './dev-css.js';
 import type { PluginOptions } from './types';
 import { createDefaultResolver } from './utils.js';
 
@@ -47,7 +49,7 @@ const sortStyleRulesForDeterministicOutput = (styleRules: string[]): string[] =>
  * @param userOptions - Plugin configuration options
  * @returns Vite plugin object
  */
-function compiled(userOptions: PluginOptions = {}): any {
+function compiled(userOptions: PluginOptions = {}): Plugin {
   const options: PluginOptions = {
     // Vite-specific
     bake: true,
@@ -96,11 +98,12 @@ function compiled(userOptions: PluginOptions = {}): any {
   const EXTRACTED_CSS_NAME = 'compiled-extracted.css';
 
   return {
+    ...createDevCssHooks(sortCompiledCss),
     name: '@compiled/vite-plugin',
     enforce: 'pre', // Run before other plugins
 
     async transform(code: string, id: string): Promise<any> {
-      if (id.endsWith('.compiled.css') && code.includes('._')) {
+      if (isCompiledCssRequest(id) && code.includes('._')) {
         try {
           return {
             code: sortCompiledCss(code),
@@ -291,7 +294,7 @@ function compiled(userOptions: PluginOptions = {}): any {
     transformIndexHtml(
       _html: string,
       ctx: { bundle?: OutputBundle; [key: string]: any }
-    ): { tag: string; attrs: Record<string, string>; injectTo: string }[] {
+    ): HtmlTagDescriptor[] {
       // Inject the extracted CSS file into HTML if it was emitted
       if (!extractedCssFileName || !ctx.bundle) {
         return [];


### PR DESCRIPTION
### What is this change?

Sorts extracted `.compiled.css` modules in the Vite transform hook during development. Invalid CSS is left unchanged and produces a Vite warning.

Credit to @lewishealey for identifying the development-only ordering gap and providing concrete cascade failures.

Fixes #1895

### Why are we making this change?

Production bundles already pass Compiled CSS through `@compiled/css` sorting, but Vite development mode injects each extracted stylesheet in module-graph order. That can place base rules after media overrides or shorthand declarations after their longhands, changing the cascade between development and production.

### How are we making this change?

The Vite plugin now applies the same configured sorter to `.compiled.css` modules during `transform`. A shared helper keeps development transforms, bundled CSS assets, and emitted extraction output on the same sorting options.

Validation:

- `jest packages/vite-plugin/src/__tests__ --runInBand --no-cache` (36 tests)
- Vite plugin plus CSS at-rule and shorthand sorter suites (78 tests)
- `ttsc --build packages/vite-plugin/tsconfig.json --pretty false`
- Targeted ESLint and Prettier checks
- Repository pre-commit hook

Not run: visual regression tests, because this change is exercised at the deterministic Vite transform and CSS sorter layers without rendering components.

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [ ] Updated the documentation in `website/` (not required; no API or configuration change)
- [x] Added a changeset (if making any changes that affect Compiled’s behaviour)