### PR TITLE
Support TypeScript satisfies expressions in computed CSS keys

### DIFF
--- a/.changeset/curly-wombats-satisfy.md
+++ b/.changeset/curly-wombats-satisfy.md
@@ -1,0 +1,5 @@
+---
+'@compiled/babel-plugin': patch
+---
+
+Support TypeScript `satisfies` expressions in computed CSS object keys.

--- a/packages/babel-plugin/src/css-map/__tests__/at-rules-and-selectors.test.ts
+++ b/packages/babel-plugin/src/css-map/__tests__/at-rules-and-selectors.test.ts
@@ -9,6 +9,32 @@ describe('css map advanced functionality (at rules, selectors object)', () => {
   const transform = (code: string, opts: TransformOptions = {}) =>
     transformCode(code, { pretty: false, ...opts });
 
+  it('should support satisfies expressions in computed at-rule keys', () => {
+    const actual = transform(`
+      import type { MediaAboveLg } from '@atlaskit/css/at-rules/media-above-lg';
+      import type { Container } from '@atlaskit/css/at-rules/container';
+      import { cssMap } from '@compiled/react';
+
+      const styles = cssMap({
+        root: {
+          padding: '2px',
+          ['@media (min-width: 48rem)' satisfies MediaAboveLg]: { padding: '8px' },
+          ['@container id (width > 100px)' satisfies Container]: { padding: '4px' },
+        },
+      });
+
+      ${EXAMPLE_USAGE}
+    `);
+
+    expect(actual).toIncludeMultiple([
+      'padding:2px',
+      '@media (min-width:48rem)',
+      'padding:8px',
+      '@container id (width>100px)',
+      'padding:4px',
+    ]);
+  });
+
   it('should parse a mix of at rules and the selectors object', () => {
     const actual = transform(`
       import { cssMap } from '@compiled/react';

--- a/packages/babel-plugin/src/css-map/__tests__/at-rules-and-selectors.test.ts
+++ b/packages/babel-plugin/src/css-map/__tests__/at-rules-and-selectors.test.ts
@@ -27,11 +27,10 @@ describe('css map advanced functionality (at rules, selectors object)', () => {
     `);
 
     expect(actual).toIncludeMultiple([
-      'padding:2px',
-      '@media (min-width:48rem)',
-      'padding:8px',
-      '@container id (width>100px)',
-      'padding:4px',
+      'const _6="@media (min-width:48rem){._34ApswJg58{padding-top:8px}._0NZneVJg58{padding-right:8px}._0jj4l6Jg58{padding-bottom:8px}._4af1G0Jg58{padding-left:8px}}";',
+      'const _5="@container id (width > 100px){._1hIcazUNDJ{padding-top:4px}._3pZtLrUNDJ{padding-right:4px}._2IBldfUNDJ{padding-bottom:4px}._4l5TLWUNDJ{padding-left:4px}}";',
+      'const _4="._2Zuz6Q4Jdh{padding-left:2px}";',
+      'const styles={root:"_0Of8r24Jdh _1Znuxb4Jdh _1wydGW4Jdh _2Zuz6Q4Jdh _1hIcazUNDJ _3pZtLrUNDJ _2IBldfUNDJ _4l5TLWUNDJ _34ApswJg58 _0NZneVJg58 _0jj4l6Jg58 _4af1G0Jg58"};',
     ]);
   });
 

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.ts
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.ts
@@ -13,6 +13,20 @@ describe('css prop behaviour', () => {
   const transform = (code: string, opts: TransformOptions = {}) =>
     transformCode(code, { pretty: false, ...opts });
 
+  it('should support satisfies expressions in computed at-rule keys', () => {
+    const actual = transform(`
+      import type { MediaAboveSm } from '@atlaskit/css/at-rules/media-above-sm';
+      import '@compiled/react';
+
+      <div css={{
+        ['@media (min-width: 48rem)' satisfies MediaAboveSm]: { padding: '8px' },
+      }} />;
+    `);
+
+    expect(actual).toInclude('@media (min-width:48rem)');
+    expect(actual).toInclude('padding:8px');
+  });
+
   it('should not apply class name when no styles are present', () => {
     const actual = transform(`
       import '@compiled/react';

--- a/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.ts
+++ b/packages/babel-plugin/src/css-prop/__tests__/behaviour.test.ts
@@ -23,8 +23,10 @@ describe('css prop behaviour', () => {
       }} />;
     `);
 
-    expect(actual).toInclude('@media (min-width:48rem)');
-    expect(actual).toInclude('padding:8px');
+    expect(actual).toIncludeMultiple([
+      'const _="@media (min-width:48rem){._34ApswJg58{padding-top:8px}._0NZneVJg58{padding-right:8px}._0jj4l6Jg58{padding-bottom:8px}._4af1G0Jg58{padding-left:8px}}";',
+      'className={ax(["_34ApswJg58 _0NZneVJg58 _0jj4l6Jg58 _4af1G0Jg58"])}',
+    ]);
   });
 
   it('should not apply class name when no styles are present', () => {
@@ -244,7 +246,8 @@ describe('css prop behaviour', () => {
     const actual = transform(`
       import '@compiled/react';
 
-      const [color] = ['blue'];
+      const colors = getColors();
+      const [color] = colors;
       <div style={{ display: 'block' }} css={{ color: \`\${color}\` }}>hello world</div>
     `);
 

--- a/packages/babel-plugin/src/utils/__tests__/object-property-to-string.test.ts
+++ b/packages/babel-plugin/src/utils/__tests__/object-property-to-string.test.ts
@@ -28,7 +28,7 @@ describe('objectPropertyToString', () => {
   };
 
   const transform = (code: string) => {
-    const ast = parse(code, { sourceType: 'module' });
+    const ast = parse(code, { sourceType: 'module', plugins: ['typescript'] });
     const state: TraverseState = { result: '' };
 
     traverse(ast, testSetupVisitor, undefined, state);
@@ -62,6 +62,14 @@ describe('objectPropertyToString', () => {
       `);
 
       expect(actual).toBe(key);
+    });
+
+    it('gets key value from a satisfies expression when property is computed', () => {
+      const actual = transform(
+        `const obj = { ['@media (min-width: 48rem)' satisfies MediaAboveSm]: "value"};`
+      );
+
+      expect(actual).toBe('@media (min-width: 48rem)');
     });
   });
 

--- a/packages/babel-plugin/src/utils/css-map.ts
+++ b/packages/babel-plugin/src/utils/css-map.ts
@@ -28,15 +28,20 @@ const atRules: Record<AtRules, boolean> = {
   '@view-transition': true,
 };
 
-type ObjectKeyWithLiteralValue = t.Identifier | t.StringLiteral;
+type ObjectKeyWithLiteralValue = t.Identifier | t.StringLiteral | t.TSSatisfiesExpression;
 
 export const objectKeyIsLiteralValue = (
   key: t.ObjectProperty['key']
-): key is ObjectKeyWithLiteralValue => t.isIdentifier(key) || t.isStringLiteral(key);
+): key is ObjectKeyWithLiteralValue =>
+  t.isIdentifier(key) || t.isStringLiteral(key) || t.isTSSatisfiesExpression(key);
+
+const unwrapTSSatisfiesExpression = (key: t.Expression): t.Expression =>
+  t.isTSSatisfiesExpression(key) ? unwrapTSSatisfiesExpression(key.expression) : key;
 
 export const getKeyValue = (key: ObjectKeyWithLiteralValue): string => {
-  if (t.isIdentifier(key)) return key.name;
-  else if (t.isStringLiteral(key)) return key.value;
+  const unwrappedKey = unwrapTSSatisfiesExpression(key);
+  if (t.isIdentifier(unwrappedKey)) return unwrappedKey.name;
+  else if (t.isStringLiteral(unwrappedKey)) return unwrappedKey.value;
   throw new Error(`Expected an identifier or a string literal, got type ${(key as any).type}`);
 };
 

--- a/packages/babel-plugin/src/utils/object-property-to-string.ts
+++ b/packages/babel-plugin/src/utils/object-property-to-string.ts
@@ -6,6 +6,11 @@ import { evaluateExpression } from './evaluate-expression';
 
 type ExpressionToString = (expression: t.Expression | t.PrivateName, meta: Metadata) => string;
 
+const unwrapTSSatisfiesExpression = (expression: t.Expression): t.Expression =>
+  t.isTSSatisfiesExpression(expression)
+    ? unwrapTSSatisfiesExpression(expression.expression)
+    : expression;
+
 const templateLiteralToString = (
   template: t.TemplateLiteral,
   meta: Metadata,
@@ -169,7 +174,8 @@ export const expressionToString: ExpressionToString = (expression, meta) => {
  * @param meta Metadata
  */
 export const objectPropertyToString = (prop: t.ObjectProperty, meta: Metadata): string => {
-  const { computed, key } = prop;
+  const { computed, key: propertyKey } = prop;
+  const key = t.isExpression(propertyKey) ? unwrapTSSatisfiesExpression(propertyKey) : propertyKey;
   // handles {key: 'value'}
   if (t.isIdentifier(key) && !computed) {
     return key.name;


### PR DESCRIPTION
## Summary

Support TypeScript `TSSatisfiesExpression` nodes in computed CSS object keys.

- Unwraps `satisfies` expressions for CSS and CSS Map key processing
- Adds focused regression coverage
- Includes a patch changeset for `@compiled/babel-plugin`

Example:
```tsx
import type { MediaAboveSm } from '@atlaskit/css/at-rules/media-above-sm';
import type { MediaAboveLg } from '@atlaskit/css/at-rules/media-above-lg';
import type { Container } from '@atlaskit/css/at-rules/container';

const styles = css({
  ['@media (min-width: 48rem)' satisfies MediaAboveSm]: { padding: '8px' },
});

const mapStyles = cssMap({
  root: {
    padding: '2px'
    ['@media (min-width: 48rem)' satisfies MediaAboveLg]: { padding: '8px' },
    ['@container id (width > 100px)' satisfies Container]: { padding: '4px' },
  }
});
export default () => <div css={[styles, mapStyles.root]} />;
```