### PR TITLE
fix: performance optimisation for insertRule, replacing appendChild with sheet.insertRule

### DIFF
--- a/.changeset/fuzzy-mirrors-listen.md
+++ b/.changeset/fuzzy-mirrors-listen.md
@@ -1,0 +1,5 @@
+---
+'@compiled/jest': minor
+---
+
+`toHaveCompiledCss` now reads rules back off the stylesheet (`sheet.cssRules`) when a `<style>` element has no text content. The browser runtime injects rules with `sheet.insertRule()`, a CSSOM-only mutation that leaves `textContent` empty, so the matcher previously found no styles to match against. Server-rendered styles and non-atomic `cssMapScoped` rules still live in a text node and are read from there as before.

--- a/.changeset/heavy-pianos-behave.md
+++ b/.changeset/heavy-pianos-behave.md
@@ -1,0 +1,10 @@
+---
+'@compiled/react': major
+---
+
+Atomic rules are now injected with `sheet.insertRule()` in every environment. Previously only production used the CSSOM; development and test builds appended a text node per rule, which forces the engine to reparse the whole sheet on every insertion.
+
+Two consequences of dev and test now behaving like production:
+
+- **`<style>` elements no longer contain text.** `insertRule` is a CSSOM-only mutation, so `styleElement.textContent` and `document.head.innerHTML` come back empty and the rules must be read off `sheet.cssRules`. Tests asserting on injected CSS via the DOM's text need updating; `toHaveCompiledCss` from `@compiled/jest` handles both sources as of the accompanying patch. In devtools, dev-mode `<style>` tags now render as empty, the same as production — inspect the element's CSSOM to see the rules.
+- **Dev no longer diverges from production.** The previous fork meant CSSOM-specific bugs could only surface in production builds; both paths are now identical by construction.

--- a/packages/jest/src/matchers.ts
+++ b/packages/jest/src/matchers.ts
@@ -28,6 +28,31 @@ const mapProperties = (properties: Record<string, any>) =>
 
 const onlyRules = (rules?: CssAtRuleAST[]) => rules?.filter((r) => r.type === 'rule');
 
