### PR TITLE
feat(react): make ax() forward-compatible with longer atomic class names

### DIFF
--- a/.changeset/ax-length-based-group-key.md
+++ b/.changeset/ax-length-based-group-key.md
@@ -1,0 +1,13 @@
+---
+'@compiled/react': minor
+---
+
+Update the `ax()` runtime to extract the atomic group key using length-based slicing
+(`className.length - 4`) instead of a hardcoded offset.
+
+This makes `ax()` forward-compatible with longer atomic class names: it now correctly
+deduplicates both the current 9-char format (`_` + 4-char group + 4-char value) and the
+upcoming 11-char format (`_` + 6-char group + 4-char value). Because the two formats
+produce group keys of different lengths, they are structurally disjoint and never falsely
+deduplicate each other — so old and new class names can safely coexist on the same element
+during a migration. Behaviour for existing 9-char class names is unchanged.

--- a/packages/react/src/runtime/__perf__/ax.test.ts
+++ b/packages/react/src/runtime/__perf__/ax.test.ts
@@ -3,21 +3,27 @@ import { runBenchmark } from '@compiled/benchmark';
 import { ax } from '../index';
 
 describe('ax benchmark', () => {
-  const chunks: string[] = ['aaaa', 'bbbb', 'cccc', 'dddd', 'eeee', 'ffff', 'gggg'];
-  const uniques: string[] = chunks.map((chunk) => `_${chunk}${chunk}`);
+  // Real 6-char base-62 group prefixes from actual Compiled output (various CSS properties)
+  // Each chunk is a 6-char group; values are 4-char suffixes — together forming 11-char classes
+  const groups: string[] = ['1UtDYz', '4ya3eE', '3iDTPb', '1DCdHi', '30huDK', '3ONivY', '09lB87'];
+  const values: string[] = ['ynoA', 'rjyG', 'vLZJ', 'Jg58', 'tfxT', 'rjyG', 'YbGa'];
+  const uniques: string[] = groups.map((g, i) => `_${g}${values[i]}`);
   const withClashes: string[] = [
-    ...Array.from({ length: 4 }, () => `_${chunks[0]}${chunks[0]}`),
-    ...Array.from({ length: 6 }, () => `_${chunks[0]}${chunks[1]}`),
-    ...Array.from({ length: 8 }, () => `_${chunks[0]}${chunks[2]}`),
+    ...Array.from({ length: 4 }, () => `_${groups[0]}${values[0]}`),
+    ...Array.from({ length: 6 }, () => `_${groups[0]}${values[1]}`),
+    ...Array.from({ length: 8 }, () => `_${groups[0]}${values[2]}`),
   ];
 
   const getRandomRules = (() => {
-    function randomChunk() {
-      return chunks[Math.floor(Math.random() * chunks.length)];
+    function randomGroup() {
+      return groups[Math.floor(Math.random() * groups.length)];
+    }
+    function randomValue() {
+      return values[Math.floor(Math.random() * values.length)];
     }
 
     return function create(): string[] {
-      return Array.from({ length: 20 }, () => `_${randomChunk()}${randomChunk()}`);
+      return Array.from({ length: 20 }, () => `_${randomGroup()}${randomValue()}`);
     };
   })();
 
@@ -25,7 +31,7 @@ describe('ax benchmark', () => {
     const benchmark = await runBenchmark('ax', [
       {
         name: 'ax() single',
-        fn: () => ax(['_aaaabbbb']),
+        fn: () => ax(['_1UtDYzynoA']),
       },
       {
         name: 'ax() uniques (array)',

--- a/packages/react/src/runtime/__tests__/ax.test.ts
+++ b/packages/react/src/runtime/__tests__/ax.test.ts
@@ -26,38 +26,68 @@ describe('ax - atomic', () => {
   it.each([
     [
       'should ensure the last atomic declaration of a single group wins',
-      ['_aaaabbbb', '_aaaacccc'],
-      '_aaaacccc',
+      // _1UtDYzynoA and _1UtDYzGowl both target `color` (same 6-char group _1UtDYz)
+      ['_1UtDYzynoA', '_1UtDYzGowl'],
+      '_1UtDYzGowl',
     ],
     [
       'should ensure the last atomic declaration of many single groups wins',
-      ['_aaaabbbb', '_aaaacccc', '_aaaadddd', '_aaaaeeee'],
-      '_aaaaeeee',
+      // All four target `color` (group _1UtDYz) — last one wins
+      ['_1UtDYzynoA', '_1UtDYzGowl', '_1UtDYzDpLb', '_1UtDYzpjc8'],
+      '_1UtDYzpjc8',
     ],
     [
       'should ensure the last atomic declaration of a multi group wins',
-      ['_aaaabbbb _aaaacccc'],
-      '_aaaacccc',
+      // Two color classes in a single string — last one wins
+      ['_1UtDYzynoA _1UtDYzGowl'],
+      '_1UtDYzGowl',
     ],
     [
       'should ensure the last atomic declaration of many multi groups wins',
-      ['_aaaabbbb _aaaacccc _aaaadddd _aaaaeeee'],
-      '_aaaaeeee',
+      // Four color classes in a single string — last one wins
+      ['_1UtDYzynoA _1UtDYzGowl _1UtDYzDpLb _1UtDYzpjc8'],
+      '_1UtDYzpjc8',
     ],
     [
-      'should ensure the last atomic declaration of many multi groups with short class name wins',
-      ['_aaaabbbb', '_aaaaaaa', '_ddddbbb', '_ddddcccc'],
-      '_aaaaaaa _ddddcccc',
+      'should ensure the last atomic declaration of many multi groups with new-format class names wins',
+      // New-format atomic classes: `_` + 6-char group + 4-char value = 11 chars total
+      // Group key is extracted via `className.length - 4` = first 7 chars
+      // _1UtDYz* = color group, _4ya3eE* = font-size group — each deduped independently
+      ['_1UtDYzynoA', '_1UtDYzGowl', '_4ya3eErjyG', '_4ya3eEEbN9'],
+      '_1UtDYzGowl _4ya3eEEbN9',
     ],
     [
       'should not remove any atomic declarations if there are no duplicate groups',
-      ['_aaaabbbb', '_bbbbcccc'],
-      '_aaaabbbb _bbbbcccc',
+      // _1UtDYzGowl = color, _4ya3eErjyG = font-size — different groups, both survive
+      ['_1UtDYzGowl', '_4ya3eErjyG'],
+      '_1UtDYzGowl _4ya3eErjyG',
+    ],
+    [
+      'should correctly dedup within legacy format (9-char, 4-char group)',
+      // Two legacy-format color classes — same 4-char group (_syaz), last wins
+      // CLEANUP: remove this test when collisionResistantHash becomes the default
+      ['_syaz13q2', '_syaz5scu'],
+      '_syaz5scu',
+    ],
+    [
+      'should correctly dedup within new format (11-char, 6-char group)',
+      // Two new-format color classes — same 6-char group (_1UtDYz), last wins
+      ['_1UtDYzynoA', '_1UtDYzGowl'],
+      '_1UtDYzGowl',
+    ],
+    [
+      'should not cross-dedup legacy 9-char and new 11-char classes for the same property',
+      // During version-skew, ax() receives old 9-char classes from pre-built packages
+      // and new 11-char classes from the app's own styles in the same call.
+      // Different group key lengths mean they never falsely dedup each other.
+      // CLEANUP: remove this test when collisionResistantHash becomes the default
+      ['_syaz13q2', '_1UtDYzynoA'],
+      '_syaz13q2 _1UtDYzynoA',
     ],
     [
       'should ignore non atomic declarations when atomic declarations exist',
-      ['hello_there', 'hello_world', '_aaaabbbb'],
-      'hello_there hello_world _aaaabbbb',
+      ['hello_there', 'hello_world', '_1UtDYzGowl'],
+      'hello_there hello_world _1UtDYzGowl',
     ],
   ])('%s', (_, params, expected) => {
     expect(ax(params)).toEqual(expected);
@@ -91,9 +121,9 @@ describe('ax - non-atomic', () => {
       'should handle mixed atomic and non-atomic classes — cc- classes are preserved alongside _ classes',
       // ax() can receive both atomic (_) classes from css()/styled() and non-atomic
       // (cc-) classes from cssMapScoped in the same call.
-      // Atomic group "aaaa" is deduped to its last value; cc- classes are all preserved.
-      ['_aaaabbbb', 'cc-1c2j123', '_aaaacccc', 'cc-o9delr'],
-      '_aaaacccc cc-1c2j123 cc-o9delr',
+      // _1UtDYzynoA and _1UtDYzGowl both target color — deduped to last; cc- classes preserved.
+      ['_1UtDYzynoA', 'cc-1c2j123', '_1UtDYzGowl', 'cc-o9delr'],
+      '_1UtDYzGowl cc-1c2j123 cc-o9delr',
     ],
     [
       'should not treat cc- as an atomic group (different cc- classes are not deduped by prefix)',

--- a/packages/react/src/runtime/ax.ts
+++ b/packages/react/src/runtime/ax.ts
@@ -1,17 +1,25 @@
 /**
- * This length includes the underscore,
- * e.g. `"_1s4A"` would be a valid atomic group hash.
+ * The length of the value hash portion of an atomic class name.
+ * Atomic class names have the format: `_<group><value>`
+ * where group is ATOMIC_GROUP_HASH_LENGTH chars and value is ATOMIC_VALUE_HASH_LENGTH chars.
+ *
+ * We extract the group key using: `className.slice(0, className.length - ATOMIC_VALUE_HASH_LENGTH)`
+ *
+ * We support both old-format classes (9 chars: `_` + 4 group + 4 value) and
+ * new-format classes (11 chars: `_` + 6 group + 4 value) by using length-based
+ * extraction rather than a hardcoded offset — old and new format group keys
+ * are different lengths so they are structurally disjoint and never alias each other.
  */
-const ATOMIC_GROUP_LENGTH = 5;
+const ATOMIC_VALUE_HASH_LENGTH = 4;
 
 /**
  * Create a single string containing all the classnames provided, separated by a space (`" "`).
  * The result will only contain the _last_ atomic style classname for each atomic `group`.
  *
  * ```ts
- * ax(['_aaaabbbb', '_aaaacccc']);
+ * ax(['_aaaaaabbbb', '_aaaaaacccc']);
  * // output
- * '_aaaacccc'
+ * '_aaaaaacccc'
  * ```
  *
  * Format of Atomic style classnames: `_{group}{value}` (`_\w{4}\w{4}`)
@@ -19,9 +27,9 @@ const ATOMIC_GROUP_LENGTH = 5;
  * `ax` will preserve any non atomic style classnames (eg `"border-red"`)
  *
  * ```ts
- * ax(['_aaaabbbb', '_aaaacccc', 'border-red']);
+ * ax(['_aaaaaabbbb', '_aaaaaacccc', 'border-red']);
  * // output
- * '_aaaacccc border-red'
+ * '_aaaaaacccc border-red'
  * ```
  */
 export default function ax(classNames: (string | undefined | null | false)[]): string | undefined {
@@ -68,7 +76,9 @@ export default function ax(classNames: (string | undefined | null | false)[]): s
        * - Okay to remove duplicates as doing so does not impact specificity
        *
        * */
-      const key = className.startsWith('_') ? className.slice(0, ATOMIC_GROUP_LENGTH) : className;
+      const key = className.startsWith('_')
+        ? className.slice(0, className.length - ATOMIC_VALUE_HASH_LENGTH)
+        : className;
       map[key] = className;
     }
   }


### PR DESCRIPTION
Extract the atomic group key via length-based slicing (`className.length - 4`) instead of the hardcoded `ATOMIC_GROUP_LENGTH = 5` offset. `ax()` now correctly deduplicates both 9-char (4-char group) and upcoming 11-char (6-char group) class names. The two formats produce different-length group keys so they are structurally disjoint and never falsely dedup each other, enabling a safe mixed-hash migration window. Behaviour for existing 9-char classes is unchanged.

Ships ahead of the new hash algorithm so every consumer's runtime is ready before any product emits new-format class names.

### Why are we making this change?
This is in preparation of https://github.com/atlassian-labs/compiled/pull/1920; it will simplify rollout: decouples runtime readiness from the hash flip — enabling the independent per-product rollout.

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
