### PR TITLE
fix(css): throw a build error for dangling combinator selectors

### DIFF
--- a/.changeset/dangling-combinators-error.md
+++ b/.changeset/dangling-combinators-error.md
@@ -1,0 +1,7 @@
+---
+'@compiled/css': minor
+---
+
+Throw a build error when a selector ends with a dangling combinator, for example `css({ '>': { marginLeft: 10 } })` or `css({ '& +': { ... } })`. Compiled used to emit `.hash > {}`, which browsers reject, so the declarations silently never applied.
+
+This can fail builds that previously compiled. A rule is now rejected as a whole, so `css({ '.a, .b >': { color: 'red' } })` no longer emits its working `.a` half, and `css({ '& >': { color: 'blue', '.child': { color: 'red' } } })` no longer emits its working `& > .child` half. Add the missing selector to fix them: `'& > *'`, or move the declarations under the nested child. Selectors whose only content is nested rules, such as `css({ '& >': { '.child': { color: 'red' } } })`, are unaffected.

--- a/packages/babel-plugin/src/__tests__/errors.test.ts
+++ b/packages/babel-plugin/src/__tests__/errors.test.ts
@@ -7,6 +7,18 @@ describe('error handling', () => {
       highlightCode: false,
     });
 
+  it('should throw a build error for a dangling combinator selector (#1751)', () => {
+    expect(() => {
+      transform(`
+        import { css } from '@compiled/react';
+
+        const styles = css({ '>': { marginLeft: 10 } });
+
+        <div css={styles} />
+      `);
+    }).toThrow("Dangling combinator '>' in selector");
+  });
+
   it('should throw when using using an invalid css node', () => {
     expect(() => {
       transform(`

--- a/packages/css/src/__tests__/transform.test.ts
+++ b/packages/css/src/__tests__/transform.test.ts
@@ -11,6 +11,36 @@ const transformCss = (
 ) => transform(code, opts, localOpts);
 
 describe('#css-transform', () => {
+  it('should throw a build error for a dangling combinator instead of emitting an invalid selector', () => {
+    expect(() =>
+      transformCss(`
+        > {
+          margin-left: 10px;
+        }
+      `)
+    ).toThrow("Dangling combinator '>' in selector '>'");
+
+    expect(() =>
+      transformCss(`
+        &:hover + {
+          color: red;
+        }
+      `)
+    ).toThrow("Dangling combinator '+' in selector '&:hover +'");
+  });
+
+  it('should not treat a combinator completed by a nested child as dangling', () => {
+    const { sheets } = transformCss(`
+      > {
+        .child {
+          color: red;
+        }
+      }
+    `);
+
+    expect(sheets.join('')).toInclude('>.child{color:red}');
+  });
+
   it('should generate the same selectors even if white space is different', () => {
     const { sheets: actualOne } = transformCss(`
       >   :first-child {

--- a/packages/css/src/plugins/__tests__/dangling-combinators.test.ts
+++ b/packages/css/src/plugins/__tests__/dangling-combinators.test.ts
@@ -1,0 +1,49 @@
+import postcss from 'postcss';
+
+import { danglingCombinators } from '../dangling-combinators';
+
+const transform = (css: string) => {
+  const result = postcss([danglingCombinators()]).process(css, { from: undefined });
+  return result.css;
+};
+
+describe('dangling combinators plugin', () => {
+  it.each([
+    ['>', '.a > { color: red; }'],
+    ['+', '.a + { color: red; }'],
+    ['~', '.a ~ { color: red; }'],
+    ['>', '& > { color: red; }'],
+    ['>', '> { color: red; }'],
+    ['+', '&:hover + { color: red; }'],
+    ['>', '.a, .b > { color: red; }'],
+    ['>', '& > { @media (min-width: 100px) { color: red; } } '],
+  ])("should throw for a trailing '%s' combinator in `%s`", (combinator, css) => {
+    expect(() => transform(css)).toThrow(`Dangling combinator '${combinator}'`);
+  });
+
+  it.each([
+    '.a > .b { color: red; }',
+    '& > * { color: red; }',
+    '> div { color: red; }',
+    '.a + .b, .c ~ .d { color: red; }',
+    '&:hover { color: red; }',
+    '.a { color: red; }',
+    '.a > .b > .c { color: red; }',
+    '& > { .child { color: red; } }',
+    '.a + { div { color: red; } }',
+  ])('should leave `%s` untouched', (css) => {
+    expect(transform(css)).toEqual(css);
+  });
+
+  it('should still throw when a trailing combinator rule also owns declarations', () => {
+    expect(() => transform('& > { color: blue; .child { color: red; } }')).toThrow(
+      "Dangling combinator '>'"
+    );
+  });
+
+  it('should point at the offending rule', () => {
+    expect(() => transform('.ok { color: red; } .a > { color: red; }')).toThrow(
+      "Dangling combinator '>' in selector '.a >'"
+    );
+  });
+});

--- a/packages/css/src/plugins/dangling-combinators.ts
+++ b/packages/css/src/plugins/dangling-combinators.ts
@@ -1,0 +1,48 @@
+import type { Plugin } from 'postcss';
+import selectorParser from 'postcss-selector-parser';
+
+/**
+ * Dangling combinators PostCSS plugin.
+ *
+ * Throws a build error when a selector ends with a combinator, for example
+ * `css({ '>': { marginLeft: 10 } })` or `css({ '& +': { ... } })`.
+ * Without this check such rules make it into the stylesheet as `.hash > {}` — a selector
+ * browsers reject, so the declarations silently never apply.
+ * See https://github.com/atlassian-labs/compiled/issues/1751
+ */
+export const danglingCombinators = (): Plugin => {
+  return {
+    postcssPlugin: 'dangling-combinators',
+    Once(root) {
+      root.walkRules((rule) => {
+        // A rule whose children are all nested rules is not dangling: postcss-nested joins its
+        // selector onto each child, so `& > { .child { color: red } }` becomes `& > .child`.
+        // Anything else — declarations, or an at-rule that bubbles and leaves the selector
+        // behind — keeps the trailing combinator in the emitted rule.
+        if (rule.every((node) => node.type === 'rule')) {
+          return;
+        }
+
+        rule.selectors.forEach((selector) => {
+          const trimmed = selector.trim();
+          // A trailing combinator always leaves one of these characters last, so this cheap
+          // test keeps the selector parser off the hot path for every other selector.
+          if (!/[>+~|]$/.test(trimmed)) {
+            return;
+          }
+
+          const last = selectorParser().astSync(trimmed, { lossless: false }).first?.last;
+          if (last && last.type === 'combinator') {
+            throw rule.error(
+              `Dangling combinator '${last.value.trim()}' in selector '${trimmed}'. ` +
+                `A combinator must be followed by a selector, e.g. '${trimmed} *' or '${trimmed} .child'. ` +
+                `Compiled would otherwise emit '${trimmed} { ... }', which browsers ignore.`
+            );
+          }
+        });
+      });
+    },
+  };
+};
+
+export const postcss = true;

--- a/packages/css/src/transform.ts
+++ b/packages/css/src/transform.ts
@@ -5,6 +5,7 @@ import nested from 'postcss-nested';
 import whitespace from 'postcss-normalize-whitespace';
 
 import { atomicifyRules } from './plugins/atomicify-rules';
+import { danglingCombinators } from './plugins/dangling-combinators';
 import { discardDuplicates } from './plugins/discard-duplicates';
 import { discardEmptyRules } from './plugins/discard-empty-rules';
 import { expandShorthands } from './plugins/expand-shorthands';
@@ -88,6 +89,7 @@ export const transformCss = (
       discardDuplicates(),
       discardEmptyRules(),
       parentOrphanedPseudos(),
+      danglingCombinators(),
       nested({
         bubble: [
           'container',

--- a/website/packages/docs/src/pages/limitations.mdx
+++ b/website/packages/docs/src/pages/limitations.mdx
@@ -217,6 +217,28 @@ function App() {
 }
 ```
 
+### Dangling combinators
+
+A selector must end with something for the combinator to point at. Compiled used to emit these
+rules with the trailing combinator intact, which browsers reject, so the declarations silently
+never applied. They now fail the build.
+
+```jsx
+// Invalid — the combinator has nothing after it
+const styles = css({ '>': { marginLeft: 10 } });
+const styles = css({ '& +': { color: 'red' } });
+
+// Valid — name what the combinator selects
+const styles = css({ '> *': { marginLeft: 10 } });
+const styles = css({ '& + .sibling': { color: 'red' } });
+
+// Valid — the nested child completes the selector
+const styles = css({ '& >': { '.child': { color: 'red' } } });
+```
+
+A rule is rejected as a whole, so `css({ '.a, .b >': { color: 'red' } })` no longer emits its
+working `.a` half either.
+
 ### Other unsupported features
 
 - [Conditional CSS rules for ClassNames](https://github.com/atlassian-labs/compiled/issues/391)


### PR DESCRIPTION
### What is this change?

Selectors ending in a combinator — `css({ '>': { marginLeft: 10 } })`, `'& +'` — now fail the build.

Fixes #1751

### Why are we making this change?

Compiled emitted `.hash > { margin-left: 10px }`, which browsers reject, so the declarations silently never applied and nothing signalled it.

### How are we making this change?

A `dangling-combinators` PostCSS plugin errors when a rule selector ends in `>`, `+` or `~`, in both the atomic and non-atomic pipelines. Rules whose children are all nested rules are skipped, since postcss-nested joins their selector onto the child. A rule fails as a whole, so `'.a, .b >'` no longer emits its working `.a` half — deliberate, and flagged in the changeset as a minor. The error currently surfaces through `transform.ts`'s generic "unhandled exception" wrapper; letting deliberate validation errors bypass it would be a separate change.

---

### PR checklist

Don't delete me!

I have...

- [x] Updated or added applicable tests
- [x] Updated the documentation in `website/`
- [x] Added a changeset (if making any changes that affect Compiled's behaviour)