### PR TITLE
fix(vite-plugin): include local development CSS in sorting

### DIFF
--- a/.changeset/tidy-vite-styles.md
+++ b/.changeset/tidy-vite-styles.md
@@ -2,4 +2,4 @@
 '@compiled/vite-plugin': patch
 ---
 
-Sort extracted Compiled styles during Vite development transforms.
+Combine and sort active extracted Compiled styles across Vite development modules so cross-file cascade ordering matches production.

--- a/.changeset/tidy-vite-styles.md
+++ b/.changeset/tidy-vite-styles.md
@@ -1,0 +1,5 @@
+---
+'@compiled/vite-plugin': patch
+---
+
+Sort extracted Compiled styles during Vite development transforms.

--- a/.changeset/tidy-vite-styles.md
+++ b/.changeset/tidy-vite-styles.md
@@ -1,5 +1,6 @@
 ---
 '@compiled/vite-plugin': patch
+'@compiled/babel-plugin-strip-runtime': patch
 ---
 
-Combine and sort active extracted Compiled styles across Vite development modules so cross-file cascade ordering matches production.
+Combine and sort active extracted and local Compiled styles across Vite development modules so cross-file cascade ordering matches production. Support React's `jsxDEV` output when stripping local development runtime styles.

--- a/.changeset/tidy-vite-styles.md
+++ b/.changeset/tidy-vite-styles.md
@@ -3,4 +3,4 @@
 '@compiled/babel-plugin-strip-runtime': patch
 ---
 
-Combine and sort active extracted and local Compiled styles across Vite development modules so cross-file cascade ordering matches production. Support React's `jsxDEV` output when stripping local development runtime styles.
+Combine and sort active extracted and local Compiled styles across Vite development modules so cross-file cascade ordering matches production. Allow the Vite plugin to opt into React `jsxDEV` handling when stripping local development runtime styles.

--- a/packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-transpiled-code.test.ts
+++ b/packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-transpiled-code.test.ts
@@ -122,12 +122,20 @@ describe('babel-plugin-strip-runtime using transpiled code', () => {
       `);
     });
 
-    it('strips the css prop runtime when using the development transform', () => {
-      const actual = transform(code, { development: true, runtime });
+    it('extracts styles and strips the css prop runtime when using the development transform', () => {
+      const actual = transform(code, {
+        development: true,
+        runtime,
+        styleSheetPath: testStyleSheetPath,
+      });
 
       expect(actual).not.toContain('CS');
       expect(actual).not.toContain('CC');
       expect(actual).toContain('jsxDEV');
+      expect(actual.match(regexToFindRequireStatements)).toEqual([
+        `require('${testStyleSheetPath}?style=._4ya3eErjyG%7Bfont-size%3A12px%7D');`,
+        `require('${testStyleSheetPath}?style=._1UtDYzynoA%7Bcolor%3Ablue%7D');`,
+      ]);
     });
   });
 

--- a/packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-transpiled-code.test.ts
+++ b/packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-transpiled-code.test.ts
@@ -19,10 +19,12 @@ const transform = (
     styleSheetPath?: string;
     compiledRequireExclude?: boolean;
     development?: boolean;
+    processJsxDev?: boolean;
     runtime: 'automatic' | 'classic';
   }
 ): string => {
-  const { modules, styleSheetPath, compiledRequireExclude, development, runtime } = opts;
+  const { modules, styleSheetPath, compiledRequireExclude, development, processJsxDev, runtime } =
+    opts;
   const filename = join(__dirname, 'app.tsx');
 
   const initialFileResult = transformSync(code, {
@@ -45,7 +47,7 @@ const transform = (
     babelrc: false,
     configFile: false,
     filename,
-    plugins: [[stripRuntimeBabelPlugin, { styleSheetPath, compiledRequireExclude }]],
+    plugins: [[stripRuntimeBabelPlugin, { styleSheetPath, compiledRequireExclude, processJsxDev }]],
   });
 
   if (!fileResult || !fileResult.code) {
@@ -122,9 +124,21 @@ describe('babel-plugin-strip-runtime using transpiled code', () => {
       `);
     });
 
