### PR TITLE
fix: make style bucketing length-agnostic for collisionResistantHash

### DIFF
--- a/.changeset/fix-new-hash-style-bucketing.md
+++ b/.changeset/fix-new-hash-style-bucketing.md
@@ -1,0 +1,12 @@
+---
+'@compiled/react': patch
+---
+
+Fix runtime style bucketing for class names generated with `collisionResistantHash`.
+
+`getStyleBucketName` located the pseudo-selector at a fixed offset, which only held for the
+legacy 9-character atomic class name. With the collision-resistant hash (11 characters) every
+pseudo-selector rule missed its bucket and fell through to the catch-all bucket, so `:hover`,
+`:focus`, `:visited` and friends were no longer ordered against each other at runtime. The
+pseudo-selector is now located relative to the opening bracket, so bucketing works for both
+class name lengths.

--- a/benchmark.config.json
+++ b/benchmark.config.json
@@ -1,5 +1,6 @@
 {
   "moduleNameMapper": {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
     "^@compiled/react/runtime$": "<rootDir>/packages/react/src/runtime.ts",
     "^@compiled/(.*)$": "<rootDir>/packages/$1/src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     },
     {
       "path": "./packages/react/dist/browser/runtime/style.js",
-      "limit": "1140B",
+      "limit": "1160B",
       "import": "CS",
       "ignore": [
         "react"

--- a/packages/babel-plugin/src/__perf__/module-traversal-cache.test.ts
+++ b/packages/babel-plugin/src/__perf__/module-traversal-cache.test.ts
@@ -29,13 +29,17 @@ const transform = (options = {}) =>
 describe('module traversal cache benchmark', () => {
   it('transforms the code correctly', () => {
     expect(transform()).toMatchInlineSnapshot(`
-      "const _4 = \\"._19ith012{border:3px solid pink}\\";
-      const _3 = \\"._bfhk32ev{background-color:pink}\\";
-      const _2 = \\"._syaz5scu{color:red}\\";
-      const _ = \\"._1wybo7ao{font-size:15px}\\";
+      "import * as React from "react";
+      import { ax, ix, CC, CS } from "@compiled/react/runtime";
+      import { colorMixin } from "../__fixtures__/mixins/objects";
+      import { secondary } from "../__fixtures__/mixins/simple";
+      const _4 = "._0KLXruy8mA{background-color:pink}";
+      const _3 = "._1UtDYzGowl{color:red}";
+      const _2 = "._4ya3eE2sAl{font-size:15px}";
+      const _ = "._30huDKzh4V{border:3px solid pink}";
       <CC>
         <CS>{[_, _2, _3, _4]}</CS>
-        {<div className={ax([\\"_1wybo7ao _syaz5scu _bfhk32ev _19ith012\\"])} />}
+        {<div className={ax(["_30huDKzh4V _4ya3eE2sAl _1UtDYzGowl _0KLXruy8mA"])} />}
       </CC>;
       "
     `);

--- a/packages/react/src/__tests__/browser.test.tsx
+++ b/packages/react/src/__tests__/browser.test.tsx
@@ -96,7 +96,13 @@ describe('browser', () => {
     render(<StyledLink href="https://atlassian.design">Atlassian Design System</StyledLink>);
 
     expect(document.head.innerHTML.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
-      "<style nonce="k0Mp1lEd">._3iDTPbQ4SZ{display:flex}._4ya3eEHMkp{font-size:50px}._1UtDYz5CUP{color:purple}._2ipzJpGowl:link{color:red}._22XfGnaJpK:focus-visible{color:white}._2ipzJpaJpK:link{color:white}._2nTuUYy8mA:visited{color:pink}._10n1R5Jwxv:focus{color:green}._0clgaMFQV5:hover{color:yellow}._0CMRbkynoA:active{color:blue}</style>
+      "<style nonce="k0Mp1lEd">._3iDTPbQ4SZ{display:flex}._4ya3eEHMkp{font-size:50px}._1UtDYz5CUP{color:purple}</style>
+      <style nonce="k0Mp1lEd">._2ipzJpGowl:link{color:red}._2ipzJpaJpK:link{color:white}</style>
+      <style nonce="k0Mp1lEd">._2nTuUYy8mA:visited{color:pink}</style>
+      <style nonce="k0Mp1lEd">._10n1R5Jwxv:focus{color:green}</style>
+      <style nonce="k0Mp1lEd">._22XfGnaJpK:focus-visible{color:white}</style>
+      <style nonce="k0Mp1lEd">._0clgaMFQV5:hover{color:yellow}</style>
+      <style nonce="k0Mp1lEd">._0CMRbkynoA:active{color:blue}</style>
       <style nonce="k0Mp1lEd">@media (max-width:800px){._3YxZqqFQV5:focus{color:yellow}._1h21S5okCM:focus-visible{color:grey}._0oG7IkokCM:hover{color:grey}._3cQMScbqW0:active{color:black}}@supports (display:grid){._3geGi3FQV5:focus{color:yellow}._0vra6NbqW0:active{color:black}}</style>
       "
     `);

--- a/packages/react/src/runtime/__perf__/cs.test.tsx
+++ b/packages/react/src/runtime/__perf__/cs.test.tsx
@@ -2,7 +2,8 @@ import { runBenchmark } from '@compiled/benchmark';
 import { JSDOM } from 'jsdom';
 import * as React from 'react';
 import { memo, type JSX } from 'react';
-import { createRoot } from 'react-dom/client';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
 import { renderToString } from 'react-dom/server';
 
 import { CC, CS } from '../index';
@@ -16,6 +17,12 @@ describe('CS benchmark', () => {
     const document = globalThis.document;
     const window = globalThis.window;
 
+    // A React 18 root may only be created once per container — recreating it on
+    // every iteration warns and leaves renders pending after teardown. The root
+    // is kept for the whole suite so each iteration measures a re-render, which
+    // is what the legacy `ReactDOM.render(el, container)` benchmark measured.
+    let root: Root | undefined;
+
     beforeAll(() => {
       if (env === 'server') {
         // @ts-expect-error
@@ -27,37 +34,49 @@ describe('CS benchmark', () => {
         globalThis.document = dom.window.document;
         // @ts-expect-error
         globalThis.window = dom.window;
+        root = createRoot(globalThis.document.getElementById('root')!);
       }
     });
 
     afterAll(() => {
+      // Unmount before the globals are restored, otherwise React commits
+      // against a `window` that no longer exists.
+      root && flushSync(() => root!.unmount());
+      root = undefined;
       globalThis.document = document;
       globalThis.window = window;
     });
 
+    // On the client the number of children dominates: a single concatenated
+    // sheet means one cache lookup per re-render, whereas the array variant
+    // walks every rule. Memoisation is not the differentiator — re-rendering
+    // `CS` is already free once its sheets are cached, so `memo` only adds a
+    // comparator call.
     const fastest =
       env === 'server'
         ? ['StyleBucketFromArray', 'StyleBucketFromString']
-        : ['MemoCS (1 array element)', 'MemoCS (n array elements)'];
+        : ['CS (1 array element)', 'MemoCS (1 array element)'];
 
     it(`completes with [${fastest.join(', ')}] as the fastest`, async () => {
+      // Collision-resistant (11-char) atomic sheets from `transformCss()`.
       const stylesArr = [
-        '._s7n4jp4b{vertical-align:top}',
-        '._1reo15vq{overflow-x:hidden}',
-        '._18m915vq{overflow-y:hidden}',
-        '._1bto1l2s{text-overflow:ellipsis}',
-        '._o5721q9c{white-space:nowrap}',
-        '._ca0qidpf{padding-top:0}',
-        '._u5f31y44{padding-right:4px}',
-        '._n3tdidpf{padding-bottom:0}',
-        '._19bv1y44{padding-left:4px}',
-        '._p12f12xx{max-width:100px}',
-        '._1bsb1osq{width:100%}',
+        '._1RrJLiBwqQ{vertical-align:top}',
+        '._4bt5LAnQyn{overflow-x:hidden}',
+        '._2WAcuGnQyn{overflow-y:hidden}',
+        '._39HuIbz8Lp{text-overflow:ellipsis}',
+        '._1ANEUSLRg7{white-space:nowrap}',
+        '._0Of8r2dnbC{padding-top:0}',
+        '._1ZnuxbUNDJ{padding-right:4px}',
+        '._1wydGWdnbC{padding-bottom:0}',
+        '._2Zuz6QUNDJ{padding-left:4px}',
+        '._1EqgXlmauj{max-width:100px}',
+        '._39xV02N91d{width:100%}',
       ];
 
       const stylesStr = stylesArr.join('');
 
-      const className = stylesArr.map((rule) => rule.slice(1, 10)).join(' ');
+      // Length-agnostic: class sits between `.` and `{` (9- or 11-char).
+      const className = stylesArr.map((rule) => rule.slice(1, rule.indexOf('{'))).join(' ');
       const nonce = 'k0Mp1lEd';
 
       const renderJSX =
@@ -66,9 +85,12 @@ describe('CS benchmark', () => {
               renderToString(<>{Array.from({ length: 10 }).map((_, i) => jsx(i))}</>);
             }
           : (jsx: (key: number) => JSX.Element) => {
-              createRoot(globalThis.document.getElementById('root')!).render(
-                <>{Array.from({ length: 10 }).map((_, i) => jsx(i))}</>
-              );
+              // `flushSync` keeps the commit inside the timed function; without
+              // it the benchmark only measures scheduling and the work lands
+              // after the suite has torn down its JSDOM globals.
+              flushSync(() => {
+                root!.render(<>{Array.from({ length: 10 }).map((_, i) => jsx(i))}</>);
+              });
             };
 
       const tests = [

--- a/packages/react/src/runtime/__perf__/sheet.test.ts
+++ b/packages/react/src/runtime/__perf__/sheet.test.ts
@@ -19,18 +19,19 @@ global.document = {
 
 describe('sheet benchmark', () => {
   it('completes without errors', async () => {
+    // Collision-resistant (11-char) atomic sheets from `transformCss()`.
     const rules = [
-      '._s7n4jp4b{vertical-align:top}',
-      '._1reo15vq{overflow-x:hidden}',
-      '._18m915vq{overflow-y:hidden}',
-      '._1bto1l2s{text-overflow:ellipsis}',
-      '._o5721q9c{white-space:nowrap}',
-      '._ca0qidpf{padding-top:0}',
-      '._u5f31y44{padding-right:4px}',
-      '._n3tdidpf{padding-bottom:0}',
-      '._19bv1y44{padding-left:4px}',
-      '._p12f12xx{max-width:100px}',
-      '._1bsb1osq{width:100%}',
+      '._1RrJLiBwqQ{vertical-align:top}',
+      '._4bt5LAnQyn{overflow-x:hidden}',
+      '._2WAcuGnQyn{overflow-y:hidden}',
+      '._39HuIbz8Lp{text-overflow:ellipsis}',
+      '._1ANEUSLRg7{white-space:nowrap}',
+      '._0Of8r2dnbC{padding-top:0}',
+      '._1ZnuxbUNDJ{padding-right:4px}',
+      '._1wydGWdnbC{padding-bottom:0}',
+      '._2Zuz6QUNDJ{padding-left:4px}',
+      '._1EqgXlmauj{max-width:100px}',
+      '._39xV02N91d{width:100%}',
     ];
 
     const benchmark = await runBenchmark('sheet', [

--- a/packages/react/src/runtime/__perf__/utils/sheet.ts
+++ b/packages/react/src/runtime/__perf__/utils/sheet.ts
@@ -97,7 +97,7 @@ function lazyAddStyleBucketToHead(
  * Input:
  *
  * ```
- * "._a1234567:hover{ color: red; }"
+ * "._a1234567890:hover{ color: red; }"
  * ```
  *
  * Output:
@@ -114,15 +114,19 @@ const getStyleBucketName = (sheet: string): string => {
     return 'm';
   }
 
+  const firstBracket = sheet.indexOf('{');
+
   /**
-   * We assume that classname will always be 9 character long,
-   * using this the 10th character could be a pseudo declaration.
+   * Atomic class names vary in length (9-char legacy vs 11-char collision-resistant),
+   * so locate the pseudo-selector relative to the opening bracket instead of a
+   * fixed offset. Keep this aligned with `packages/react/src/runtime/sheet.ts`.
    */
-  if (sheet.charCodeAt(10) === 58 /* ":" */) {
+  const colon = sheet.lastIndexOf(':', firstBracket);
+  if (colon !== -1 && colon < firstBracket) {
     // We send through a subset of the string instead of the full pseudo name.
     // For example `"focus-visible"` name would instead of `"us-visible"`.
     // Return a mapped pseudo else the default catch all bucket.
-    return pseudosMap[sheet.slice(14, sheet.indexOf('{'))] || '';
+    return pseudosMap[sheet.slice(colon + 4, firstBracket)] || '';
   }
 
   // Return default catch all bucket

--- a/packages/react/src/runtime/__tests__/sheet.test.ts
+++ b/packages/react/src/runtime/__tests__/sheet.test.ts
@@ -1,0 +1,88 @@
+import { getStyleBucketName } from '../sheet';
+
+/**
+ * Sheets below are real `transformCss()` output.
+ *
+ * - Legacy hash: 9-char classes (`_` + 4-char group + 4-char value)
+ * - Collision-resistant hash: 11-char classes (`_` + 6-char group + 4-char value)
+ *
+ */
+describe('getStyleBucketName', () => {
+  describe('legacy hash (9-char class names)', () => {
+    it.each([
+      ['link', '._ysv75scu:link{color:red}', 'l'],
+      ['visited', '._10535scu:visited{color:red}', 'v'],
+      ['focus-within', '._vp7g5scu:focus-within{color:red}', 'w'],
+      ['focus', '._f8pj5scu:focus{color:red}', 'f'],
+      ['focus-visible', '._v0vw5scu:focus-visible{color:red}', 'i'],
+      ['hover', '._30l35scu:hover{color:red}', 'h'],
+      ['active', '._9h8h5scu:active{color:red}', 'a'],
+    ])('buckets :%s', (_, sheet, expected) => {
+      expect(getStyleBucketName(sheet)).toEqual(expected);
+    });
+
+    it('prefers the pseudo bucket over the shorthand bucket', () => {
+      expect(getStyleBucketName('._19it107e{border:1px solid red}')).toEqual('s-1');
+      expect(getStyleBucketName('._bfw7107e:hover{border:1px solid red}')).toEqual('h');
+    });
+
+    it('buckets a trailing pseudo of a compound selector, matching the build-time sort', () => {
+      // `sort-pseudo-selectors.ts` scores on the trailing pseudo (`endsWith`),
+      // so `:hover:focus` must land in the focus bucket — not catch-all.
+      expect(getStyleBucketName('._z1ku5scu:hover:focus{color:red}')).toEqual('f');
+    });
+
+    it.each([
+      ['a plain declaration', '._syaz5scu{color:red}'],
+      ['an unmapped pseudo element', '._1kt91x3x:before{content:"a"}'],
+    ])('falls back to the catch-all bucket for %s', (_, sheet) => {
+      expect(getStyleBucketName(sheet)).toEqual('');
+    });
+
+    it('buckets shorthand properties by depth', () => {
+      expect(getStyleBucketName('._19it107e{border:1px solid red}')).toEqual('s-1');
+    });
+
+    it('buckets at-rules', () => {
+      expect(getStyleBucketName('@media screen{._30l35scu:hover{color:red}}')).toEqual('m');
+    });
+  });
+
+  describe('collision-resistant hash (11-char class names)', () => {
+    it.each([
+      ['link', '._2ipzJpGowl:link{color:red}', 'l'],
+      ['visited', '._2nTuUYGowl:visited{color:red}', 'v'],
+      ['focus-within', '._25IEJJGowl:focus-within{color:red}', 'w'],
+      ['focus', '._10n1R5Gowl:focus{color:red}', 'f'],
+      ['focus-visible', '._22XfGnGowl:focus-visible{color:red}', 'i'],
+      ['hover', '._0clgaMGowl:hover{color:red}', 'h'],
+      ['active', '._0CMRbkGowl:active{color:red}', 'a'],
+    ])('buckets :%s', (_, sheet, expected) => {
+      expect(getStyleBucketName(sheet)).toEqual(expected);
+    });
+
+    it('prefers the pseudo bucket over the shorthand bucket', () => {
+      expect(getStyleBucketName('._30huDK9HCG{border:1px solid red}')).toEqual('s-1');
+      expect(getStyleBucketName('._0KOPe29HCG:hover{border:1px solid red}')).toEqual('h');
+    });
+
+    it('buckets a trailing pseudo of a compound selector, matching the build-time sort', () => {
+      expect(getStyleBucketName('._2joYD5Gowl:hover:focus{color:red}')).toEqual('f');
+    });
+
+    it.each([
+      ['a plain declaration', '._1UtDYzGowl{color:red}'],
+      ['an unmapped pseudo element', '._3Ku51IR2KL:before{content:"a"}'],
+    ])('falls back to the catch-all bucket for %s', (_, sheet) => {
+      expect(getStyleBucketName(sheet)).toEqual('');
+    });
+
+    it('buckets shorthand properties by depth', () => {
+      expect(getStyleBucketName('._30huDK9HCG{border:1px solid red}')).toEqual('s-1');
+    });
+
+    it('buckets at-rules', () => {
+      expect(getStyleBucketName('@media screen{._0clgaMGowl:hover{color:red}}')).toEqual('m');
+    });
+  });
+});

--- a/packages/react/src/runtime/sheet.ts
+++ b/packages/react/src/runtime/sheet.ts
@@ -156,14 +156,20 @@ export const getStyleBucketName = (sheet: string): Bucket => {
   const firstBracket = sheet.indexOf('{');
 
   /**
-   * We assume that classname will always be 9 character long,
-   * using this the 10th characters could be a pseudo declaration.
+   * Atomic class names vary in length (9 chars for the legacy hash, 11 for the
+   * collision-resistant hash), so the pseudo-selector cannot be found at a fixed
+   * offset. We search backwards from the opening bracket instead, which also
+   * skips over any colons appearing earlier in the selector (e.g. in an
+   * attribute selector). This mirrors the build-time ordering in
+   * `packages/css/src/utils/sort-pseudo-selectors.ts`, which matches on the
+   * selector's trailing pseudo.
    */
-  if (sheet.charCodeAt(10) === 58 /* ":" */) {
+  const colon = sheet.lastIndexOf(':', firstBracket);
+  if (colon !== -1 && colon < firstBracket) {
     // We send through a subset of the string instead of the full pseudo name.
     // For example `"focus-visible"` name would instead of `"us-visible"`.
     // Return a mapped pseudo else the default catch all bucket.
-    const mapped = pseudosMap[sheet.slice(14, firstBracket)];
+    const mapped = pseudosMap[sheet.slice(colon + 4, firstBracket)];
     if (mapped) return mapped;
   }
 


### PR DESCRIPTION
### What is this change?

- Fix `getStyleBucketName` so runtime style bucketing works for both legacy (9-char) and `collisionResistantHash` (11-char) class names — locate the pseudo with `lastIndexOf` instead of a fixed offset at index 10.
- Align the `__perf__` sheet harness and fixtures with the same logic; fix the React 18 CS client bench; refresh the stale babel-plugin benchmark snapshot; add the missing `.js` module mapper to `benchmark.config.json` (an oversight from [#1865](https://github.com/atlassian-labs/compiled/pull/1865)).

### Why are we making this change?

- Surfaced the issue when enabling the new hash in a product: 2 units test started to fail due to the wrong bucketing under the the new hash: a user-cell unit test (should render Popup on hover) failed with `toBeVisible()` returning false under the new hash, while passing under the old hash. The rendered DOM and CSS declarations were byte-for-byte equivalent between old and new — only the class names differed.
- Captured the emitted stylesheet in both builds and found the base `{opacity:0}` rule and the `:hover{opacity:1}` rule had swapped relative order between old and new hash.  jsdom doesn't model interactive state (it can't know :hover isn't active) and doesn't implement specificity — it naively applies matching rules in source order, last-wins. Hence, while this won't be an issue at runtime, it flagged an oversight from previous PR where we changed the hash strategy https://github.com/atlassian-labs/compiled/pull/1920

---

### PR checklist

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