+/**
+ * Reads the CSS text out of a `<style>` element.
+ *
+ * The browser runtime injects rules with `sheet.insertRule()`, a CSSOM-only mutation
+ * that leaves the element's `textContent` empty — so those rules have to be read back
+ * off the sheet. Server-rendered styles and non-atomic `cssMapScoped` rules still live
+ * in a text node, hence the `textContent` is preferred when present.
+ *
+ * Preferring text is only safe because no `<style>` ever holds CSS in both places:
+ * atomic rules go exclusively through `insertRule`, non-atomic ones exclusively through
+ * `Text.appendData` on the dedicated `cc` bucket, and the two never share an element
+ * (see `styleBucketOrdering` and `insertNonAtomicRule` in `react/src/runtime/sheet.ts`).
+ * Atomic buckets are created holding an *empty* text node, which is falsy and so falls
+ * through to the sheet.
+ */
+const getCssText = (styleElement: HTMLStyleElement): string => {
+  if (styleElement.textContent) {
+    return styleElement.textContent;
+  }
+
+  const { sheet } = styleElement;
+
+  return sheet ? Array.from(sheet.cssRules, (rule) => rule.cssText).join('') : '';
+};
+
 const findMediaRules = (
   allRules: CssAtRuleAST[] = [],
   media: string
@@ -135,7 +160,7 @@ export function toHaveCompiledCss(
   const classNames = element.classList;
 
   for (const styleElement of styleElements) {
-    let css = styleElement.textContent || '';
+    let css = getCssText(styleElement);
     // This is a hack to get ahold of the styles.
     // Unfortunately JSDOM doesn't handle css variables properly
     // See: https://github.com/jsdom/jsdom/issues/1895

--- a/packages/react/src/__tests__/browser.test.tsx
+++ b/packages/react/src/__tests__/browser.test.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 
 import Style from '../runtime/style';
 
+import { getAllCssText, getStyleCssTexts } from './utils/css-text';
+
 jest.mock('../runtime/is-server-environment', () => ({
   isServerEnvironment: () => false,
 }));
@@ -12,9 +14,18 @@ jest.mock('../runtime/is-server-environment', () => ({
 describe('browser', () => {
   beforeEach(() => {
     // Reset style tags in head before each test so that it will remove styles
-    // injected by test
+    // injected by test. Clearing `textContent` alone is not enough: it only clears the
+    // sheet as a side effect of removing a child text node, and `insertRule` never
+    // creates one — so after the first reset there is nothing left to remove and the
+    // rules survive. The elements themselves must stay, as the runtime caches its style
+    // buckets in a module-level singleton.
     document.head.querySelectorAll('style').forEach((styleElement) => {
       styleElement.textContent = '';
+
+      const { sheet } = styleElement;
+      while (sheet && sheet.cssRules.length > 0) {
+        sheet.deleteRule(sheet.cssRules.length - 1);
+      }
     });
   });
 
@@ -42,9 +53,7 @@ describe('browser', () => {
       </>
     );
 
-    expect(document.head.innerHTML).toMatchInlineSnapshot(
-      `"<style nonce="k0Mp1lEd">._4ya3eEEbN9{font-size:14px}</style>"`
-    );
+    expect(getAllCssText()).toMatchInlineSnapshot(`"._4ya3eEEbN9 {font-size: 14px;}"`);
   });
 
   it('should render style tags in buckets', () => {
@@ -95,16 +104,17 @@ describe('browser', () => {
 
     render(<StyledLink href="https://atlassian.design">Atlassian Design System</StyledLink>);
 
-    expect(document.head.innerHTML.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
-      "<style nonce="k0Mp1lEd">._3iDTPbQ4SZ{display:flex}._4ya3eEHMkp{font-size:50px}._1UtDYz5CUP{color:purple}</style>
-      <style nonce="k0Mp1lEd">._2ipzJpGowl:link{color:red}._2ipzJpaJpK:link{color:white}</style>
-      <style nonce="k0Mp1lEd">._2nTuUYy8mA:visited{color:pink}</style>
-      <style nonce="k0Mp1lEd">._10n1R5Jwxv:focus{color:green}</style>
-      <style nonce="k0Mp1lEd">._22XfGnaJpK:focus-visible{color:white}</style>
-      <style nonce="k0Mp1lEd">._0clgaMFQV5:hover{color:yellow}</style>
-      <style nonce="k0Mp1lEd">._0CMRbkynoA:active{color:blue}</style>
-      <style nonce="k0Mp1lEd">@media (max-width:800px){._3YxZqqFQV5:focus{color:yellow}._1h21S5okCM:focus-visible{color:grey}._0oG7IkokCM:hover{color:grey}._3cQMScbqW0:active{color:black}}@supports (display:grid){._3geGi3FQV5:focus{color:yellow}._0vra6NbqW0:active{color:black}}</style>
-      "
+    expect(getStyleCssTexts()).toMatchInlineSnapshot(`
+      [
+        "._3iDTPbQ4SZ {display: flex;}._4ya3eEHMkp {font-size: 50px;}._1UtDYz5CUP {color: purple;}",
+        "._2ipzJpGowl:link {color: red;}._2ipzJpaJpK:link {color: white;}",
+        "._2nTuUYy8mA:visited {color: pink;}",
+        "._10n1R5Jwxv:focus {color: green;}",
+        "._22XfGnaJpK:focus-visible {color: white;}",
+        "._0clgaMFQV5:hover {color: yellow;}",
+        "._0CMRbkynoA:active {color: blue;}",
+        "@media (max-width:800px) {._3YxZqqFQV5:focus {color: yellow;}._1h21S5okCM:focus-visible {color: grey;}._0oG7IkokCM:hover {color: grey;}._3cQMScbqW0:active {color: black;}}@supports (display:grid) {._3geGi3FQV5:focus {color: yellow;}._0vra6NbqW0:active {color: black;}}",
+      ]
     `);
   });
 
@@ -132,13 +142,11 @@ describe('browser', () => {
     // The `m` bucket precedes the `cc` bucket in `styleBucketOrdering`, so the
     // atomic-`m` `<style>` appears first in `document.head`, then the `cc`
     // `<style>` — the cascade contract for `.cc-` (last-in-head) is preserved.
-    const styleTexts = Array.from(document.head.querySelectorAll('style'))
-      .map((s) => s.textContent ?? '')
-      .filter((t) => t.length > 0);
+    const styleTexts = getStyleCssTexts().filter((t) => t.length > 0);
     expect(styleTexts).toMatchInlineSnapshot(`
       [
-        "@media (min-width:1px){._bbbbbbbb{color:blue}}",
-        "@media (min-width:1px){.cc-zzzzzz .panel{background:gray}}@media (min-width:1px){.cc-aaaaaa .panel{background:pink}}",
+        "@media (min-width:1px) {._bbbbbbbb {color: blue;}}",
+        "@media (min-width:1px) {.cc-zzzzzz .panel {background: gray;}}@media (min-width:1px) {.cc-aaaaaa .panel {background: pink;}}",
       ]
     `);
   });

--- a/packages/react/src/__tests__/utils/css-text.ts
+++ b/packages/react/src/__tests__/utils/css-text.ts
@@ -1,0 +1,12 @@
+// `sheet.cssRules` reflects rules added via `insertRule` (atomic buckets) as well as
+// rules added as text (the non-atomic `cc` bucket, SSR), so it reads back both paths.
+// The text comes back in the CSSOM's formatting, not Compiled's.
+
+/** The CSS of each `<style>` in `root`, one string per element, in document order. */
+export const getStyleCssTexts = (root: ParentNode = document.head): string[] =>
+  Array.from(root.querySelectorAll('style'), (style) =>
+    Array.from(style.sheet?.cssRules ?? [], (rule) => rule.cssText).join('')
+  );
+
+/** The CSS of every `<style>` in `root`, concatenated. */
+export const getAllCssText = (root?: ParentNode): string => getStyleCssTexts(root).join('');

--- a/packages/react/src/keyframes/__tests__/index.test.tsx
+++ b/packages/react/src/keyframes/__tests__/index.test.tsx
@@ -3,6 +3,7 @@
 import { keyframes, styled, css } from '@compiled/react';
 import { render } from '@testing-library/react';
 
+import { getStyleCssTexts } from '../../__tests__/utils/css-text';
 import defaultFadeOut, { namedFadeOut, fadeOut as shadowedFadeOut } from '../__fixtures__';
 
 const getOpacity = (str: string | number) => str;
@@ -10,7 +11,8 @@ const getOpacity = (str: string | number) => str;
 const getKeyframe = (name: string) => {
   const searchStr = `@keyframes ${name}`;
 
-  return Array.from(document.head.querySelectorAll('style'), (style) => style.innerHTML)
+  return getStyleCssTexts()
+    .map((style) => style.replace(/\s+/g, ' '))
     .filter((style) => style.indexOf(searchStr) >= 0)
     .map((style) => style.substring(style.indexOf(searchStr)))
     .join('\n');
@@ -49,7 +51,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1m8j3od');
         expect(getKeyframe('k1m8j3od')).toMatchInlineSnapshot(
-          `"@keyframes k1m8j3od{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1m8j3od { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -59,7 +61,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'klmf72q');
         expect(getKeyframe('klmf72q')).toMatchInlineSnapshot(
-          `"@keyframes klmf72q{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes klmf72q { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -69,7 +71,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1b0zjii');
         expect(getKeyframe('k1b0zjii')).toMatchInlineSnapshot(
-          `"@keyframes k1b0zjii{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1b0zjii { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -83,7 +85,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1vk0ha6');
         expect(getKeyframe('k1vk0ha6')).toMatchInlineSnapshot(
-          `"@keyframes k1vk0ha6{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1vk0ha6 { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -94,7 +96,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1m8j3od');
         expect(getKeyframe('k1m8j3od')).toMatchInlineSnapshot(
-          `"@keyframes k1m8j3od{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1m8j3od { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -103,7 +105,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1m8j3od');
         expect(getKeyframe('k1m8j3od')).toMatchInlineSnapshot(
-          `"@keyframes k1m8j3od{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1m8j3od { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -114,7 +116,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1m8j3od');
         expect(getKeyframe('k1m8j3od')).toMatchInlineSnapshot(
-          `"@keyframes k1m8j3od{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1m8j3od { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -135,7 +137,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'kbrsk95');
         expect(getKeyframe('kbrsk95')).toMatchInlineSnapshot(
-          `"@keyframes kbrsk95{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes kbrsk95 { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -156,7 +158,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'korwhog');
         expect(getKeyframe('korwhog')).toMatchInlineSnapshot(
-          `"@keyframes korwhog{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes korwhog { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -177,7 +179,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'korwhog');
         expect(getKeyframe('korwhog')).toMatchInlineSnapshot(
-          `"@keyframes korwhog{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes korwhog { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -203,7 +205,7 @@ describe('keyframes', () => {
           opacity: 'var(--opacity)',
         });
         expect(getKeyframe('k1sm7npi')).toMatchInlineSnapshot(
-          `"@keyframes k1sm7npi{0%{--opacity:1px}to{--opacity:0}}"`
+          `"@keyframes k1sm7npi { 0% {--opacity: 1px;} to {--opacity: 0;} }"`
         );
       });
     });
@@ -227,7 +229,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1m8j3od');
         expect(getKeyframe('k1m8j3od')).toMatchInlineSnapshot(
-          `"@keyframes k1m8j3od{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1m8j3od { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -238,7 +240,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'klmf72q');
         expect(getKeyframe('klmf72q')).toMatchInlineSnapshot(
-          `"@keyframes klmf72q{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes klmf72q { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -249,7 +251,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1b0zjii');
         expect(getKeyframe('k1b0zjii')).toMatchInlineSnapshot(
-          `"@keyframes k1b0zjii{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1b0zjii { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -264,7 +266,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1vk0ha6');
         expect(getKeyframe('k1vk0ha6')).toMatchInlineSnapshot(
-          `"@keyframes k1vk0ha6{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1vk0ha6 { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -274,7 +276,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1m8j3od');
         expect(getKeyframe('k1m8j3od')).toMatchInlineSnapshot(
-          `"@keyframes k1m8j3od{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1m8j3od { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -284,7 +286,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1m8j3od');
         expect(getKeyframe('k1m8j3od')).toMatchInlineSnapshot(
-          `"@keyframes k1m8j3od{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1m8j3od { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -294,7 +296,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'k1m8j3od');
         expect(getKeyframe('k1m8j3od')).toMatchInlineSnapshot(
-          `"@keyframes k1m8j3od{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes k1m8j3od { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -316,7 +318,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'kbrsk95');
         expect(getKeyframe('kbrsk95')).toMatchInlineSnapshot(
-          `"@keyframes kbrsk95{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes kbrsk95 { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -338,7 +340,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'korwhog');
         expect(getKeyframe('korwhog')).toMatchInlineSnapshot(
-          `"@keyframes korwhog{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes korwhog { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
 
@@ -360,7 +362,7 @@ describe('keyframes', () => {
 
         expect(getByText('hello world')).toHaveCompiledCss('animation-name', 'korwhog');
         expect(getKeyframe('korwhog')).toMatchInlineSnapshot(
-          `"@keyframes korwhog{0%{opacity:1}to{opacity:0}}"`
+          `"@keyframes korwhog { 0% {opacity: 1;} to {opacity: 0;} }"`
         );
       });
     });

--- a/packages/react/src/runtime/__tests__/style.test.tsx
+++ b/packages/react/src/runtime/__tests__/style.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import type { ComponentType } from 'react';
 
+import { getAllCssText, getStyleCssTexts } from '../../__tests__/utils/css-text';
 import StyleWithContainer from '../style';
 import { StyleContainerProvider } from '../style-container';
 import type * as StyleContainerModule from '../style-container';
@@ -47,7 +48,7 @@ describe('<Style />', () => {
     createIsolatedTest((Style) => {
       render(<Style>{[`.b { display: block; }`]}</Style>);
 
-      expect(document.head.innerHTML).toInclude('<style>.b { display: block; }</style>');
+      expect(getAllCssText()).toInclude('.b {display: block;}');
       expect(console.error).not.toHaveBeenCalled();
     });
   });
@@ -57,7 +58,7 @@ describe('<Style />', () => {
       render(<Style>{[`.c { display: block; }`]}</Style>);
       render(<Style>{[`.c { display: block; }`]}</Style>);
 
-      expect(document.head.innerHTML).toIncludeRepeated('<style>.c { display: block; }</style>', 1);
+      expect(getAllCssText()).toIncludeRepeated('.c {display: block;}', 1);
       expect(console.error).not.toHaveBeenCalled();
     });
   });
@@ -114,17 +115,18 @@ describe('<Style />', () => {
         </Style>
       );
 
-      expect(document.head.innerHTML.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
-        "<style>._d1234567{ display: block; }</style>
-        <style>._c1234567:link{ color: green; }</style>
-        <style>._g1234567:visited{ color: grey; }</style>
-        <style>._i1234567:focus-within{ color: black; }</style>
-        <style>._f1234567:focus{ color: pink; }</style>
-        <style>._h1234567:focus-visible{ color: white; }</style>
-        <style>._a1234567:hover{ color: red; }</style>
-        <style>._b1234567:active{ color: blue; }</style>
-        <style>@media (max-width: 800px){ ._e1234567{ color: yellow; } }</style>
-        "
+      expect(getStyleCssTexts()).toMatchInlineSnapshot(`
+        [
+          "._d1234567 {display: block;}",
+          "._c1234567:link {color: green;}",
+          "._g1234567:visited {color: grey;}",
+          "._i1234567:focus-within {color: black;}",
+          "._f1234567:focus {color: pink;}",
+          "._h1234567:focus-visible {color: white;}",
+          "._a1234567:hover {color: red;}",
+          "._b1234567:active {color: blue;}",
+          "@media (max-width: 800px) {._e1234567 {color: yellow;}}",
+        ]
       `);
       expect(console.error).not.toHaveBeenCalled();
     });
@@ -159,16 +161,17 @@ describe('<Style />', () => {
           ]}
         </Style>
       );
-      expect(document.head.innerHTML.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
-        "<style>._a1234567{ all: unset; }</style>
-        <style>._b1234567{ border: solid 1px blue; }._j1234567{ padding: 5px; }</style>
-        <style>._k1234567{ padding-block: 6px; }._l1234567{ padding-inline: 7px; }</style>
-        <style>._c1234567{ border-block: solid 2px blue; }._g1234567{ border-inline: solid 5px blue; }</style>
-        <style>._e1234567{ border-bottom: solid 4px blue; }._h1234567{ border-top: solid 6px blue; }</style>
-        <style>._d1234567{ border-block-end: solid 3px blue; }</style>
-        <style>._i1234567{ border-top-color: pink; }._m1234567{ padding-top: 8px; }</style>
-        <style>._a1234567:hover{ all: revert; }._g1234567:hover{ border-inline: solid 5px blue; }._k1234567:hover{ padding-block: 6px; }._l1234567:hover{ padding-inline: 7px; }._j1234567:hover{ padding: 5px; }</style>
-        "
+      expect(getStyleCssTexts()).toMatchInlineSnapshot(`
+        [
+          "._a1234567 {all: unset;}",
+          "._b1234567 {border: solid 1px blue;}._j1234567 {padding: 5px;}",
+          "._k1234567 {padding-block: 6px;}._l1234567 {padding-inline: 7px;}",
+          "._c1234567 {border-block: solid 2px blue;}._g1234567 {border-inline: solid 5px blue;}",
+          "._e1234567 {border-bottom: solid 4px blue;}._h1234567 {border-top: solid 6px blue;}",
+          "._d1234567 {border-block-end: solid 3px blue;}",
+          "._i1234567 {border-top-color: pink;}._m1234567 {padding-top: 8px;}",
+          "._a1234567:hover {all: revert;}._g1234567:hover {border-inline: solid 5px blue;}._k1234567:hover {padding-block: 6px;}._l1234567:hover {padding-inline: 7px;}._j1234567:hover {padding: 5px;}",
+        ]
       `);
       expect(console.error).not.toHaveBeenCalled();
     });
@@ -180,28 +183,12 @@ describe('<Style />', () => {
 
       rerender(<Style>{[`.second-render { display: block; }`]}</Style>);
 
-      expect(document.head.innerHTML).toInclude('.second-render { display: block; }');
+      expect(getAllCssText()).toInclude('.second-render {display: block;}');
       expect(console.error).not.toHaveBeenCalled();
     });
   });
 
   describe('cssMapScoped — non-atomic style injection', () => {
-    // Helper: read all CSS text from <style> tags via textContent (works for both
-    // appendData/appendChild text-node paths AND insertRule cssRules-based injection)
-    const getAllCssText = () =>
-      Array.from(document.head.querySelectorAll('style'))
-        .map((s) => {
-          const sheet = (s as HTMLStyleElement).sheet as CSSStyleSheet | null;
-          // Prefer cssRules (real browser path) — falls back to textContent (jsdom path)
-          if (sheet?.cssRules?.length) {
-            return Array.from(sheet.cssRules)
-              .map((r) => r.cssText)
-              .join('');
-          }
-          return s.textContent ?? '';
-        })
-        .join('');
-
     it('should inject cssMapScoped rules into the catch-all style bucket, not a shorthand bucket', () => {
       createIsolatedTest((Style) => {
         // border-bottom is shorthand depth 4 → would normally go to s-4 bucket
@@ -475,8 +462,8 @@ describe('<Style />', () => {
         </StyleContainerProvider>
       );
 
-      expect(container.innerHTML).toInclude('.a { color: red; }');
-      expect(document.head.innerHTML).not.toInclude('.a { color: red; }');
+      expect(getAllCssText(container)).toInclude('.a {color: red;}');
+      expect(getAllCssText()).not.toInclude('.a {color: red;}');
       expect(console.error).not.toHaveBeenCalled();
     });
 
@@ -494,12 +481,13 @@ describe('<Style />', () => {
         </StyleContainerProvider>
       );
 
-      expect(container.innerHTML.split('</style>').join('</style>\n')).toMatchInlineSnapshot(`
-        "<style>._c1234567{ display: block; }</style>
-        <style>._a1234567:hover{ color: red; }</style>
-        <style>._b1234567:active{ color: blue; }</style>
-        <style>@media (max-width: 800px){ ._d1234567{ color: yellow; } }</style>
-        "
+      expect(getStyleCssTexts(container)).toMatchInlineSnapshot(`
+        [
+          "._c1234567 {display: block;}",
+          "._a1234567:hover {color: red;}",
+          "._b1234567:active {color: blue;}",
+          "@media (max-width: 800px) {._d1234567 {color: yellow;}}",
+        ]
       `);
       expect(console.error).not.toHaveBeenCalled();
     });
@@ -512,7 +500,7 @@ describe('<Style />', () => {
         </StyleContainerProvider>
       );
 
-      expect(container.innerHTML).toIncludeRepeated('.b { color: blue; }', 1);
+      expect(getAllCssText(container)).toIncludeRepeated('.b {color: blue;}', 1);
       expect(console.error).not.toHaveBeenCalled();
     });
 
@@ -527,8 +515,8 @@ describe('<Style />', () => {
         </StyleContainerProvider>
       );
 
-      expect(document.head.innerHTML).toInclude('.c { color: green; }');
-      expect(container.innerHTML).toInclude('.c { color: green; }');
+      expect(getAllCssText()).toInclude('.c {color: green;}');
+      expect(getAllCssText(container)).toInclude('.c {color: green;}');
       expect(console.error).not.toHaveBeenCalled();
     });
 
@@ -548,8 +536,8 @@ describe('<Style />', () => {
         </StyleContainerProvider>
       );
 
-      expect(container.innerHTML).toInclude('.d { color: pink; }');
-      expect(container2.innerHTML).toInclude('.d { color: pink; }');
+      expect(getAllCssText(container)).toInclude('.d {color: pink;}');
+      expect(getAllCssText(container2)).toInclude('.d {color: pink;}');
 
       document.body.removeChild(container2);
       expect(console.error).not.toHaveBeenCalled();
@@ -562,7 +550,7 @@ describe('<Style />', () => {
         </StyleContainerProvider>
       );
 
-      expect(container.innerHTML).toInclude('nonce="abc123"');
+      expect(container.querySelector('style')?.getAttribute('nonce')).toBe('abc123');
       expect(console.error).not.toHaveBeenCalled();
     });
 

--- a/packages/react/src/runtime/sheet.ts
+++ b/packages/react/src/runtime/sheet.ts
@@ -236,17 +236,12 @@ export const getStyleBucketName = (sheet: string): Bucket => {
 export default function insertRule(css: string, opts: StyleSheetOpts): void {
   const bucketName = getStyleBucketName(css);
   const style = lazyAddStyleBucketToContainer(bucketName, opts);
+  const sheet = style.sheet as CSSStyleSheet;
 
-  if (process.env.NODE_ENV === 'production') {
-    const sheet = style.sheet as CSSStyleSheet;
-
-    // Used to avoid unhandled exceptions across browsers with prefixed selectors such as -moz-placeholder.
-    try {
-      sheet.insertRule(css, sheet.cssRules.length);
-    } catch {}
-  } else {
-    style.appendChild(document.createTextNode(css));
-  }
+  // Used to avoid unhandled exceptions across browsers with prefixed selectors such as -moz-placeholder.
+  try {
+    sheet.insertRule(css, sheet.cssRules.length);
+  } catch {}
 }
 
 /**


### PR DESCRIPTION
### What is this change?

This change is removing special logic for inserting rule in dev mode. And makes it behave like a production build.

### Why are we making this change?

In dev mode compiled is using appendChild to add styles. This is extremely slow on big amount of CSS. Can lock up browser for 4-5 sec. 

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)