-    it('extracts styles and strips the css prop runtime when using the development transform', () => {
+    it('leaves development transform handling disabled by default', () => {
       const actual = transform(code, {
         development: true,
+        runtime,
+        styleSheetPath: testStyleSheetPath,
+      });
+
+      expect(actual).toContain('jsxDEV');
+      expect(actual.match(regexToFindRequireStatements)).toBeNull();
+    });
+
+    it('extracts styles and strips the css prop runtime when development handling is enabled', () => {
+      const actual = transform(code, {
+        development: true,
+        processJsxDev: true,
         runtime,
         styleSheetPath: testStyleSheetPath,
       });

--- a/packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-transpiled-code.test.ts
+++ b/packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-transpiled-code.test.ts
@@ -18,10 +18,11 @@ const transform = (
     modules?: boolean;
     styleSheetPath?: string;
     compiledRequireExclude?: boolean;
+    development?: boolean;
     runtime: 'automatic' | 'classic';
   }
 ): string => {
-  const { modules, styleSheetPath, compiledRequireExclude, runtime } = opts;
+  const { modules, styleSheetPath, compiledRequireExclude, development, runtime } = opts;
   const filename = join(__dirname, 'app.tsx');
 
   const initialFileResult = transformSync(code, {
@@ -32,7 +33,7 @@ const transform = (
     presets: [
       ['@babel/preset-env', { targets: { esmodules: true }, modules: modules ?? 'auto' }],
       '@babel/preset-typescript',
-      ['@babel/preset-react', { runtime, useBuiltIns: true }],
+      ['@babel/preset-react', { development, runtime, useBuiltIns: true }],
     ],
   });
 
@@ -119,6 +120,14 @@ describe('babel-plugin-strip-runtime using transpiled code', () => {
           });
         "
       `);
+    });
+
+    it('strips the css prop runtime when using the development transform', () => {
+      const actual = transform(code, { development: true, runtime });
+
+      expect(actual).not.toContain('CS');
+      expect(actual).not.toContain('CC');
+      expect(actual).toContain('jsxDEV');
     });
   });
 

--- a/packages/babel-plugin-strip-runtime/src/index.ts
+++ b/packages/babel-plugin-strip-runtime/src/index.ts
@@ -184,7 +184,10 @@ export default declare<PluginPass>((api) => {
           return;
         }
 
-        if (isAutomaticRuntime(path.node, 'jsxs') || isAutomaticRuntime(path.node, 'jsxDEV')) {
+        if (
+          isAutomaticRuntime(path.node, 'jsxs') ||
+          (pass.opts.processJsxDev && isAutomaticRuntime(path.node, 'jsxDEV'))
+        ) {
           // We've found something that looks like _jsxs(...) or _jsxDEV(...)
           // Now we want to check if it's from the Compiled Runtime and if it is - replace with its children.
           const component = path.node.arguments[0];

--- a/packages/babel-plugin-strip-runtime/src/index.ts
+++ b/packages/babel-plugin-strip-runtime/src/index.ts
@@ -184,8 +184,8 @@ export default declare<PluginPass>((api) => {
           return;
         }
 
-        if (isAutomaticRuntime(path.node, 'jsxs')) {
-          // We've found something that looks like _jsxs(...)
+        if (isAutomaticRuntime(path.node, 'jsxs') || isAutomaticRuntime(path.node, 'jsxDEV')) {
+          // We've found something that looks like _jsxs(...) or _jsxDEV(...)
           // Now we want to check if it's from the Compiled Runtime and if it is - replace with its children.
           const component = path.node.arguments[0];
           if (!isCCComponent(component)) {

--- a/packages/babel-plugin-strip-runtime/src/types.ts
+++ b/packages/babel-plugin-strip-runtime/src/types.ts
@@ -22,6 +22,12 @@ export interface PluginOptions {
   compiledRequireExclude?: boolean;
 
   /**
+   * Whether to process calls emitted by React's development JSX transform.
+   * Defaults to `false`.
+   */
+  processJsxDev?: boolean;
+
+  /**
    * When set, extract styles to an external CSS file
    */
   extractStylesToDirectory?: { source: string; dest: string };

--- a/packages/babel-plugin-strip-runtime/src/utils/is-automatic-runtime.ts
+++ b/packages/babel-plugin-strip-runtime/src/utils/is-automatic-runtime.ts
@@ -9,7 +9,7 @@ import * as t from '@babel/types';
  */
 export const isAutomaticRuntime = (
   node: t.Node,
-  func: 'jsx' | 'jsxs'
+  func: 'jsx' | 'jsxs' | 'jsxDEV'
 ): node is t.CallExpression => {
   if (t.isCallExpression(node) && t.isIdentifier(node.callee) && node.callee.name === `_${func}`) {
     return true;

--- a/packages/babel-plugin-strip-runtime/src/utils/remove-style-declarations.ts
+++ b/packages/babel-plugin-strip-runtime/src/utils/remove-style-declarations.ts
@@ -87,7 +87,10 @@ export const removeStyleDeclarations = (
     return;
   }
 
-  if (isAutomaticRuntime(node, 'jsx') || isAutomaticRuntime(node, 'jsxDEV')) {
+  if (
+    isAutomaticRuntime(node, 'jsx') ||
+    (pass.opts.processJsxDev && isAutomaticRuntime(node, 'jsxDEV'))
+  ) {
     // We've found something that looks like _jsx(CS) or _jsxDEV(CS)
     const [styles] = getJsxRuntimeChildren(node);
 

--- a/packages/babel-plugin-strip-runtime/src/utils/remove-style-declarations.ts
+++ b/packages/babel-plugin-strip-runtime/src/utils/remove-style-declarations.ts
@@ -87,8 +87,8 @@ export const removeStyleDeclarations = (
     return;
   }
 
-  if (isAutomaticRuntime(node, 'jsx')) {
-    // We've found something that looks like _jsx(CS)
+  if (isAutomaticRuntime(node, 'jsx') || isAutomaticRuntime(node, 'jsxDEV')) {
+    // We've found something that looks like _jsx(CS) or _jsxDEV(CS)
     const [styles] = getJsxRuntimeChildren(node);
 
     if (t.isArrayExpression(styles)) {

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/asset.svg
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/asset.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1">
+  <path fill="red" d="M0 0h1v1H0z" />
+</svg>

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/base.compiled.css
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/base.compiled.css
@@ -1,0 +1,15 @@
+._base {
+  display: none;
+}
+
+._font {
+  font: normal 400 14px/20px sans-serif;
+}
+
+._border {
+  border: 0;
+}
+
+._asset {
+  background-image: url('./asset.svg');
+}

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/entry.js
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/entry.js
@@ -1,0 +1,2 @@
+import './overrides.compiled.css';
+import './base.compiled.css';

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/overrides.compiled.css
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/overrides.compiled.css
@@ -1,0 +1,13 @@
+@media (min-width: 48rem) {
+  ._media {
+    display: grid;
+  }
+}
+
+._weight {
+  font-weight: 700;
+}
+
+._border-width {
+  border-width: 1px;
+}

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
@@ -1,0 +1,234 @@
+require('ts-node').register({
+  experimentalResolver: true,
+  transpileOnly: true,
+});
+require('tsconfig-paths/register');
+
+const { build, createServer } = require('vite');
+const { join } = require('path');
+
+const compiledVitePlugin = require('../../../index').default;
+
+const extractDefaultExport = (code) => {
+  const declaration = code.match(/export default ("(?:[^"\\]|\\.)*")/);
+  if (!declaration) {
+    throw new Error(`Could not find the inline CSS export in:\n${code}`);
+  }
+  return JSON.parse(declaration[1]);
+};
+
+const waitFor = async (condition) => {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (condition()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('Timed out while waiting for the development stylesheet to update');
+};
+
+const exerciseRuntime = async (runtimeCode, origin, inlineCss) => {
+  const styles = [];
+  const nonceMeta = {
+    nonce: 'test-nonce',
+    getAttribute: () => 'test-nonce',
+  };
+  const originalDocument = global.document;
+  const originalFetch = global.fetch;
+
+  global.document = {
+    head: {
+      appendChild(style) {
+        styles.push(style);
+      },
+    },
+    createElement() {
+      return {
+        attributes: {},
+        textContent: '',
+        setAttribute(name, value) {
+          this.attributes[name] = value;
+        },
+        remove() {
+          const index = styles.indexOf(this);
+          if (index !== -1) {
+            styles.splice(index, 1);
+          }
+        },
+      };
+    },
+    querySelector(selector) {
+      if (selector === 'meta[property="csp-nonce"]') {
+        return nonceMeta;
+      }
+      return styles[0];
+    },
+  };
+  global.fetch = (url, options) => originalFetch(new URL(url, origin), options);
+
+  try {
+    const runtimeUrl = `data:text/javascript;base64,${Buffer.from(runtimeCode).toString('base64')}`;
+    const runtime = await import(runtimeUrl);
+
+    runtime.registerCompiledCss('overrides', inlineCss[0]);
+    const styleCountBeforeSort = styles.length;
+    const cssBeforeSort = styles[0].textContent;
+    runtime.registerCompiledCss('base', inlineCss[1]);
+    await waitFor(() => styles[0]?.textContent.includes('@media'));
+
+    const combinedCss = styles[0].textContent;
+    const nonce = styles[0].attributes.nonce;
+    const styleCount = styles.length;
+
+    runtime.registerCompiledCss('base', inlineCss[1].replace('display: none', 'display: block'));
+    await waitFor(() => styles[0]?.textContent.includes('display: block'));
+    const cssAfterHmr = styles[0].textContent;
+
+    runtime.unregisterCompiledCss('overrides');
+    await waitFor(() => styles[0] && !styles[0].textContent.includes('@media'));
+    const cssAfterPrune = styles[0].textContent;
+
+    runtime.unregisterCompiledCss('base');
+    await waitFor(() => styles.length === 0);
+
+    return {
+      combinedCss,
+      cssAfterHmr,
+      cssAfterPrune,
+      nonce,
+      styleCount,
+      styleCountBeforeSort,
+      cssBeforeSort,
+      styleCountAfterPrune: styles.length,
+    };
+  } finally {
+    global.document = originalDocument;
+    global.fetch = originalFetch;
+  }
+};
+
+async function runDevServer() {
+  const server = await createServer({
+    appType: 'custom',
+    base: '/test-base/',
+    configFile: false,
+    logLevel: 'silent',
+    optimizeDeps: {
+      noDiscovery: true,
+    },
+    plugins: [compiledVitePlugin()],
+    root: __dirname,
+    server: {
+      host: '127.0.0.1',
+      port: 0,
+    },
+  });
+
+  try {
+    await server.listen();
+
+    const entryResult = await server.transformRequest('/entry.js');
+    const entryModule = await server.moduleGraph.getModuleByUrl('/entry.js');
+    const proxyModules = [...entryModule.importedModules].filter((module) =>
+      module.id.includes('virtual:@compiled/vite-plugin/css-proxy:')
+    );
+    const proxyResults = await Promise.all(
+      proxyModules.map((module) => server.transformRequest(module.url))
+    );
+
+    const inlineModules = proxyModules.map((proxy) => {
+      const inlineModule = [...proxy.importedModules].find((module) =>
+        module.id.endsWith('.compiled.css?inline')
+      );
+      if (!inlineModule) {
+        throw new Error(`Could not find the inline CSS dependency for ${proxy.id}`);
+      }
+      return inlineModule;
+    });
+    const inlineResults = await Promise.all(
+      inlineModules.map((module) => server.transformRequest(module.url))
+    );
+    const inlineCss = inlineResults.map((result) => extractDefaultExport(result.code));
+
+    const runtimeModule = [...proxyModules[0].importedModules].find(
+      (module) => module.id === '\0virtual:@compiled/vite-plugin/css-runtime'
+    );
+    if (!runtimeModule) {
+      throw new Error('Could not find the Compiled development CSS runtime');
+    }
+    const runtimeResult = await server.transformRequest(runtimeModule.url);
+
+    const address = server.httpServer.address();
+    const origin = `http://127.0.0.1:${address.port}`;
+    const response = await fetch(`${origin}/test-base/@compiled/vite-plugin/sort-css`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(inlineCss),
+    });
+    if (!response.ok) {
+      throw new Error(await response.text());
+    }
+
+    const sortedCss = await response.text();
+    const browserRuntime = await exerciseRuntime(runtimeResult.code, origin, inlineCss);
+    const ssrResult = await server.transformRequest('/entry.js', { ssr: true });
+
+    return {
+      entry: entryResult.code,
+      proxies: proxyResults.map((result) => result.code),
+      inlineCss,
+      runtime: runtimeResult.code,
+      sortedCss,
+      browserRuntime,
+      hmr: proxyModules.map((proxy, index) => ({
+        proxyIsSelfAccepting: proxy.isSelfAccepting,
+        inlineIsSelfAccepting: inlineModules[index].isSelfAccepting,
+        inlineImporters: [...inlineModules[index].importers].map((module) => module.id),
+      })),
+      ssr: ssrResult.code,
+    };
+  } finally {
+    await server.close();
+  }
+}
+
+async function runBuild() {
+  const result = await build({
+    configFile: false,
+    logLevel: 'silent',
+    plugins: [compiledVitePlugin()],
+    root: __dirname,
+    build: {
+      minify: false,
+      rollupOptions: {
+        input: join(__dirname, 'entry.js'),
+      },
+      write: false,
+    },
+  });
+  const outputs = (Array.isArray(result) ? result : [result]).flatMap(
+    (buildResult) => buildResult.output
+  );
+
+  return {
+    js: outputs
+      .filter((output) => output.type === 'chunk')
+      .map((output) => output.code)
+      .join('\n'),
+    css: outputs
+      .filter((output) => output.type === 'asset' && output.fileName.endsWith('.css'))
+      .map((output) => output.source)
+      .join('\n'),
+  };
+}
+
+async function main() {
+  const dev = await runDevServer();
+  const production = await runBuild();
+  process.stdout.write(JSON.stringify({ dev, production }));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
@@ -12,9 +12,37 @@ if (!nodeCrypto.getRandomValues && nodeCrypto.webcrypto?.getRandomValues) {
 }
 
 const { build, createServer } = require('vite');
+const { request } = require('http');
 const { join } = require('path');
 
 const compiledVitePlugin = require('../../../index').default;
+
+const fetchForTest = (url, options = {}) =>
+  new Promise((resolve, reject) => {
+    const httpRequest = request(
+      url,
+      {
+        method: options.method,
+        headers: options.headers,
+      },
+      (response) => {
+        const chunks = [];
+        response.on('data', (chunk) => chunks.push(chunk));
+        response.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf8');
+          resolve({
+            ok: response.statusCode >= 200 && response.statusCode < 300,
+            text: async () => body,
+          });
+        });
+      }
+    );
+    httpRequest.on('error', reject);
+    if (options.body) {
+      httpRequest.write(options.body);
+    }
+    httpRequest.end();
+  });
 
 const extractDefaultExport = (code) => {
   const declaration = code.match(/export default ("(?:[^"\\]|\\.)*")/);
@@ -71,7 +99,7 @@ const exerciseRuntime = async (runtimeCode, origin, inlineCss) => {
       return styles[0];
     },
   };
-  global.fetch = (url, options) => originalFetch(new URL(url, origin), options);
+  global.fetch = (url, options) => fetchForTest(new URL(url, origin), options);
 
   try {
     const runtimeUrl = `data:text/javascript;base64,${Buffer.from(runtimeCode).toString('base64')}`;
@@ -167,7 +195,7 @@ async function runDevServer() {
 
     const address = server.httpServer.address();
     const origin = `http://127.0.0.1:${address.port}`;
-    const response = await fetch(`${origin}/test-base/@compiled/vite-plugin/sort-css`, {
+    const response = await fetchForTest(`${origin}/test-base/@compiled/vite-plugin/sort-css`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(inlineCss),

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
@@ -4,6 +4,13 @@ require('ts-node').register({
 });
 require('tsconfig-paths/register');
 
+// Vite 5 uses the Node 18+ crypto.getRandomValues alias. This repository also
+// validates Node 16, where the same API is available through crypto.webcrypto.
+const nodeCrypto = require('crypto');
+if (!nodeCrypto.getRandomValues && nodeCrypto.webcrypto?.getRandomValues) {
+  nodeCrypto.getRandomValues = nodeCrypto.webcrypto.getRandomValues.bind(nodeCrypto.webcrypto);
+}
+
 const { build, createServer } = require('vite');
 const { join } = require('path');
 

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
@@ -327,7 +327,7 @@ async function runBuild() {
 async function main() {
   const dev = await runDevServer();
   const production = await runBuild();
-  process.stdout.write(`${JSON.stringify({ dev, production })}\n`);
+  process.stdout.write(`${JSON.stringify({ dev, production })}\n`, () => process.exit(0));
 }
 
 main().catch((error) => {

--- a/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
+++ b/packages/vite-plugin/src/__tests__/__fixtures__/dev-css-order/run-vite.cjs
@@ -16,6 +16,21 @@ const { request } = require('http');
 const { join } = require('path');
 
 const compiledVitePlugin = require('../../../index').default;
+const localModuleId = join(__dirname, 'local.tsx');
+let localSource = `
+  import { css } from '@compiled/react';
+  export const Component = () => <div css={css({ color: 'red' })} />;
+  if (import.meta.hot) import.meta.hot.accept();
+`;
+const localSourcePlugin = {
+  name: 'local-source-fixture',
+  resolveId(source) {
+    return source === '/local.tsx' ? localModuleId : null;
+  },
+  load(id) {
+    return id === localModuleId ? localSource : null;
+  },
+};
 
 const fetchForTest = (url, options = {}) =>
   new Promise((resolve, reject) => {
@@ -142,6 +157,56 @@ const exerciseRuntime = async (runtimeCode, origin, inlineCss) => {
   }
 };
 
+const exerciseLocalCssHmr = async (server) => {
+  const firstLocalResult = await server.transformRequest('/local.tsx');
+  const firstLocalModule = await server.moduleGraph.getModuleByUrl('/local.tsx');
+  const firstCssModule = [...firstLocalModule.importedModules].find((module) =>
+    module.id.includes('virtual:@compiled/vite-plugin/local-css:')
+  );
+  if (!firstCssModule) {
+    throw new Error('Could not find local Compiled CSS before the hot update');
+  }
+  const firstCssResult = await server.transformRequest(firstCssModule.url);
+
+  localSource = localSource.replace("color: 'red'", "color: 'blue'");
+  const timestamp = Date.now();
+  const hmrContext = {
+    file: localModuleId,
+    timestamp,
+    modules: [firstLocalModule],
+    read: async () => localSource,
+    server,
+  };
+  for (const hook of server.config.getSortedPluginHooks('handleHotUpdate')) {
+    const filteredModules = await hook(hmrContext);
+    if (filteredModules) {
+      hmrContext.modules = filteredModules;
+    }
+  }
+  server.moduleGraph.invalidateModule(firstLocalModule, new Set(), timestamp, true);
+
+  const secondLocalResult = await server.transformRequest('/local.tsx');
+  const secondLocalModule = await server.moduleGraph.getModuleByUrl('/local.tsx');
+  const secondCssModule = [...secondLocalModule.importedModules].find((module) =>
+    module.id.includes('virtual:@compiled/vite-plugin/local-css:')
+  );
+  if (!secondCssModule) {
+    throw new Error('Could not find local Compiled CSS after the hot update');
+  }
+  const secondCssResult = await server.transformRequest(`${secondCssModule.url}?t=${timestamp}`);
+
+  return {
+    firstCss: firstCssResult.code,
+    firstParent: firstLocalResult.code,
+    sameVirtualModule: firstCssModule === secondCssModule,
+    secondCss: secondCssResult.code,
+    secondParent: secondLocalResult.code,
+    virtualModuleCount: [...secondLocalModule.importedModules].filter((module) =>
+      module.id.includes('virtual:@compiled/vite-plugin/local-css:')
+    ).length,
+  };
+};
+
 async function runDevServer() {
   const server = await createServer({
     appType: 'custom',
@@ -151,7 +216,7 @@ async function runDevServer() {
     optimizeDeps: {
       noDiscovery: true,
     },
-    plugins: [compiledVitePlugin()],
+    plugins: [localSourcePlugin, compiledVitePlugin()],
     root: __dirname,
     server: {
       host: '127.0.0.1',
@@ -207,6 +272,7 @@ async function runDevServer() {
     const sortedCss = await response.text();
     const browserRuntime = await exerciseRuntime(runtimeResult.code, origin, inlineCss);
     const ssrResult = await server.transformRequest('/entry.js', { ssr: true });
+    const localHmr = await exerciseLocalCssHmr(server);
 
     return {
       entry: entryResult.code,
@@ -215,6 +281,7 @@ async function runDevServer() {
       runtime: runtimeResult.code,
       sortedCss,
       browserRuntime,
+      localHmr,
       hmr: proxyModules.map((proxy, index) => ({
         proxyIsSelfAccepting: proxy.isSelfAccepting,
         inlineIsSelfAccepting: inlineModules[index].isSelfAccepting,
@@ -260,7 +327,7 @@ async function runBuild() {
 async function main() {
   const dev = await runDevServer();
   const production = await runBuild();
-  process.stdout.write(JSON.stringify({ dev, production }));
+  process.stdout.write(`${JSON.stringify({ dev, production })}\n`);
 }
 
 main().catch((error) => {

--- a/packages/vite-plugin/src/__tests__/dev-css.test.ts
+++ b/packages/vite-plugin/src/__tests__/dev-css.test.ts
@@ -67,6 +67,20 @@ describe('development Compiled CSS', () => {
     expect(dev.runtime).toContain('const endpoint = "/test-base/@compiled/vite-plugin/sort-css"');
     expect(dev.runtime).toContain('data-compiled-vite-dev-id');
 
+    // Local CSS keeps one virtual module while Vite invalidates and reloads
+    // its contents for the source module's normal hot-update request.
+    expect(dev.localHmr).toEqual(
+      expect.objectContaining({
+        sameVirtualModule: true,
+        virtualModuleCount: 1,
+      })
+    );
+    expect(dev.localHmr.firstCss).toContain('color:red');
+    expect(dev.localHmr.secondCss).toContain('color:blue');
+    expect(dev.localHmr.secondCss).not.toContain('color:red');
+    expect(dev.localHmr.firstParent).not.toContain('?t=');
+    expect(dev.localHmr.secondParent).toMatch(/local-css:[^"?]+\?t=\d{13}/);
+
     // Inline CSS updates propagate into self-accepting JavaScript proxies.
     for (const hmr of dev.hmr) {
       expect(hmr.proxyIsSelfAccepting).toBe(true);

--- a/packages/vite-plugin/src/__tests__/dev-css.test.ts
+++ b/packages/vite-plugin/src/__tests__/dev-css.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+
+import { execFileSync } from 'child_process';
+import { join } from 'path';
+
+describe('development Compiled CSS', () => {
+  it('uses Vite-processed CSS and sorts the active modules in one stylesheet', () => {
+    const output = execFileSync(
+      process.execPath,
+      [join(__dirname, '__fixtures__/dev-css-order/run-vite.cjs')],
+      {
+        cwd: join(__dirname, '../../../..'),
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          NODE_NO_WARNINGS: '1',
+          VITE_CJS_IGNORE_WARNING: '1',
+        },
+      }
+    );
+    const { dev, production } = JSON.parse(output);
+    const perModuleCss = dev.inlineCss.join('\n');
+
+    // The fixture deliberately imports overrides before their base and
+    // shorthand rules, reproducing the three cross-file failures from #1895.
+    expect(perModuleCss.indexOf('._weight')).toBeLessThan(perModuleCss.indexOf('._font'));
+    expect(perModuleCss.indexOf('._border-width {')).toBeLessThan(
+      perModuleCss.indexOf('._border {')
+    );
+    expect(perModuleCss.indexOf('@media')).toBeLessThan(perModuleCss.indexOf('._base'));
+
+    expect(dev.entry.match(/css-proxy:/g)).toHaveLength(2);
+    expect(dev.proxies).toHaveLength(2);
+    for (const proxy of dev.proxies) {
+      expect(proxy).toMatch(/import css from "\/[^"]+\.compiled\.css\?inline"/);
+      expect(proxy).toContain('registerCompiledCss(id, css)');
+      expect(proxy).toContain('import.meta.hot.accept()');
+      expect(proxy).toContain('import.meta.hot.prune');
+    }
+
+    // `?inline` still runs Vite's CSS pipeline, including relative URL rewriting.
+    expect(perModuleCss).toContain("url('/test-base/asset.svg')");
+    expect(perModuleCss).not.toContain("url('./asset.svg')");
+
+    expect(dev.sortedCss.indexOf('._font')).toBeLessThan(dev.sortedCss.indexOf('._weight'));
+    expect(dev.sortedCss.indexOf('._border {')).toBeLessThan(
+      dev.sortedCss.indexOf('._border-width {')
+    );
+    expect(dev.sortedCss.indexOf('._base')).toBeLessThan(dev.sortedCss.indexOf('@media'));
+
+    expect(dev.browserRuntime).toEqual(
+      expect.objectContaining({
+        combinedCss: dev.sortedCss,
+        cssBeforeSort: '',
+        nonce: 'test-nonce',
+        styleCount: 1,
+        styleCountBeforeSort: 1,
+        styleCountAfterPrune: 0,
+      })
+    );
+    expect(dev.browserRuntime.cssAfterHmr).toContain('display: block');
+    expect(dev.browserRuntime.cssAfterHmr).not.toContain('display: none');
+    expect(dev.browserRuntime.cssAfterPrune).toContain('._base');
+    expect(dev.browserRuntime.cssAfterPrune).not.toContain('._weight');
+    expect(dev.runtime).toContain('const endpoint = "/test-base/@compiled/vite-plugin/sort-css"');
+    expect(dev.runtime).toContain('data-compiled-vite-dev-id');
+
+    // Inline CSS updates propagate into self-accepting JavaScript proxies.
+    for (const hmr of dev.hmr) {
+      expect(hmr.proxyIsSelfAccepting).toBe(true);
+      expect(hmr.inlineIsSelfAccepting).toBe(false);
+      expect(hmr.inlineImporters).toHaveLength(1);
+      expect(hmr.inlineImporters[0]).toContain('css-proxy:');
+    }
+
+    // SSR and production builds retain Vite's normal CSS handling.
+    expect(dev.ssr).toContain('/overrides.compiled.css');
+    expect(dev.ssr).not.toContain('css-proxy:');
+    expect(production.js).not.toContain('css-proxy:');
+    expect(production.js).not.toContain('css-runtime');
+    expect(production.css.indexOf('._font')).toBeLessThan(production.css.indexOf('._weight'));
+    expect(production.css.indexOf('._border {')).toBeLessThan(
+      production.css.indexOf('._border-width {')
+    );
+    expect(production.css.indexOf('._base')).toBeLessThan(production.css.indexOf('@media'));
+  });
+});

--- a/packages/vite-plugin/src/__tests__/extraction.test.ts
+++ b/packages/vite-plugin/src/__tests__/extraction.test.ts
@@ -127,7 +127,7 @@ describe('CSS Extraction', () => {
       expect(emittedFiles.length).toBe(0);
     });
 
-    it('should not emit CSS file in development mode', async () => {
+    it('should honor explicit extraction independently of NODE_ENV', async () => {
       process.env.NODE_ENV = 'development';
       const plugin = compiledVitePlugin({ extract: true, collisionResistantHash: true });
       const emittedFiles: any[] = [];
@@ -147,7 +147,11 @@ describe('CSS Extraction', () => {
 
       await plugin.generateBundle.call(context, {}, {});
 
-      expect(emittedFiles.length).toBe(0);
+      expect(emittedFiles.length).toBe(1);
+      expect(emittedFiles[0]).toMatchObject({
+        name: 'compiled-extracted.css',
+        type: 'asset',
+      });
     });
 
     it('should apply sorting and deduplication to CSS assets containing Compiled styles', async () => {

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -76,18 +76,18 @@ describe('compiledVitePlugin', () => {
     const resolveOptions = { attributes: {}, isEntry: false };
     const context = { resolve: jest.fn() };
     const id = '/project/local.tsx';
+    const code = `
+      import { css } from '@compiled/react';
+      export const Component = () => <div css={css({ display: 'flex' })} />;
+    `;
 
     plugin.configResolved({ base: '/', command: 'serve' });
-    const result = await plugin.transform!(
-      `
-        import { css } from '@compiled/react';
-        export const Component = () => <div css={css({ display: 'flex' })} />;
-      `,
-      id
-    );
+    const result = await plugin.transform!(code, id);
 
     expect(result.code).toContain('virtual:@compiled/vite-plugin/local-css:');
     expect(result.code).not.toContain('CS');
+    expect(result.map.sourcesContent).toEqual([code]);
+    expect(result.map.mappings).toMatch(/^;/);
 
     const source = result.code.match(/"(virtual:@compiled\/vite-plugin\/local-css:[^"]+)"/)?.[1];
     expect(source).toBeDefined();
@@ -109,6 +109,38 @@ describe('compiledVitePlugin', () => {
 
     expect(resultWithoutStyles.code).not.toContain('virtual:@compiled/vite-plugin/local-css:');
     expect(plugin.load(virtualId)).toBeNull();
+  });
+
+  it('invalidates local development CSS before a hot update re-transforms its source', async () => {
+    const plugin: any = compiledVitePlugin();
+    const file = '/project/local.tsx';
+    const timestamp = 1_725_000_000_000;
+
+    plugin.configResolved({ base: '/', command: 'serve' });
+    const result = await plugin.transform!(
+      `
+        import { css } from '@compiled/react';
+        export const Component = () => <div css={css({ display: 'flex' })} />;
+      `,
+      file
+    );
+    const source = result.code.match(/"(virtual:@compiled\/vite-plugin\/local-css:[^"]+)"/)?.[1];
+    const virtualId = await plugin.resolveId.call({ resolve: jest.fn() }, source, file, {
+      attributes: {},
+      isEntry: false,
+    });
+    const localCssModule = { id: virtualId };
+    const getModuleById = jest.fn().mockReturnValue(localCssModule);
+    const invalidateModule = jest.fn();
+
+    plugin.handleHotUpdate({
+      file,
+      server: { moduleGraph: { getModuleById, invalidateModule } },
+      timestamp,
+    });
+
+    expect(getModuleById).toHaveBeenCalledWith(virtualId);
+    expect(invalidateModule).toHaveBeenCalledWith(localCssModule, expect.any(Set), timestamp, true);
   });
 
   it('keeps dev SSR transforms on the existing runtime path', async () => {

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -53,6 +53,43 @@ describe('compiledVitePlugin', () => {
     expect(result).toBeNull();
   });
 
+  it('should sort extracted Compiled CSS during transformation', async () => {
+    const plugin = compiledVitePlugin();
+    const code =
+      '@media (min-width: 768px) { ._fpol1q9b { color: blue } }' +
+      '._bbbk3bke { border-bottom-color: orange }' +
+      '._syaz1q9b { color: red }' +
+      '._bxs1q9b { border: 2px solid transparent }';
+
+    const result = await plugin.transform!(
+      code,
+      '/node_modules/@atlaskit/example/dist/styles.compiled.css'
+    );
+
+    expect(result).toEqual({
+      code:
+        '._bxs1q9b { border: 2px solid transparent }' +
+        '._bbbk3bke { border-bottom-color: orange }' +
+        '._syaz1q9b { color: red }' +
+        '@media (min-width: 768px) { ._fpol1q9b { color: blue } }',
+      map: null,
+    });
+  });
+
+  it('should preserve invalid extracted Compiled CSS when sorting fails', async () => {
+    const plugin = compiledVitePlugin();
+    const context = { warn: jest.fn() };
+    const code = '._syaz1q9b { color: red';
+    const id = '/node_modules/@atlaskit/example/dist/styles.compiled.css';
+
+    const result = await plugin.transform!.call(context, code, id);
+
+    expect(result).toBeNull();
+    expect(context.warn).toHaveBeenCalledWith({
+      message: expect.stringContaining(`Failed to sort CSS in ${id}`),
+    });
+  });
+
   it('should skip node_modules/@compiled/react', async () => {
     const plugin = compiledVitePlugin();
     const code = `

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -71,6 +71,33 @@ describe('compiledVitePlugin', () => {
     ).resolves.toBeNull();
   });
 
+  it('registers local development rules with the sorted stylesheet', async () => {
+    const plugin: any = compiledVitePlugin();
+    const resolveOptions = { attributes: {}, isEntry: false };
+    const context = { resolve: jest.fn() };
+    const id = '/project/local.tsx';
+
+    plugin.configResolved({ base: '/', command: 'serve' });
+    const result = await plugin.transform!(
+      `
+        import { css } from '@compiled/react';
+        export const Component = () => <div css={css({ display: 'flex' })} />;
+      `,
+      id
+    );
+
+    expect(result.code).toContain('virtual:@compiled/vite-plugin/local-css:');
+    expect(result.code).not.toContain('CS');
+
+    const source = result.code.match(/"(virtual:@compiled\/vite-plugin\/local-css:[^"]+)"/)?.[1];
+    expect(source).toBeDefined();
+    const virtualId = await plugin.resolveId.call(context, source, id, resolveOptions);
+    const module = plugin.load(virtualId);
+
+    expect(module).toContain('registerCompiledCss');
+    expect(module).toContain('display:flex');
+  });
+
   it('should transform code with Compiled imports', async () => {
     const plugin = compiledVitePlugin({ collisionResistantHash: true });
     const code = `

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -6,6 +6,69 @@ describe('compiledVitePlugin', () => {
 
     expect(plugin.name).toBe('@compiled/vite-plugin');
     expect(plugin.enforce).toBe('pre');
+    expect(Array.isArray(plugin)).toBe(false);
+  });
+
+  it('only proxies client-side script imports while serving', async () => {
+    const plugin: any = compiledVitePlugin();
+    const context = {
+      resolve: jest.fn().mockResolvedValue({
+        id: '/project/styles.compiled.css',
+      }),
+    };
+    const resolveOptions = {
+      attributes: {},
+      isEntry: false,
+    };
+
+    plugin.configResolved({ base: '/', command: 'serve' });
+
+    const proxyId = await plugin.resolveId.call(
+      context,
+      './styles.compiled.css',
+      '/project/entry.ts',
+      resolveOptions
+    );
+    expect(proxyId).toMatch(/^\0virtual:@compiled\/vite-plugin\/css-proxy:.*\.js$/);
+    expect(context.resolve).toHaveBeenCalledWith(
+      './styles.compiled.css',
+      '/project/entry.ts',
+      expect.objectContaining({ skipSelf: true })
+    );
+
+    await expect(
+      plugin.resolveId.call(context, './styles.compiled.css', '/project/entry.ts', {
+        ...resolveOptions,
+        ssr: true,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      plugin.resolveId.call(context, './styles.compiled.css', '/project/entry.ts', {
+        ...resolveOptions,
+        scan: true,
+      })
+    ).resolves.toBeNull();
+    await expect(
+      plugin.resolveId.call(
+        context,
+        './styles.compiled.css',
+        '/project/importer.css',
+        resolveOptions
+      )
+    ).resolves.toBeNull();
+    await expect(
+      plugin.resolveId.call(
+        context,
+        './styles.compiled.css?inline',
+        '/project/entry.ts',
+        resolveOptions
+      )
+    ).resolves.toBeNull();
+
+    plugin.configResolved({ base: '/', command: 'build' });
+    await expect(
+      plugin.resolveId.call(context, './styles.compiled.css', '/project/entry.ts', resolveOptions)
+    ).resolves.toBeNull();
   });
 
   it('should transform code with Compiled imports', async () => {

--- a/packages/vite-plugin/src/__tests__/plugin.test.ts
+++ b/packages/vite-plugin/src/__tests__/plugin.test.ts
@@ -95,7 +95,36 @@ describe('compiledVitePlugin', () => {
     const module = plugin.load(virtualId);
 
     expect(module).toContain('registerCompiledCss');
+    expect(module).toContain('unregisterCompiledCss');
+    expect(module).toContain('import.meta.hot.prune');
     expect(module).toContain('display:flex');
+
+    const resultWithoutStyles = await plugin.transform!(
+      `
+        import { css } from '@compiled/react';
+        export const Component = () => <div />;
+      `,
+      id
+    );
+
+    expect(resultWithoutStyles.code).not.toContain('virtual:@compiled/vite-plugin/local-css:');
+    expect(plugin.load(virtualId)).toBeNull();
+  });
+
+  it('keeps dev SSR transforms on the existing runtime path', async () => {
+    const plugin: any = compiledVitePlugin();
+    const id = '/project/server.tsx';
+    const code = `
+      import { css } from '@compiled/react';
+      export const Component = () => <div css={css({ display: 'flex' })} />;
+    `;
+
+    plugin.configResolved({ base: '/', command: 'serve' });
+    const result = await plugin.transform(code, id, { ssr: true });
+
+    expect(result.code).not.toContain('virtual:@compiled/vite-plugin/local-css:');
+    expect(result.code).toContain('CC');
+    expect(result.code).toContain('CS');
   });
 
   it('should transform code with Compiled imports', async () => {
@@ -118,6 +147,58 @@ describe('compiledVitePlugin', () => {
       expect(result.code).toContain('_1UtDYzGowl');
       expect(result.code).toContain('color:red');
       expect(result.code).toContain('font-size:9pt'); // 12px gets normalized to 9pt
+    }
+  });
+
+  it('keeps production transforms unchanged when extraction is disabled', async () => {
+    const plugin: any = compiledVitePlugin();
+    const code = `
+      import { css } from '@compiled/react';
+      export const Component = () => <div css={css({ display: 'flex' })} />;
+    `;
+
+    plugin.configResolved({ base: '/', command: 'build' });
+    const result = await plugin.transform(code, '/project/production.tsx', { ssr: false });
+
+    expect(result.code).not.toContain('virtual:@compiled/vite-plugin/local-css:');
+    expect(result.code).toContain('CC');
+    expect(result.code).toContain('CS');
+  });
+
+  it('extracts during builds independently of NODE_ENV and preserves the original source map', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'test';
+
+    try {
+      const plugin: any = compiledVitePlugin({ extract: true });
+      const code = [
+        "import { css } from '@compiled/react';",
+        'export const Component = () => (',
+        "  <div css={css({ display: 'flex' })}>source map target</div>",
+        ');',
+      ].join('\n');
+      const emitFile = jest.fn();
+
+      plugin.configResolved({ base: '/', command: 'build' });
+      const result = await plugin.transform(code, '/project/extracted.tsx', { ssr: false });
+      plugin.generateBundle.call({ emitFile, warn: jest.fn() }, {}, {});
+
+      expect(result.code).not.toContain('CC');
+      expect(result.code).not.toContain('CS');
+      expect(result.map.sourcesContent).toEqual([code]);
+      expect(emitFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'compiled-extracted.css',
+          source: expect.stringContaining('display:flex'),
+          type: 'asset',
+        })
+      );
+    } finally {
+      if (previousNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = previousNodeEnv;
+      }
     }
   });
 
@@ -144,16 +225,18 @@ describe('compiledVitePlugin', () => {
   });
 
   it('should sort extracted Compiled CSS during transformation', async () => {
-    const plugin = compiledVitePlugin();
+    const plugin: any = compiledVitePlugin();
     const code =
       '@media (min-width: 768px) { ._fpol1q9b { color: blue } }' +
       '._bbbk3bke { border-bottom-color: orange }' +
       '._syaz1q9b { color: red }' +
       '._bxs1q9b { border: 2px solid transparent }';
 
-    const result = await plugin.transform!(
+    plugin.configResolved({ base: '/', command: 'serve' });
+    const result = await plugin.transform(
       code,
-      '/node_modules/@atlaskit/example/dist/styles.compiled.css'
+      '/node_modules/@atlaskit/example/dist/styles.compiled.css',
+      { ssr: false }
     );
 
     expect(result).toEqual({
@@ -166,13 +249,26 @@ describe('compiledVitePlugin', () => {
     });
   });
 
+  it('does not sort extracted Compiled CSS outside client development transforms', async () => {
+    const plugin: any = compiledVitePlugin();
+    const code = '._syaz1q9b { color: red }';
+    const id = '/node_modules/@atlaskit/example/dist/styles.compiled.css';
+
+    plugin.configResolved({ base: '/', command: 'build' });
+    await expect(plugin.transform(code, id, { ssr: false })).resolves.toBeNull();
+
+    plugin.configResolved({ base: '/', command: 'serve' });
+    await expect(plugin.transform(code, id, { ssr: true })).resolves.toBeNull();
+  });
+
   it('should preserve invalid extracted Compiled CSS when sorting fails', async () => {
-    const plugin = compiledVitePlugin();
+    const plugin: any = compiledVitePlugin();
     const context = { warn: jest.fn() };
     const code = '._syaz1q9b { color: red';
     const id = '/node_modules/@atlaskit/example/dist/styles.compiled.css';
 
-    const result = await plugin.transform!.call(context, code, id);
+    plugin.configResolved({ base: '/', command: 'serve' });
+    const result = await plugin.transform.call(context, code, id, { ssr: false });
 
     expect(result).toBeNull();
     expect(context.warn).toHaveBeenCalledWith({

--- a/packages/vite-plugin/src/dev-css.ts
+++ b/packages/vite-plugin/src/dev-css.ts
@@ -45,9 +45,30 @@ type DevCssServer = {
   };
 };
 
+type DevCssModuleNode = {
+  id: string | null;
+};
+
+type DevCssHotUpdateContext = {
+  file: string;
+  server: {
+    moduleGraph: {
+      getModuleById(id: string): DevCssModuleNode | undefined;
+      invalidateModule(
+        module: DevCssModuleNode,
+        seen: Set<DevCssModuleNode>,
+        timestamp: number,
+        isHmr: boolean
+      ): void;
+    };
+  };
+  timestamp: number;
+};
+
 type DevCssHooks = {
   configResolved(config: { base: string; command: string }): void;
   configureServer(server: DevCssServer): void;
+  handleHotUpdate(context: DevCssHotUpdateContext): void;
   load(id: string, options?: { ssr?: boolean }): string | null;
   resolveId(
     this: DevCssPluginContext,
@@ -69,6 +90,9 @@ const decodeModuleId = (id: string): string | undefined => {
 };
 
 const toInlineRequest = (id: string): string => `${id}${id.includes('?') ? '&' : '?'}inline`;
+
+const toResolvedLocalCssId = (id: string): string =>
+  `${RESOLVED_COMPILED_DEV_LOCAL_CSS_PREFIX}${encodeModuleId(id)}.js`;
 
 const isScriptImport = (importer: string | undefined): importer is string =>
   Boolean(importer && !STYLE_IMPORTER.test(importer) && !HTML_IMPORTER.test(importer));
@@ -97,6 +121,17 @@ export const createDevCssHooks = (
       sortEndpointPath = getRequestPath(sortEndpoint);
     },
 
+    handleHotUpdate({ file, server, timestamp }) {
+      if (!isDevServer) {
+        return;
+      }
+
+      const localCssModule = server.moduleGraph.getModuleById(toResolvedLocalCssId(file));
+      if (localCssModule) {
+        server.moduleGraph.invalidateModule(localCssModule, new Set(), timestamp, true);
+      }
+    },
+
     async resolveId(source, importer, options) {
       if (!isDevServer || options.ssr) {
         return null;
@@ -112,9 +147,8 @@ export const createDevCssHooks = (
       }
 
       if (source.startsWith(COMPILED_DEV_LOCAL_CSS_PREFIX)) {
-        return `${RESOLVED_COMPILED_DEV_LOCAL_CSS_PREFIX}${source.slice(
-          COMPILED_DEV_LOCAL_CSS_PREFIX.length
-        )}.js`;
+        const cssId = decodeModuleId(source.slice(COMPILED_DEV_LOCAL_CSS_PREFIX.length));
+        return cssId ? toResolvedLocalCssId(cssId) : null;
       }
 
       if (options.scan || !isScriptImport(importer) || !COMPILED_CSS_IMPORT.test(source)) {

--- a/packages/vite-plugin/src/dev-css.ts
+++ b/packages/vite-plugin/src/dev-css.ts
@@ -1,4 +1,4 @@
-import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
+import type { IncomingMessage, ServerResponse } from 'http';
 
 const COMPILED_CSS_REQUEST = /\.compiled\.css(?:$|\?)/;
 const COMPILED_CSS_IMPORT = /\.compiled\.css$/;
@@ -16,7 +16,46 @@ const COMPILED_DEV_RUNTIME_ID = 'virtual:@compiled/vite-plugin/css-runtime';
 const RESOLVED_COMPILED_DEV_RUNTIME_ID = `\0${COMPILED_DEV_RUNTIME_ID}`;
 const MAX_CSS_PAYLOAD_SIZE = 50_000_000;
 
-type DevCssHooks = Pick<Plugin, 'configResolved' | 'configureServer' | 'load' | 'resolveId'>;
+type ResolveOptions = {
+  scan?: boolean;
+  ssr?: boolean;
+  [key: string]: unknown;
+};
+
+type DevCssPluginContext = {
+  resolve(
+    source: string,
+    importer: string | undefined,
+    options: ResolveOptions & { skipSelf: boolean }
+  ): Promise<{
+    external?: boolean | 'absolute' | 'relative';
+    id: string;
+  } | null>;
+};
+
+type DevCssServer = {
+  middlewares: {
+    use(
+      handler: (
+        request: IncomingMessage,
+        response: ServerResponse,
+        next: () => void
+      ) => void | Promise<void>
+    ): void;
+  };
+};
+
+type DevCssHooks = {
+  configResolved(config: { base: string; command: string }): void;
+  configureServer(server: DevCssServer): void;
+  load(id: string, options?: { ssr?: boolean }): string | null;
+  resolveId(
+    this: DevCssPluginContext,
+    source: string,
+    importer: string | undefined,
+    options: ResolveOptions
+  ): Promise<string | null>;
+};
 
 export const isCompiledCssRequest = (id: string): boolean => COMPILED_CSS_REQUEST.test(id);
 
@@ -52,7 +91,7 @@ export const createDevCssHooks = (
   let sortEndpointPath = sortEndpoint;
 
   return {
-    configResolved(config: ResolvedConfig) {
+    configResolved(config) {
       isDevServer = config.command === 'serve';
       sortEndpoint = `${config.base}${COMPILED_DEV_SORT_PATH}`;
       sortEndpointPath = getRequestPath(sortEndpoint);
@@ -78,11 +117,7 @@ export const createDevCssHooks = (
         )}.js`;
       }
 
-      if (
-        (options as typeof options & { scan?: boolean }).scan ||
-        !isScriptImport(importer) ||
-        !COMPILED_CSS_IMPORT.test(source)
-      ) {
+      if (options.scan || !isScriptImport(importer) || !COMPILED_CSS_IMPORT.test(source)) {
         return null;
       }
 
@@ -209,12 +244,17 @@ export const createDevCssHooks = (
         }
 
         return `
-          import { registerCompiledCss } from ${JSON.stringify(COMPILED_DEV_RUNTIME_ID)}
+          import {
+            registerCompiledCss,
+            unregisterCompiledCss,
+          } from ${JSON.stringify(COMPILED_DEV_RUNTIME_ID)}
 
-          registerCompiledCss(${JSON.stringify(`local:${cssId}`)}, ${JSON.stringify(css)})
+          const id = ${JSON.stringify(`local:${cssId}`)}
+          registerCompiledCss(id, ${JSON.stringify(css)})
 
           if (import.meta.hot) {
             import.meta.hot.accept()
+            import.meta.hot.prune(() => unregisterCompiledCss(id))
           }
         `;
       }
@@ -246,7 +286,7 @@ export const createDevCssHooks = (
       `;
     },
 
-    configureServer(server: ViteDevServer) {
+    configureServer(server) {
       server.middlewares.use(async (request, response, next) => {
         if (
           request.method !== 'POST' ||

--- a/packages/vite-plugin/src/dev-css.ts
+++ b/packages/vite-plugin/src/dev-css.ts
@@ -9,6 +9,8 @@ const COMPILED_DEV_STYLE_ID = '@compiled/vite-plugin:compiled.css';
 const COMPILED_DEV_SORT_PATH = '@compiled/vite-plugin/sort-css';
 const COMPILED_DEV_PROXY_PREFIX = 'virtual:@compiled/vite-plugin/css-proxy:';
 const RESOLVED_COMPILED_DEV_PROXY_PREFIX = `\0${COMPILED_DEV_PROXY_PREFIX}`;
+const COMPILED_DEV_LOCAL_CSS_PREFIX = 'virtual:@compiled/vite-plugin/local-css:';
+const RESOLVED_COMPILED_DEV_LOCAL_CSS_PREFIX = `\0${COMPILED_DEV_LOCAL_CSS_PREFIX}`;
 const COMPILED_DEV_INLINE_PREFIX = 'virtual:@compiled/vite-plugin/css-inline:';
 const COMPILED_DEV_RUNTIME_ID = 'virtual:@compiled/vite-plugin/css-runtime';
 const RESOLVED_COMPILED_DEV_RUNTIME_ID = `\0${COMPILED_DEV_RUNTIME_ID}`;
@@ -41,7 +43,10 @@ const getRequestPath = (url: string): string => new URL(url, 'http://vite.local'
  * the public `?inline` API and registers it in one browser-side stylesheet,
  * allowing the complete active stylesheet to be sorted across module files.
  */
-export const createDevCssHooks = (sortCss: (css: string) => string): DevCssHooks => {
+export const createDevCssHooks = (
+  sortCss: (css: string) => string,
+  getLocalCss: (id: string) => string | undefined
+): DevCssHooks => {
   let isDevServer = false;
   let sortEndpoint = `/${COMPILED_DEV_SORT_PATH}`;
   let sortEndpointPath = sortEndpoint;
@@ -65,6 +70,12 @@ export const createDevCssHooks = (sortCss: (css: string) => string): DevCssHooks
       if (source.startsWith(COMPILED_DEV_INLINE_PREFIX)) {
         const cssId = decodeModuleId(source.slice(COMPILED_DEV_INLINE_PREFIX.length));
         return cssId ? toInlineRequest(cssId) : null;
+      }
+
+      if (source.startsWith(COMPILED_DEV_LOCAL_CSS_PREFIX)) {
+        return `${RESOLVED_COMPILED_DEV_LOCAL_CSS_PREFIX}${source.slice(
+          COMPILED_DEV_LOCAL_CSS_PREFIX.length
+        )}.js`;
       }
 
       if (
@@ -185,7 +196,27 @@ export const createDevCssHooks = (sortCss: (css: string) => string): DevCssHooks
       }
 
       if (!id.startsWith(RESOLVED_COMPILED_DEV_PROXY_PREFIX) || !id.endsWith('.js')) {
-        return null;
+        if (!id.startsWith(RESOLVED_COMPILED_DEV_LOCAL_CSS_PREFIX) || !id.endsWith('.js')) {
+          return null;
+        }
+
+        const cssId = decodeModuleId(
+          id.slice(RESOLVED_COMPILED_DEV_LOCAL_CSS_PREFIX.length, -'.js'.length)
+        );
+        const css = cssId && getLocalCss(cssId);
+        if (!cssId || !css) {
+          return null;
+        }
+
+        return `
+          import { registerCompiledCss } from ${JSON.stringify(COMPILED_DEV_RUNTIME_ID)}
+
+          registerCompiledCss(${JSON.stringify(`local:${cssId}`)}, ${JSON.stringify(css)})
+
+          if (import.meta.hot) {
+            import.meta.hot.accept()
+          }
+        `;
       }
 
       const cssId = decodeModuleId(

--- a/packages/vite-plugin/src/dev-css.ts
+++ b/packages/vite-plugin/src/dev-css.ts
@@ -1,0 +1,254 @@
+import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite';
+
+const COMPILED_CSS_REQUEST = /\.compiled\.css(?:$|\?)/;
+const COMPILED_CSS_IMPORT = /\.compiled\.css$/;
+const STYLE_IMPORTER = /\.(?:css|less|sass|scss|styl|stylus|pcss|postcss|sss)(?:$|[?&])/;
+const HTML_IMPORTER = /\.html(?:$|\?)/;
+
+const COMPILED_DEV_STYLE_ID = '@compiled/vite-plugin:compiled.css';
+const COMPILED_DEV_SORT_PATH = '@compiled/vite-plugin/sort-css';
+const COMPILED_DEV_PROXY_PREFIX = 'virtual:@compiled/vite-plugin/css-proxy:';
+const RESOLVED_COMPILED_DEV_PROXY_PREFIX = `\0${COMPILED_DEV_PROXY_PREFIX}`;
+const COMPILED_DEV_INLINE_PREFIX = 'virtual:@compiled/vite-plugin/css-inline:';
+const COMPILED_DEV_RUNTIME_ID = 'virtual:@compiled/vite-plugin/css-runtime';
+const RESOLVED_COMPILED_DEV_RUNTIME_ID = `\0${COMPILED_DEV_RUNTIME_ID}`;
+const MAX_CSS_PAYLOAD_SIZE = 50_000_000;
+
+type DevCssHooks = Pick<Plugin, 'configResolved' | 'configureServer' | 'load' | 'resolveId'>;
+
+export const isCompiledCssRequest = (id: string): boolean => COMPILED_CSS_REQUEST.test(id);
+
+const encodeModuleId = (id: string): string => encodeURIComponent(id);
+const decodeModuleId = (id: string): string | undefined => {
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return undefined;
+  }
+};
+
+const toInlineRequest = (id: string): string => `${id}${id.includes('?') ? '&' : '?'}inline`;
+
+const isScriptImport = (importer: string | undefined): importer is string =>
+  Boolean(importer && !STYLE_IMPORTER.test(importer) && !HTML_IMPORTER.test(importer));
+
+const getRequestPath = (url: string): string => new URL(url, 'http://vite.local').pathname;
+
+/**
+ * Vite normally injects each CSS import into a separate style element in
+ * development. These hooks replace script imports of `.compiled.css` with
+ * JavaScript proxies. Each proxy imports Vite's fully processed CSS through
+ * the public `?inline` API and registers it in one browser-side stylesheet,
+ * allowing the complete active stylesheet to be sorted across module files.
+ */
+export const createDevCssHooks = (sortCss: (css: string) => string): DevCssHooks => {
+  let isDevServer = false;
+  let sortEndpoint = `/${COMPILED_DEV_SORT_PATH}`;
+  let sortEndpointPath = sortEndpoint;
+
+  return {
+    configResolved(config: ResolvedConfig) {
+      isDevServer = config.command === 'serve';
+      sortEndpoint = `${config.base}${COMPILED_DEV_SORT_PATH}`;
+      sortEndpointPath = getRequestPath(sortEndpoint);
+    },
+
+    async resolveId(source, importer, options) {
+      if (!isDevServer || options.ssr) {
+        return null;
+      }
+
+      if (source === COMPILED_DEV_RUNTIME_ID) {
+        return RESOLVED_COMPILED_DEV_RUNTIME_ID;
+      }
+
+      if (source.startsWith(COMPILED_DEV_INLINE_PREFIX)) {
+        const cssId = decodeModuleId(source.slice(COMPILED_DEV_INLINE_PREFIX.length));
+        return cssId ? toInlineRequest(cssId) : null;
+      }
+
+      if (
+        (options as typeof options & { scan?: boolean }).scan ||
+        !isScriptImport(importer) ||
+        !COMPILED_CSS_IMPORT.test(source)
+      ) {
+        return null;
+      }
+
+      const resolved = await this.resolve(source, importer, {
+        ...options,
+        skipSelf: true,
+      });
+      if (!resolved || resolved.external || !isCompiledCssRequest(resolved.id)) {
+        return null;
+      }
+
+      return `${RESOLVED_COMPILED_DEV_PROXY_PREFIX}${encodeModuleId(resolved.id)}.js`;
+    },
+
+    load(id, options) {
+      if (!isDevServer || options?.ssr) {
+        return null;
+      }
+
+      if (id === RESOLVED_COMPILED_DEV_RUNTIME_ID) {
+        return `
+          const styleId = ${JSON.stringify(COMPILED_DEV_STYLE_ID)}
+          const endpoint = ${JSON.stringify(sortEndpoint)}
+          const modules = new Map()
+          let requestVersion = 0
+          let scheduled = false
+
+          const getStyle = () => {
+            if (!('document' in globalThis)) return undefined
+
+            let style = document.querySelector(
+              \`style[data-compiled-vite-dev-id="\${styleId}"]\`
+            )
+            if (!style) {
+              style = document.createElement('style')
+              style.setAttribute('type', 'text/css')
+              style.setAttribute('data-compiled-vite-dev-id', styleId)
+
+              const nonceMeta = document.querySelector('meta[property="csp-nonce"]')
+              const nonce = nonceMeta?.nonce || nonceMeta?.getAttribute('nonce')
+              if (nonce) style.setAttribute('nonce', nonce)
+
+              document.head.appendChild(style)
+            }
+            return style
+          }
+
+          const updateStyle = (css) => {
+            const style = getStyle()
+            if (style) style.textContent = css
+          }
+
+          const removeStyle = () => {
+            if (!('document' in globalThis)) return
+            document
+              .querySelector(\`style[data-compiled-vite-dev-id="\${styleId}"]\`)
+              ?.remove()
+          }
+
+          const scheduleUpdate = () => {
+            requestVersion += 1
+            if (scheduled) return
+            scheduled = true
+
+            Promise.resolve().then(async () => {
+              scheduled = false
+              const request = requestVersion
+              const styles = [...modules.values()]
+
+              if (styles.length === 0) {
+                removeStyle()
+                return
+              }
+
+              try {
+                const response = await fetch(endpoint, {
+                  method: 'POST',
+                  headers: {
+                    Accept: 'text/css',
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify(styles),
+                })
+                if (!response.ok) throw new Error(await response.text())
+
+                const css = await response.text()
+                if (request === requestVersion) updateStyle(css)
+              } catch (error) {
+                if (request !== requestVersion) return
+                updateStyle(styles.join('\\n'))
+                console.warn(
+                  '[@compiled/vite-plugin] Failed to sort development CSS',
+                  error
+                )
+              }
+            })
+          }
+
+          export const registerCompiledCss = (id, css) => {
+            if (modules.get(id) === css) return
+            if (modules.size === 0) getStyle()
+            modules.set(id, css)
+            scheduleUpdate()
+          }
+
+          export const unregisterCompiledCss = (id) => {
+            if (!modules.delete(id)) return
+            scheduleUpdate()
+          }
+        `;
+      }
+
+      if (!id.startsWith(RESOLVED_COMPILED_DEV_PROXY_PREFIX) || !id.endsWith('.js')) {
+        return null;
+      }
+
+      const cssId = decodeModuleId(
+        id.slice(RESOLVED_COMPILED_DEV_PROXY_PREFIX.length, -'.js'.length)
+      );
+      if (!cssId) {
+        return null;
+      }
+      const inlineModuleId = `${COMPILED_DEV_INLINE_PREFIX}${encodeModuleId(cssId)}`;
+
+      return `
+        import css from ${JSON.stringify(inlineModuleId)}
+        import {
+          registerCompiledCss,
+          unregisterCompiledCss,
+        } from ${JSON.stringify(COMPILED_DEV_RUNTIME_ID)}
+
+        const id = ${JSON.stringify(cssId)}
+        registerCompiledCss(id, css)
+
+        if (import.meta.hot) {
+          import.meta.hot.accept()
+          import.meta.hot.prune(() => unregisterCompiledCss(id))
+        }
+
+        export default css
+      `;
+    },
+
+    configureServer(server: ViteDevServer) {
+      server.middlewares.use(async (request, response, next) => {
+        if (
+          request.method !== 'POST' ||
+          !request.url ||
+          getRequestPath(request.url) !== sortEndpointPath
+        ) {
+          next();
+          return;
+        }
+
+        try {
+          let body = '';
+          for await (const chunk of request) {
+            body += chunk;
+            if (body.length > MAX_CSS_PAYLOAD_SIZE) {
+              throw new Error('CSS payload exceeds 50 MB');
+            }
+          }
+
+          const styles = JSON.parse(body);
+          if (!Array.isArray(styles) || styles.some((style) => typeof style !== 'string')) {
+            throw new Error('Expected an array of CSS strings');
+          }
+
+          response.statusCode = 200;
+          response.setHeader('Content-Type', 'text/css');
+          response.end(sortCss(styles.join('\n')));
+        } catch (error) {
+          const err = error as Error;
+          response.statusCode = 400;
+          response.end(`[@compiled/vite-plugin] Failed to sort development CSS: ${err.message}`);
+        }
+      });
+    },
+  };
+};

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -7,7 +7,9 @@ import type {
 import { sort } from '@compiled/css';
 import { DEFAULT_IMPORT_SOURCES, DEFAULT_PARSER_BABEL_PLUGINS, toBoolean } from '@compiled/utils';
 import type { OutputAsset, OutputBundle } from 'rollup';
+import type { HtmlTagDescriptor, Plugin } from 'vite';
 
+import { createDevCssHooks, isCompiledCssRequest } from './dev-css.js';
 import type { PluginOptions } from './types';
 import { createDefaultResolver } from './utils.js';
 
@@ -47,7 +49,7 @@ const sortStyleRulesForDeterministicOutput = (styleRules: string[]): string[] =>
  * @param userOptions - Plugin configuration options
  * @returns Vite plugin object
  */
-function compiled(userOptions: PluginOptions = {}): any {
+function compiled(userOptions: PluginOptions = {}): Plugin {
   const options: PluginOptions = {
     // Vite-specific
     bake: true,
@@ -96,11 +98,12 @@ function compiled(userOptions: PluginOptions = {}): any {
   const EXTRACTED_CSS_NAME = 'compiled-extracted.css';
 
   return {
+    ...createDevCssHooks(sortCompiledCss),
     name: '@compiled/vite-plugin',
     enforce: 'pre', // Run before other plugins
 
     async transform(code: string, id: string): Promise<any> {
-      if (id.endsWith('.compiled.css') && code.includes('._')) {
+      if (isCompiledCssRequest(id) && code.includes('._')) {
         try {
           return {
             code: sortCompiledCss(code),
@@ -289,7 +292,7 @@ function compiled(userOptions: PluginOptions = {}): any {
     transformIndexHtml(
       _html: string,
       ctx: { bundle?: OutputBundle; [key: string]: any }
-    ): { tag: string; attrs: Record<string, string>; injectTo: string }[] {
+    ): HtmlTagDescriptor[] {
       // Inject the extracted CSS file into HTML if it was emitted
       if (!extractedCssFileName || !ctx.bundle) {
         return [];

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -263,7 +263,13 @@ function compiled(userOptions: PluginOptions = {}): any {
               : '';
           return {
             code: `${localCssImport}${result.code}`,
-            map: localCssImport ? null : result.map ?? null,
+            map:
+              localCssImport && result.map
+                ? {
+                    ...result.map,
+                    mappings: `;${result.map.mappings}`,
+                  }
+                : result.map ?? null,
           };
         }
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -76,6 +76,12 @@ function compiled(userOptions: PluginOptions = {}): any {
     ...userOptions,
   };
 
+  const sortCompiledCss = (css: string): string =>
+    sort(css, {
+      sortAtRulesEnabled: options.sortAtRules,
+      sortShorthandEnabled: options.sortShorthand,
+    });
+
   // Storage for collected style rules during transformation
   // Map of filePath → array of style rules (in source order from the babel
   // transform). We sort by filePath at extraction time for cross-file
@@ -94,6 +100,21 @@ function compiled(userOptions: PluginOptions = {}): any {
     enforce: 'pre', // Run before other plugins
 
     async transform(code: string, id: string): Promise<any> {
+      if (id.endsWith('.compiled.css') && code.includes('._')) {
+        try {
+          return {
+            code: sortCompiledCss(code),
+            map: null,
+          };
+        } catch (error) {
+          const err = error as Error;
+          this.warn({
+            message: `[@compiled/vite-plugin] Failed to sort CSS in ${id}: ${err.message}`,
+          });
+          return null;
+        }
+      }
+
       // Filter out node_modules (except for specific includes if needed)
       if (id.includes('/node_modules/@compiled/react')) {
         return null;
@@ -216,16 +237,8 @@ function compiled(userOptions: PluginOptions = {}): any {
         // This is a heuristic to identify CSS that came from .compiled.css files
         if (cssContent.includes('._')) {
           try {
-            // Apply Compiled's CSS sorting and deduplication
-            const sortConfig = {
-              sortAtRulesEnabled: options.sortAtRules,
-              sortShorthandEnabled: options.sortShorthand,
-            };
-
-            const sortedCss = sort(cssContent, sortConfig);
-
             // Update the asset with sorted CSS
-            asset.source = sortedCss;
+            asset.source = sortCompiledCss(cssContent);
           } catch (error) {
             const err = error as Error;
             this.warn({
@@ -252,19 +265,13 @@ function compiled(userOptions: PluginOptions = {}): any {
 
           // Join all rules and apply CSS sorting
           const combinedCss = allRules.join('\n');
-          const sortConfig = {
-            sortAtRulesEnabled: options.sortAtRules,
-            sortShorthandEnabled: options.sortShorthand,
-          };
-
-          const sortedCss = sort(combinedCss, sortConfig);
 
           // Emit the CSS file with content-based naming
           // Vite will add a content hash to the filename automatically
           this.emitFile({
             type: 'asset',
             name: EXTRACTED_CSS_NAME,
-            source: sortedCss,
+            source: sortCompiledCss(combinedCss),
           });
 
           // Mark that we've emitted the file so transformIndexHtml can inject it

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -97,10 +97,22 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
   // Name used for the extracted CSS asset
   const EXTRACTED_CSS_NAME = 'compiled-extracted.css';
 
+  // Local source normally relies on the Compiled runtime in development. Keep
+  // those atomic rules in the same stylesheet as imported `.compiled.css`
+  // modules so the cascade is deterministic across both sources.
+  const localDevCssByFile = new Map<string, string>();
+  let isDevServer = false;
+  const devCssHooks = createDevCssHooks(sortCompiledCss, (id) => localDevCssByFile.get(id));
+
   return {
-    ...createDevCssHooks(sortCompiledCss),
+    ...devCssHooks,
     name: '@compiled/vite-plugin',
     enforce: 'pre', // Run before other plugins
+
+    configResolved(config) {
+      isDevServer = config.command === 'serve';
+      devCssHooks.configResolved?.(config);
+    },
 
     async transform(code: string, id: string): Promise<any> {
       if (isCompiledCssRequest(id) && code.includes('._')) {
@@ -155,12 +167,16 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
           return null;
         }
 
-        // Disable stylesheet extraction in development mode
-        const isDevelopment = process.env.NODE_ENV === 'development';
+        // Production extraction writes a CSS asset. In development we instead
+        // strip the runtime and register this module's rules with the virtual
+        // stylesheet that also contains pre-built package CSS.
+        const isDevelopment = process.env.NODE_ENV !== 'production';
         const extract = options.extract && !isDevelopment;
+        const stripRuntime = extract || isDevServer;
 
-        // Transform using the Compiled Babel Plugin
-        const result = await transformFromAstAsync(ast, code, {
+        // First compile the source. Runtime stripping must be a separate
+        // transform so it can observe the JSX calls emitted by Compiled.
+        const compiledResult = await transformFromAstAsync(ast, code, {
           babelrc: false,
           configFile: false,
           sourceMaps: true,
@@ -179,34 +195,69 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
                 cache: false,
               } as BabelPluginOptions,
             ],
-            extract && [
-              '@compiled/babel-plugin-strip-runtime',
-              {
-                compiledRequireExclude: options.ssr || extract,
-                extractStylesToDirectory: options.extractStylesToDirectory,
-              } as BabelStripRuntimePluginOptions,
-            ],
           ].filter(toBoolean),
           caller: {
             name: 'compiled',
           },
         });
 
-        // Store metadata for CSS extraction if enabled
-        if (extract && result?.metadata) {
+        let result = compiledResult;
+        if (stripRuntime && compiledResult?.code) {
+          const compiledAst = await parseAsync(compiledResult.code, {
+            filename: id,
+            babelrc: false,
+            configFile: false,
+            caller: { name: 'compiled' },
+            rootMode: 'upward-optional',
+            parserOpts: {
+              plugins: options.parserBabelPlugins ?? DEFAULT_PARSER_BABEL_PLUGINS,
+            },
+          });
+
+          result = compiledAst
+            ? await transformFromAstAsync(compiledAst, compiledResult.code, {
+                babelrc: false,
+                configFile: false,
+                sourceMaps: true,
+                filename: id,
+                plugins: [
+                  [
+                    '@compiled/babel-plugin-strip-runtime',
+                    {
+                      compiledRequireExclude: true,
+                      extractStylesToDirectory: options.extractStylesToDirectory,
+                    } as BabelStripRuntimePluginOptions,
+                  ],
+                ],
+                caller: { name: 'compiled' },
+              })
+            : compiledResult;
+        }
+
+        // Store metadata for CSS extraction if enabled.
+        if (stripRuntime && result?.metadata) {
           const metadata = result.metadata as BabelFileMetadata;
           // Collect style rules from this file, keyed by filePath for
           // cross-file deterministic ordering at extraction time.
           if (metadata.styleRules && metadata.styleRules.length > 0) {
             collectedStyleRulesByFile.set(id, metadata.styleRules.slice());
+            if (isDevServer) {
+              localDevCssByFile.set(id, metadata.styleRules.join('\n'));
+            }
           }
         }
 
         // Return transformed code and source map
         if (result?.code) {
+          const localCssImport =
+            isDevServer && localDevCssByFile.has(id)
+              ? `import ${JSON.stringify(
+                  `virtual:@compiled/vite-plugin/local-css:${encodeURIComponent(id)}`
+                )};\n`
+              : '';
           return {
-            code: result.code,
-            map: result.map ?? null,
+            code: `${localCssImport}${result.code}`,
+            map: localCssImport ? null : result.map ?? null,
           };
         }
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -7,7 +7,6 @@ import type {
 import { sort } from '@compiled/css';
 import { DEFAULT_IMPORT_SOURCES, DEFAULT_PARSER_BABEL_PLUGINS, toBoolean } from '@compiled/utils';
 import type { OutputAsset, OutputBundle } from 'rollup';
-import type { HtmlTagDescriptor, Plugin } from 'vite';
 
 import { createDevCssHooks, isCompiledCssRequest } from './dev-css.js';
 import type { PluginOptions } from './types';
@@ -49,7 +48,7 @@ const sortStyleRulesForDeterministicOutput = (styleRules: string[]): string[] =>
  * @param userOptions - Plugin configuration options
  * @returns Vite plugin object
  */
-function compiled(userOptions: PluginOptions = {}): Plugin {
+function compiled(userOptions: PluginOptions = {}): any {
   const options: PluginOptions = {
     // Vite-specific
     bake: true,
@@ -109,13 +108,15 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
     name: '@compiled/vite-plugin',
     enforce: 'pre', // Run before other plugins
 
-    configResolved(config) {
+    configResolved(config: { base: string; command: string }) {
       isDevServer = config.command === 'serve';
-      devCssHooks.configResolved?.(config);
+      devCssHooks.configResolved(config);
     },
 
-    async transform(code: string, id: string): Promise<any> {
-      if (isCompiledCssRequest(id) && code.includes('._')) {
+    async transform(code: string, id: string, transformOptions?: { ssr?: boolean }): Promise<any> {
+      const isClientDevTransform = isDevServer && !transformOptions?.ssr;
+
+      if (isClientDevTransform && isCompiledCssRequest(id) && code.includes('._')) {
         try {
           return {
             code: sortCompiledCss(code),
@@ -167,12 +168,10 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
           return null;
         }
 
-        // Production extraction writes a CSS asset. In development we instead
-        // strip the runtime and register this module's rules with the virtual
-        // stylesheet that also contains pre-built package CSS.
-        const isDevelopment = process.env.NODE_ENV !== 'production';
-        const extract = options.extract && !isDevelopment;
-        const stripRuntime = extract || isDevServer;
+        // Build extraction follows the explicit option regardless of NODE_ENV.
+        // Client-side dev transforms force extraction so local rules can join
+        // the virtual stylesheet; dev SSR keeps its existing runtime behavior.
+        const extract = isClientDevTransform || (options.extract && !isDevServer);
 
         // First compile the source. Runtime stripping must be a separate
         // transform so it can observe the JSX calls emitted by Compiled.
@@ -202,7 +201,7 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
         });
 
         let result = compiledResult;
-        if (stripRuntime && compiledResult?.code) {
+        if (extract && compiledResult?.code) {
           const compiledAst = await parseAsync(compiledResult.code, {
             filename: id,
             babelrc: false,
@@ -219,6 +218,7 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
                 babelrc: false,
                 configFile: false,
                 sourceMaps: true,
+                inputSourceMap: compiledResult.map ?? undefined,
                 filename: id,
                 plugins: [
                   [
@@ -234,14 +234,19 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
             : compiledResult;
         }
 
-        // Store metadata for CSS extraction if enabled.
-        if (stripRuntime && result?.metadata) {
+        // Store metadata for CSS extraction if enabled. Clear the previous
+        // local value first so HMR updates that remove all styles do not keep
+        // registering stale CSS.
+        if (isClientDevTransform) {
+          localDevCssByFile.delete(id);
+        }
+        if (extract && result?.metadata) {
           const metadata = result.metadata as BabelFileMetadata;
           // Collect style rules from this file, keyed by filePath for
           // cross-file deterministic ordering at extraction time.
           if (metadata.styleRules && metadata.styleRules.length > 0) {
             collectedStyleRulesByFile.set(id, metadata.styleRules.slice());
-            if (isDevServer) {
+            if (isClientDevTransform) {
               localDevCssByFile.set(id, metadata.styleRules.join('\n'));
             }
           }
@@ -250,7 +255,7 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
         // Return transformed code and source map
         if (result?.code) {
           const localCssImport =
-            isDevServer && localDevCssByFile.has(id)
+            isClientDevTransform && localDevCssByFile.has(id)
               ? `import ${JSON.stringify(
                   `virtual:@compiled/vite-plugin/local-css:${encodeURIComponent(id)}`
                 )};\n`
@@ -274,8 +279,7 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
 
     generateBundle(_outputOptions: any, bundle: OutputBundle) {
       // Post-process CSS assets to apply Compiled's sorting and deduplication
-      const isDevelopment = process.env.NODE_ENV === 'development';
-      const extract = options.extract && !isDevelopment;
+      const extract = options.extract;
 
       // Process each CSS asset in the bundle
       for (const [fileName, output] of Object.entries(bundle)) {
@@ -343,7 +347,7 @@ function compiled(userOptions: PluginOptions = {}): Plugin {
     transformIndexHtml(
       _html: string,
       ctx: { bundle?: OutputBundle; [key: string]: any }
-    ): HtmlTagDescriptor[] {
+    ): { tag: string; attrs: Record<string, string>; injectTo: string }[] {
       // Inject the extracted CSS file into HTML if it was emitted
       if (!extractedCssFileName || !ctx.bundle) {
         return [];

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -226,6 +226,7 @@ function compiled(userOptions: PluginOptions = {}): any {
                     {
                       compiledRequireExclude: true,
                       extractStylesToDirectory: options.extractStylesToDirectory,
+                      processJsxDev: isClientDevTransform,
                     } as BabelStripRuntimePluginOptions,
                   ],
                 ],


### PR DESCRIPTION
Builds on #1916 to include local Compiled runtime styles in the same development stylesheet as imported `.compiled.css` modules. This prevents a later runtime-injected atomic rule from overriding a responsive rule from a package stylesheet.\n\nIt also strips React `jsxDEV` output so local development styles can be collected.\n\nValidation: `yarn jest packages/babel-plugin-strip-runtime/src/__tests__/strip-runtime-transpiled-code.test.ts packages/vite-plugin/src/__tests__/plugin.test.ts packages/vite-plugin/src/__tests__/dev-css.test.ts --runInBand --watchman=false`.